### PR TITLE
feat: add JSON Schema for .graphqlrc configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,33 @@ graphql-lsp/
 ## Crates
 
 ### graphql-config
+
 Parses and loads `.graphqlrc` configuration files with parity to the npm `graphql-config` package.
 
 **Features:**
+
 - YAML and JSON config formats
 - Single and multi-project configurations
 - Schema and document patterns
 - Configuration discovery (walks up directory tree)
 
 ### graphql-extract
+
 Extracts GraphQL queries, mutations, and fragments from source files.
 
 **Supported:**
+
 - Raw GraphQL files (`.graphql`, `.gql`, `.gqls`)
 - TypeScript/JavaScript (via SWC) - Coming soon
 - Template literals with `gql` tags
 - Magic comments (`/* GraphQL */`)
 
 ### graphql-project
+
 Core library providing validation, indexing, diagnostics, and linting.
 
 **Features:**
+
 - Schema loading from files and URLs
 - Document loading and extraction
 - Apollo compiler validation engine
@@ -48,9 +54,11 @@ Core library providing validation, indexing, diagnostics, and linting.
 - Diagnostic system
 
 ### graphql-lsp
+
 Language Server Protocol implementation for GraphQL.
 
 **Implemented Features:**
+
 - Real-time validation with project-wide diagnostics
 - Configurable linting with custom rules
 - Comprehensive go-to-definition support:
@@ -62,15 +70,18 @@ Language Server Protocol implementation for GraphQL.
 - Works with embedded GraphQL in TypeScript/JavaScript
 
 **Planned Features:**
+
 - Additional find references support (fields, variables, directives, enum values)
 - Autocomplete
 - Document symbols
 - Code actions
 
 ### graphql-cli
+
 Command-line tool for validation, linting, and CI/CD integration.
 
 **Commands:**
+
 - `graphql validate` - Validate schema and documents (Apollo compiler validation)
 - `graphql lint` - Run custom lint rules with configurable severity
 - `graphql check` - Check for breaking changes (coming soon)
@@ -82,11 +93,13 @@ Command-line tool for validation, linting, and CI/CD integration.
 #### Install from Binary (Recommended)
 
 **macOS and Linux:**
+
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trevor-scheer/graphql-lsp/releases/latest/download/graphql-cli-installer.sh | sh
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 irm https://github.com/trevor-scheer/graphql-lsp/releases/latest/download/graphql-cli-installer.ps1 | iex
 ```
@@ -100,6 +113,7 @@ cargo install --git https://github.com/trevor-scheer/graphql-lsp graphql-cli
 #### Download Binary Directly
 
 Download the appropriate binary for your platform from the [releases page](https://github.com/trevor-scheer/graphql-lsp/releases):
+
 - macOS (Intel): `graphql-cli-x86_64-apple-darwin.tar.xz`
 - macOS (Apple Silicon): `graphql-cli-aarch64-apple-darwin.tar.xz`
 - Linux (x86_64): `graphql-cli-x86_64-unknown-linux-gnu.tar.xz`
@@ -117,12 +131,14 @@ Simply install the VSCode extension - it will download the appropriate binary fo
 #### Manual Installation
 
 **Via cargo:**
+
 ```bash
 cargo install graphql-lsp
 ```
 
 **From releases:**
 Download the appropriate binary from the [releases page](https://github.com/trevor-scheer/graphql-lsp/releases):
+
 - macOS (Intel): `graphql-lsp-x86_64-apple-darwin.tar.xz`
 - macOS (Apple Silicon): `graphql-lsp-aarch64-apple-darwin.tar.xz`
 - Linux (x86_64): `graphql-lsp-x86_64-unknown-linux-gnu.tar.xz`
@@ -187,6 +203,7 @@ cargo run -p graphql-lsp
 ## Development Status
 
 ✅ **Completed:**
+
 - Cargo workspace structure
 - graphql-config implementation (parsing, loading, validation)
 - Core validation engine with project-wide diagnostics
@@ -196,19 +213,27 @@ cargo run -p graphql-lsp
 - Schema and document indexing
 
 🚧 **In Progress:**
+
 - VS Code extension improvements
 - Additional LSP features (completions, document symbols)
 
 📋 **Planned:**
+
 - Breaking change detection
 - Code actions and refactoring
 - Remote schema introspection
 - Additional find references support (fields, variables, directives, enum values)
 
-## Configuration Example
+## Configuration
+
+Configuration files support IDE validation and autocompletion via JSON Schema. See [graphqlrc.schema.md](./crates/graphql-config/schema/graphqlrc.schema.md) for setup instructions.
+
+### Configuration Example
 
 `.graphqlrc.yml`:
+
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schema/graphqlrc.schema.json
 schema: "schema.graphql"
 documents: "src/**/*.{graphql,ts,tsx}"
 extensions:
@@ -222,6 +247,7 @@ extensions:
 ```
 
 Multi-project:
