### PR TITLE
feat: Add concurrency control to GitHub Actions workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,10 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     name: Cargo Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary

- Adds `concurrency` configuration to CI and Security Audit workflows
- Automatically cancels superseded workflow runs when new commits are pushed to PRs
- Saves CI resources and provides faster feedback on the latest code

## How It Works

The `concurrency` group uses:
- Workflow name + PR number for pull request events
- Workflow name + git ref for push events

When `cancel-in-progress: true` is set, any running workflow in the same concurrency group is automatically cancelled when a new run starts.

## Benefits

- **Faster feedback**: No need to wait for outdated runs to complete
- **Resource efficiency**: Saves GitHub Actions minutes by cancelling unnecessary runs
- **Cleaner UI**: Fewer queued/running workflows in the Actions tab

## Test Plan

- [ ] Push multiple commits to this PR and verify older runs are cancelled
- [ ] Verify workflows still run normally on the main branch
- [ ] Confirm scheduled workflows (cron) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)