### PR TITLE
feat: add batch parsing infrastructure for find_references optimization

### DIFF
--- a/crates/graphql-project/src/lib.rs
+++ b/crates/graphql-project/src/lib.rs
@@ -28,4 +28,5 @@ pub use validation::Validator;
 
 // Re-export common types from dependencies
 pub use apollo_compiler::validation::DiagnosticList;
+pub use apollo_parser::SyntaxTree;
 pub use graphql_config::{GraphQLConfig, ProjectConfig};


### PR DESCRIPTION
## Summary

Implements Phase 2 of the parsing optimization plan by adding infrastructure to support batch parsing in find_references operations.

## Changes

- Add `find_references_with_asts()` method accepting pre-parsed AST map
- Update helper functions to check AST cache before parsing
- Export `SyntaxTree` from graphql_project for use in server
- Add infrastructure in server.rs to pass AST map (currently None)
- Remove unused forwarding methods

## Implementation Details

The implementation uses `Option<&HashMap<String, SyntaxTree>>` to allow graceful fallback to on-demand parsing if ASTs not provided. This eliminates redundant parsing within a single find_references call while maintaining backward compatibility.

Currently passes `None` for the AST map in server.rs to keep the change focused. Future optimization can build and pass the actual AST map to achieve full batch parsing across workspace (50%+ reduction in find_references time expected).

## Related

- Builds on top of PR #29 (Phase 1: AST caching)
- Follows analysis in `.claude/notes/PARSING_CACHE_ANALYSIS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)