### PR TITLE
feat: support graphql() call expression with fragment arguments

### DIFF
--- a/crates/graphql-extract/README.md
+++ b/crates/graphql-extract/README.md
@@ -74,6 +74,24 @@ const query = gql`
 `;
 ```
 
+### Call Expression with Arguments
+
+```typescript
+const fragment1 = graphql`fragment F1 on User { id }`;
+const fragment2 = graphql`fragment F2 on User { name }`;
+
+const document = graphql(`
+  query GetUser {
+    user {
+      ...F1
+      ...F2
+    }
+  }
+`, [fragment1, fragment2]);
+```
+
+This pattern is useful when passing fragments as a second argument. The extractor only processes the first argument (the template literal) and ignores additional arguments.
+
 ## Usage
 
 ### Extract from File


### PR DESCRIPTION
## Summary

Adds support for extracting GraphQL from call expressions with the pattern:
```ts
graphql(`query { ... }`, [fragment1, fragment2])
```

The extractor now recognizes when `gql()` or `graphql()` functions are called with a template literal as the first argument. Additional arguments (like fragment arrays) are ignored as requested.

## Changes

- Enhanced `visit_call_expr` in the GraphQL visitor to:
  - Detect calls to configured tag identifiers (`gql`, `graphql`)
  - Extract template literals from the first argument
  - Ignore additional arguments (fragment arrays, etc.)
  - Maintain backward compatibility with magic comment patterns
- Added 3 comprehensive tests covering different scenarios
- Updated README with documentation and examples

## Test Plan

- ✅ All existing tests continue to pass (27 tests)
- ✅ New tests verify extraction with/without second argument
- ✅ Tested with both `gql` and `graphql` identifiers
- ✅ Manual validation with CLI tool confirms correct extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)