### PR TITLE
Re-enable CI caching for all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,30 +26,29 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      # TODO: Re-enable caching once https://github.com/actions/runner/issues/449 is resolved
-      # - name: Cache cargo registry
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/registry
-      #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-      # - name: Cache cargo index
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/git
-      #     key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-git-
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
 
-      # - name: Cache cargo build
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: target
-      #     key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-build-target-
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
 
       - name: Run tests
         run: cargo test --workspace --all-features
@@ -65,22 +64,21 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # TODO: Re-enable caching once https://github.com/actions/runner/issues/449 is resolved
-      # - name: Cache cargo registry
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/registry
-      #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-      # - name: Cache cargo index
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/git
-      #     key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-git-
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check
@@ -103,30 +101,29 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      # TODO: Re-enable caching once https://github.com/actions/runner/issues/449 is resolved
-      # - name: Cache cargo registry
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/registry
-      #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-      # - name: Cache cargo index
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/git
-      #     key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-git-
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
 
-      # - name: Cache cargo build
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: target
-      #     key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-build-target-
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
 
       - name: Build workspace
         run: cargo build --workspace --all-features --verbose
@@ -143,22 +140,21 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # TODO: Re-enable caching once https://github.com/actions/runner/issues/449 is resolved
-      # - name: Cache cargo registry
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/registry
-      #     key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-registry-
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
-      # - name: Cache cargo index
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cargo/git
-      #     key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-cargo-git-
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
 
       - name: Check workspace
         run: cargo check --workspace --all-features --verbose


### PR DESCRIPTION
## Summary

Re-enables caching for cargo registry, index, and build artifacts across all CI jobs (test, lint, build, check).

## Background

Caching was previously disabled due to a GitHub Actions macOS runner issue where the `hashFiles()` function failed with "The template is not valid" errors. This issue has been resolved - GitHub rolled back the problematic runner image on November 24, 2025.

## Changes

- Removed all TODO comments referencing the runner issue
- Re-enabled caching steps in all four CI jobs:
  - **test**: cargo registry, index, and build target caching
  - **lint**: cargo registry and index caching  
  - **build**: cargo registry, index, and build target caching
  - **check**: cargo registry and index caching

## Benefits

This will significantly improve CI performance by:
- Avoiding redundant dependency downloads
- Reusing compiled artifacts across runs
- Reducing overall CI execution time

## References

- Issue discussion: https://github.com/orgs/community/discussions/180160
- Resolution confirmed by multiple users on November 24, 2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)