### PR TITLE
fix: resolve hover not working in TypeScript files

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -767,15 +767,20 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        // Convert LSP position to graphql-project Position (0-indexed)
+        // Convert LSP position to graphql-project Position
         let position = graphql_project::Position {
             line: lsp_position.line as usize,
             character: lsp_position.character as usize,
         };
 
-        // Get hover info from the project
-        let file_path = uri.to_string();
-        let Some(hover_info) = project.hover_info(&content, position, &file_path) else {
+        // Get hover info from the project (handles TypeScript extraction internally)
+        // Convert URI to file path for cache lookup consistency
+        let file_path = uri
+            .to_file_path()
+            .map_or_else(|| uri.to_string(), |path| path.display().to_string());
+
+        let Some(hover_info) = project.hover_info_at_position(&file_path, position, &content)
+        else {
             return Ok(None);
         };
 

--- a/crates/graphql-project/src/hover.rs
+++ b/crates/graphql-project/src/hover.rs
@@ -106,7 +106,12 @@ impl HoverProvider {
         };
 
         // If there are syntax errors, we may not be able to provide accurate hover info
-        if tree.errors().count() > 0 {
+        let error_count = tree.errors().count();
+        if error_count > 0 {
+            tracing::debug!(
+                "Hover provider: parse tree has {} syntax error(s), returning None",
+                error_count
+            );
             return None;
         }
 


### PR DESCRIPTION
## Summary

Fixes hover functionality for GraphQL fields in TypeScript/JavaScript files. Previously, hover would work in `.graphql` files but not in TypeScript files with embedded GraphQL.

## Root Cause

The issue had two parts:

1. **Inconsistent file path handling**: The LSP hover handler passed URI strings (`file:///...`) to the project layer, but cached extracted blocks were stored using filesystem paths (`/Users/...`). This mismatch caused cache lookups to fail.

2. **Wrong AST being used**: When hover was called for extracted GraphQL blocks, it tried to use the cached AST for the TypeScript file, which had 239+ syntax errors when parsed as GraphQL. The hover provider rejected requests with syntax errors.

## Solution

- Added `hover_info_at_position()` method in `graphql-project` that encapsulates all TypeScript/JavaScript extraction logic
- This method automatically:
  - Detects file type based on extension
  - Retrieves cached extracted GraphQL blocks
  - Adjusts cursor positions relative to the extracted content
  - Uses the block's pre-parsed clean AST (not the TypeScript file's AST)
- Updated LSP hover handler to convert URIs to file paths for consistent cache lookups
- Simplified hover handler by delegating extraction logic to the project layer

## Changes

**[crates/graphql-project/src/project.rs](crates/graphql-project/src/project.rs)**
- Added `hover_info_at_position()` method for handling hover with automatic TypeScript extraction

**[crates/graphql-lsp/src/server.rs](crates/graphql-lsp/src/server.rs)**  
- Updated hover handler to use file paths instead of URIs
- Simplified by calling `hover_info_at_position()` which handles all extraction

**[crates/graphql-project/src/hover.rs](crates/graphql-project/src/hover.rs)**
- Added debug logging for parse errors to aid troubleshooting

## Testing

- ✅ Hover now works correctly in TypeScript/JavaScript files
- ✅ Hover continues to work in `.graphql` files
- ✅ All tests pass
- ✅ Clippy passes with no warnings

## Architecture

This fix maintains separation of concerns:
- The LSP layer doesn't need to know about GraphQL extraction from TypeScript
- The project layer encapsulates all extraction logic
- Follows the same pattern as `goto_definition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)