### PR TITLE
ci: Add path filters to skip CI on documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'rustfmt.toml'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Add path filters to the CI workflow to only run lint, test, build, and check jobs when source code or configuration files are modified. This prevents unnecessary CI runs when only documentation or other non-code files are changed.

## Changes

- Added `paths` filters to both `push` and `pull_request` triggers in the CI workflow
- CI now only runs when the following paths are modified:
  - `crates/**` (Rust source code)
  - `Cargo.toml` and `Cargo.lock` (dependencies)
  - `rust-toolchain.toml` and `rustfmt.toml` (tooling configuration)
  - `.github/workflows/ci.yml` (workflow itself)

## Benefits

- Reduces CI resource usage
- Faster feedback loop for documentation-only changes
- No unnecessary CI runs for README updates, markdown changes, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)