+
 ```yaml
 projects:
   frontend:
@@ -241,23 +267,27 @@ projects:
 Linting is opt-in and configured via the `extensions.project.lint` section:
 
 **Available rules:**
+
 - `unique_names` - Ensures operation and fragment names are unique (recommended: error)
 - `deprecated_field` - Warns when using fields marked with @deprecated (recommended: warn)
 
 **Severity levels:**
+
 - `off` - Disable the rule
 - `warn` - Show as warning
 - `error` - Show as error
 
 **Recommended preset:**
+
 ```yaml
 extensions:
   project:
     lint:
-      recommended: error  # Enables all recommended rules
+      recommended: error # Enables all recommended rules
 ```
 
 **Custom configuration:**
+
 ```yaml
 extensions:
   project:
@@ -267,12 +297,13 @@ extensions:
 ```
 
 **Override recommended:**
+
 ```yaml
 extensions:
   project:
     lint:
       recommended: error
-      deprecated_field: off  # Disable specific rule
+      deprecated_field: off # Disable specific rule
 ```
 
 ## License

--- a/crates/graphql-config/schema/example-multi-project.graphqlrc.yaml
+++ b/crates/graphql-config/schema/example-multi-project.graphqlrc.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=./graphqlrc.schema.json
+# Or use public URL: https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schema/graphqlrc.schema.json
+
+# Example multi-project GraphQL configuration
+
+projects:
+  api:
+    schema: api/schema.graphql
+    documents: "api/**/*.graphql"
+    extensions:
+      project:
+        lint:
+          recommended: error
+          deprecated_field: off
+
+  client:
+    schema:
+      - client/schema.graphql
+      - client/fragments/*.graphql
+    documents:
+      - "client/**/*.ts"
+      - "client/**/*.tsx"
+    include:
+      - "client/src/**/*"
+    exclude:
+      - "client/**/*.test.ts"
+    extensions:
+      extractConfig:
+        tagIdentifiers: ["gql"]
+        modules: ["@apollo/client"]
+      project:
+        lint:
+          unique_names: error
+          deprecated_field: warn
+
+  admin:
+    schema: "https://admin-api.example.com/graphql"
+    documents: "admin/**/*.graphql"
+    extensions:
+      project:
+        lint: "recommended"

--- a/crates/graphql-config/schema/example.graphqlrc.yaml
+++ b/crates/graphql-config/schema/example.graphqlrc.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./graphqlrc.schema.json
+# Or use public URL: https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schema/graphqlrc.schema.json
+
+# Example GraphQL configuration file with schema validation
+# This file demonstrates all supported configuration options
+
+schema: schema.graphql
+documents: "**/*.{graphql,gql,ts,tsx,js,jsx}"
+
+# Optional: include/exclude patterns
+include:
+  - "src/**/*"
+exclude:
+  - "**/*.test.ts"
+  - "**/__tests__/**"
+
+# Tool-specific extensions
+extensions:
+  # Configuration for extracting GraphQL from TypeScript/JavaScript
+  extractConfig:
+    magicComment: "GraphQL"
+    tagIdentifiers:
+      - "gql"
+      - "graphql"
+    modules:
+      - "graphql-tag"
+      - "@apollo/client"
+    allowGlobalIdentifiers: false
+
+  # Project-level settings for GraphQL LSP
+  project:
+    lint: "recommended"
+    # Or use custom rules:
+    # lint:
+    #   recommended: error
+    #   deprecated_field: warn
+    #   unique_names: error

--- a/crates/graphql-config/schema/graphqlrc.schema.json
+++ b/crates/graphql-config/schema/graphqlrc.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://graphql-lsp.dev/schemas/graphqlrc.json",
+  "title": "GraphQL Configuration",
+  "description": "Configuration file for GraphQL LSP and related tools",
+  "oneOf": [
+    {
+      "description": "Single project configuration",
+      "$ref": "#/definitions/ProjectConfig"
+    },
+    {
+      "description": "Multi-project configuration",
+      "type": "object",
+      "required": ["projects"],
+      "properties": {
+        "projects": {
+          "type": "object",
+          "description": "Named projects in this configuration",
+          "additionalProperties": {
+            "$ref": "#/definitions/ProjectConfig"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "ProjectConfig": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/SchemaConfig",
+          "description": "GraphQL schema source(s)"
+        },
+        "documents": {
+          "$ref": "#/definitions/DocumentsConfig",
+          "description": "Document patterns for queries, mutations, and fragments"
+        },
+        "include": {
+          "description": "File patterns to include",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "exclude": {
+          "description": "File patterns to exclude",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "description": "Tool-specific extensions",
+          "properties": {
+            "extractConfig": {
+              "$ref": "#/definitions/ExtractConfig",
+              "description": "Configuration for extracting GraphQL from TypeScript/JavaScript files"
+            },
+            "project": {
+              "type": "object",
+              "description": "Project-level settings for GraphQL LSP",
+              "properties": {
+                "lint": {
+                  "$ref": "#/definitions/LintConfig",
+                  "description": "Linting configuration"
+                }
+              }
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "SchemaConfig": {
+      "description": "GraphQL schema source configuration",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Single schema file path, glob pattern, or HTTP URL"
+        },
+        {
+          "type": "array",
+          "description": "Multiple schema sources",
+          "items": {
+            "type": "string",
+            "description": "Schema file path, glob pattern, or HTTP URL"
+          }
+        }
+      ]
+    },
+    "DocumentsConfig": {
+      "description": "Document source configuration",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Single document pattern"
+        },
+        {
+          "type": "array",
+          "description": "Multiple document patterns",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "ExtractConfig": {
+      "type": "object",
+      "description": "Configuration for extracting GraphQL from TypeScript/JavaScript",
+      "properties": {
+        "magicComment": {
+          "type": "string",
+          "description": "Magic comment to look for (e.g., /* GraphQL */)",
+          "default": "GraphQL"
+        },
+        "tagIdentifiers": {
+          "type": "array",
+          "description": "Tag identifiers to extract (e.g., gql, graphql)",
+          "items": {
+            "type": "string"
+          },
+          "default": ["gql", "graphql"]
+        },
+        "modules": {
+          "type": "array",
+          "description": "Module names to recognize as GraphQL sources",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "graphql-tag",
+            "@apollo/client",
+            "apollo-server",
+            "apollo-server-express",
+            "gatsby",
+            "react-relay"
+          ]
+        },
+        "allowGlobalIdentifiers": {
+          "type": "boolean",
+          "description": "Allow extraction without imports (global identifiers)",
+          "default": false
+        }
+      }
+    },
+    "LintConfig": {
+      "description": "Linting configuration for GraphQL documents",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["recommended"],
+          "description": "Use the recommended preset with default rule configuration"
+        },
+        {
+          "type": "object",
+          "description": "Custom lint rule configuration",
+          "properties": {
+            "recommended": {
+              "$ref": "#/definitions/LintSeverity",
+              "description": "Enable recommended rules with this severity, can be overridden per rule"
+            },
+            "unique_names": {
+              "$ref": "#/definitions/LintRuleConfig",
+              "description": "Ensure operation and fragment names are unique across the project"
+            },
+            "deprecated_field": {
+              "$ref": "#/definitions/LintRuleConfig",
+              "description": "Warn about usage of deprecated fields"
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/LintRuleConfig"
+          }
+        }
+      ]
+    },
+    "LintRuleConfig": {
+      "description": "Configuration for a single lint rule",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/LintSeverity"
+        },
+        {
+          "type": "object",
+          "required": ["severity"],
+          "properties": {
+            "severity": {
+              "$ref": "#/definitions/LintSeverity"
+            },
+            "options": {
+              "description": "Rule-specific options (future use)"
+            }
+          }
+        }
+      ]
+    },
+    "LintSeverity": {
+      "type": "string",
+      "enum": ["off", "warn", "error"],
+      "description": "Severity level for a lint rule"
+    }
+  }
+}

--- a/crates/graphql-config/schema/graphqlrc.schema.md
+++ b/crates/graphql-config/schema/graphqlrc.schema.md
@@ -1,0 +1,197 @@
+# GraphQL Configuration Schema
+
+This directory contains a JSON Schema for `.graphqlrc` configuration files used by GraphQL LSP and related tools.
+
+## What is it?
+
+The [graphqlrc.schema.json](./crates/graphql-config/schema/graphqlrc.schema.json) file provides IDE validation, autocompletion, and documentation for GraphQL configuration files.
+
+## How to Use
+
+### VSCode
+
+Add a comment at the top of your `.graphqlrc.yaml` or `.graphqlrc.yml` file:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schem./crates/graphql-config/schema/graphqlrc.schema.json
+schema: schema.graphql
+documents: "**/*.{graphql,gql,ts,tsx}"
+```
+
+Or configure it globally in your VSCode settings (`.vscode/settings.json`):
+
+```json
+{
+  "yaml.schemas": {
+    "./crates/graphql-config/schem./crates/graphql-config/schema/graphqlrc.schema.json": [
+      ".graphqlrc",
+      ".graphqlrc.yaml",
+      ".graphqlrc.yml",
+      "graphql.config.yaml",
+      "graphql.config.yml"
+    ]
+  },
+  "json.schemas": [
+    {
+      "fileMatch": [".graphqlrc.json", ".graphqlrc"],
+      "url": "./crates/graphql-config/schem./crates/graphql-config/schema/graphqlrc.schema.json"
+    }
+  ]
+}
+```
+
+### JetBrains IDEs (IntelliJ, WebStorm, etc.)
+
+1. Open Settings → Languages & Frameworks → Schemas and DTDs → JSON Schema Mappings
+2. Add a new mapping:
+   - Name: GraphQL Configuration
+   - Schema file or URL: Point to `graphqlrc.schema.json`
+   - Schema version: JSON Schema version 7
+   - File path pattern: `.graphqlrc*`, `graphql.config.*`
+
+### Other Editors
+
+Most editors with YAML/JSON support can use the modeline comment:
+
+```yaml
+# yaml-language-server: $schema=./crates/graphql-config/schema/graphqlrc.schema.json
+```
+
+## Configuration Examples
+
+### Single Project
+
+```yaml
+schema: schema.graphql
+documents: "**/*.{graphql,gql,ts,tsx,js,jsx}"
+extensions:
+  project:
+    lint: "recommended"
+```
+
+### Multi-Project
+
+```yaml
+projects:
+  api:
+    schema: api/schema.graphql
+    documents: "api/**/*.graphql"
+    extensions:
+      project:
+        lint:
+          recommended: error
+          deprecated_field: off
+
+  client:
+    schema: client/schema.graphql
+    documents: "client/**/*.{ts,tsx}"
+    extensions:
+      extractConfig:
+        tagIdentifiers: ["gql"]
+        modules: ["@apollo/client"]
+      project:
+        lint: "recommended"
+```
+
+### Custom Extract Configuration
+
+```yaml
+schema: schema.graphql
+documents: "**/*.ts"
+extensions:
+  extractConfig:
+    magicComment: "MyGraphQL"
+    tagIdentifiers: ["myGql", "graphql"]
+    modules: ["my-graphql-lib"]
+    allowGlobalIdentifiers: true
+```
+
+### Custom Lint Rules
+
+```yaml
+schema: schema.graphql
+documents: "**/*.graphql"
+extensions:
+  project:
+    lint:
+      unique_names: error
+      deprecated_field: warn
+```
+
+### Recommended Preset with Overrides
+
+```yaml
+schema: schema.graphql
+documents: "**/*.graphql"
+extensions:
+  project:
+    lint:
+      recommended: error
+      deprecated_field: off # Override to disable this rule
+```
+
+## Schema Features
+
+The schema provides:
+
+- **Validation**: Ensures required fields are present and values are correct types
+- **Autocompletion**: Suggests available fields and values
+- **Documentation**: Shows descriptions for each field on hover
+- **Error Detection**: Highlights invalid configurations immediately
+
+## Supported Fields
+
+### Top Level
+
+- `schema` (required): String or array of schema file paths/patterns/URLs
+- `documents`: String or array of document file patterns
+- `include`: String or array of file patterns to include
+- `exclude`: String or array of file patterns to exclude
+- `extensions`: Object containing tool-specific configuration
+- `projects`: Object mapping project names to project configurations (for multi-project setups)
+
+### Extensions
+
+#### `extensions.extractConfig`
+
+Configuration for extracting GraphQL from TypeScript/JavaScript files:
+
+- `magicComment`: String to look for in comments (default: `"GraphQL"`)
+- `tagIdentifiers`: Array of tag names to extract (default: `["gql", "graphql"]`)
+- `modules`: Array of module names to recognize (default: graphql-tag, @apollo/client, etc.)
+- `allowGlobalIdentifiers`: Boolean to allow extraction without imports (default: `false`)
+
+#### `extensions.project.lint`
+
+Linting configuration:
+
+- String value `"recommended"` to use preset
+- Object with rule configurations:
+  - `recommended`: Severity to apply recommended rules
+  - `unique_names`: Ensure operation/fragment names are unique
+  - `deprecated_field`: Warn about deprecated field usage
+  - Additional custom rules
+
+Severity values: `"off"`, `"warn"`, `"error"`
+
+## Publishing
+
+To make the schema publicly available:
+
+1. Commit the schema file to your repository
+2. Use the raw GitHub URL in the `$schema` comment:
+
+   ```yaml
+   # yaml-language-server: $schema=https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schem./crates/graphql-config/schema/graphqlrc.schema.json
+   ```
+
+3. (Optional) Publish to [Schema Store](https://www.schemastore.org/) for automatic IDE support without manual configuration
+
+## Updating the Schema
+
+When adding new configuration options to the GraphQL LSP:
+
+1. Update the Rust types in `crates/graphql-config/src/config.rs`
+2. Update this JSON Schema to match
+3. Add examples to this README
+4. Update the schema version/date if needed

--- a/test-workspace/graphql.config.yaml
+++ b/test-workspace/graphql.config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../crates/graphql-config/schema/graphqlrc.schema.json
 schema: schema.graphql
 documents: "**/*.{graphql,gql,ts,tsx,js,jsx}"
 extensions:


### PR DESCRIPTION
## Summary

Adds a comprehensive JSON Schema for `.graphqlrc` configuration files that provides IDE validation, autocompletion, and documentation.

## Changes

- Added JSON Schema with full coverage of all configuration options:
  - Single and multi-project configurations
  - Schema and documents configuration (string or array)
  - Include/exclude patterns
  - ExtractConfig extension (magicComment, tagIdentifiers, modules, allowGlobalIdentifiers)
  - Lint configuration (recommended preset and custom rules)
- Added comprehensive documentation (graphqlrc.schema.md) with setup instructions for multiple IDEs
- Added example configuration files (single-project and multi-project)
- Updated VSCode workspace settings to use the schema
- Updated test-workspace config with schema reference
- Updated main README with link to schema documentation

## Schema Location

The schema lives in `crates/graphql-config/schema/` alongside the config parsing code for better organization and maintainability.

## Public URL

Once merged, the schema will be available at:
```
https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schema/graphqlrc.schema.json
```

Users can reference it in their config files:
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/trevor-scheer/graphql-lsp/main/crates/graphql-config/schema/graphqlrc.schema.json
schema: schema.graphql
documents: "**/*.graphql"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)