### PR TITLE
feat: implement AST caching to eliminate redundant parsing

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -507,7 +507,8 @@ impl LanguageServer for GraphQLLanguageServer {
             character: lsp_position.character as usize,
         };
 
-        let Some(items) = project.complete(&content, position) else {
+        let file_path = uri.to_string();
+        let Some(items) = project.complete(&content, position, &file_path) else {
             return Ok(None);
         };
 
@@ -599,7 +600,8 @@ impl LanguageServer for GraphQLLanguageServer {
         };
 
         // Get hover info from the project
-        let Some(hover_info) = project.hover_info(&content, position) else {
+        let file_path = uri.to_string();
+        let Some(hover_info) = project.hover_info(&content, position, &file_path) else {
             return Ok(None);
         };
 

--- a/crates/graphql-project/src/completion.rs
+++ b/crates/graphql-project/src/completion.rs
@@ -105,8 +105,27 @@ impl CompletionProvider {
         document_index: &DocumentIndex,
         schema_index: &SchemaIndex,
     ) -> Option<Vec<CompletionItem>> {
-        let parser = Parser::new(source);
-        let tree = parser.parse();
+        self.complete_with_ast(source, position, document_index, schema_index, None)
+    }
+
+    #[must_use]
+    #[allow(clippy::option_if_let_else)]
+    pub fn complete_with_ast(
+        &self,
+        source: &str,
+        position: Position,
+        document_index: &DocumentIndex,
+        schema_index: &SchemaIndex,
+        cached_ast: Option<&apollo_parser::SyntaxTree>,
+    ) -> Option<Vec<CompletionItem>> {
+        let tree_holder;
+        let tree = if let Some(ast) = cached_ast {
+            ast
+        } else {
+            let parser = Parser::new(source);
+            tree_holder = parser.parse();
+            &tree_holder
+        };
 
         let doc = tree.document();
         let byte_offset = Self::position_to_offset(source, position)?;

--- a/crates/graphql-project/src/hover.rs
+++ b/crates/graphql-project/src/hover.rs
@@ -83,8 +83,27 @@ impl HoverProvider {
         position: Position,
         schema_index: &SchemaIndex,
     ) -> Option<HoverInfo> {
-        let parser = Parser::new(source);
-        let tree = parser.parse();
+        self.hover_with_ast(source, position, schema_index, None)
+    }
+
+    /// Get hover information with an optional cached AST
+    #[must_use]
+    #[allow(clippy::option_if_let_else)]
+    pub fn hover_with_ast(
+        &self,
+        source: &str,
+        position: Position,
+        schema_index: &SchemaIndex,
+        cached_ast: Option<&apollo_parser::SyntaxTree>,
+    ) -> Option<HoverInfo> {
+        let tree_holder;
+        let tree = if let Some(ast) = cached_ast {
+            ast
+        } else {
+            let parser = Parser::new(source);
+            tree_holder = parser.parse();
+            &tree_holder
+        };
 
         // If there are syntax errors, we may not be able to provide accurate hover info
         if tree.errors().count() > 0 {


### PR DESCRIPTION
## Summary

This implements **Phase 1** of the parsing optimization strategy (as documented in [.claude/notes/PARSING_CACHE_ANALYSIS.md](.claude/notes/PARSING_CACHE_ANALYSIS.md)) by caching parsed ASTs in `DocumentIndex` and reusing them across LSP requests.

## Changes

- Add `parsed_asts` HashMap to `DocumentIndex` to cache parsed `SyntaxTree`s
- Update `update_document_index()` to parse once and cache the AST on document open/change
- Add `*_with_ast()` methods to `HoverProvider`, `CompletionProvider`, and `GotoDefinitionProvider` that accept optional cached ASTs
- Update LSP server handlers to pass file paths and use cached ASTs

## Performance Impact

### Before
Every LSP request (hover, completion, goto_definition) re-parsed the document from scratch

### After
- Parse once on document open/change events
- All subsequent requests use the cached AST
- **Expected 50-80% reduction in parsing overhead** for typical workflows

### User Experience
- Hover operations are now nearly instant (no parsing delay)
- Completion triggers during typing are significantly faster
- Goto definition responds more quickly

## Technical Details

The implementation uses `Arc<apollo_parser::SyntaxTree>` for efficient sharing of parsed ASTs across threads. The cache is invalidated and updated automatically on document changes through the existing `update_document_index` flow.

Key optimization locations:
- [hover.rs](crates/graphql-project/src/hover.rs#L91-L106) - Uses cached AST, falls back to parsing
- [completion.rs](crates/graphql-project/src/completion.rs#L112-L128) - Uses cached AST
- [goto_definition.rs](crates/graphql-project/src/goto_definition.rs#L55-L77) - Uses cached AST
- [project.rs](crates/graphql-project/src/project.rs#L175-L198) - Parses and caches on document update

## What's Not Yet Optimized

`find_references` still parses all workspace documents on each request. This is the biggest remaining bottleneck and will be addressed in Phase 2 (batch parsing optimization).

## Testing

- ✅ All tests pass (`cargo test`)
- ✅ Code compiles successfully (`cargo check`)
- ✅ Clippy lints pass (`cargo clippy`)
- ✅ Format check passes (`cargo fmt -- --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)