### PR TITLE
ci: Add gatekeeper job for path filters with required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,3 +176,17 @@ jobs:
 
       - name: Check workspace
         run: cargo check --workspace --all-features --verbose
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test, lint, build, check]
+    steps:
+      - name: Check all jobs
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
## Summary

Adds a `ci-success` gatekeeper job that resolves the conflict between path filters and required status checks.

## Changes

- Added `ci-success` job that depends on all other CI jobs
- Job always runs (even when others are skipped due to path filters)
- Job fails only if any dependent job actually failed (not skipped)

## Problem Solved

Previously, docs-only changes couldn't merge because the path-filtered CI jobs were skipped, but GitHub still expected them to pass as required checks. This gatekeeper pattern allows:

- Docs-only changes: Individual jobs skip, but `ci-success` runs and passes
- Code changes: All jobs run normally, `ci-success` passes only if they all pass
- Failures: Any job failure causes `ci-success` to fail, blocking merge

## Required GitHub Settings Update

After merging, update branch protection settings:

1. Go to **Settings** → **Branches** → `main` branch protection rule
2. Under "Require status checks to pass before merging"
3. Remove individual checks: `Test`, `Lint`, `Build`, `Check`
4. Add only: `CI Success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)