### PR TITLE
fix: implement unused_fields lint rule for CLI and LSP

### DIFF
--- a/crates/graphql-cli/src/commands/lint.rs
+++ b/crates/graphql-cli/src/commands/lint.rs
@@ -211,6 +211,46 @@ pub async fn run(
             }
         }
 
+        // Run project-wide lint rules (e.g., unused_fields, unique_names)
+        let project_diagnostics = project.lint_project();
+        for diag in project_diagnostics {
+            // Extract file path from diagnostic source field (format: "graphql-linter:path")
+            let file_path = if diag.source.starts_with("graphql-linter:") {
+                diag.source
+                    .strip_prefix("graphql-linter:")
+                    .unwrap()
+                    .to_string()
+            } else {
+                "(project)".to_string()
+            };
+
+            let diag_output = DiagnosticOutput {
+                file_path,
+                // Convert from 0-indexed to 1-indexed for display
+                line: diag.range.start.line + 1,
+                column: diag.range.start.character + 1,
+                end_line: diag.range.end.line + 1,
+                end_column: diag.range.end.character + 1,
+                message: diag.message,
+                severity: match diag.severity {
+                    Severity::Error => "error".to_string(),
+                    Severity::Warning => "warning".to_string(),
+                    Severity::Information => "info".to_string(),
+                    Severity::Hint => "hint".to_string(),
+                },
+                rule: diag.code.clone(),
+            };
+
+            match diag.severity {
+                Severity::Warning | Severity::Information | Severity::Hint => {
+                    all_warnings.push(diag_output);
+                }
+                Severity::Error => {
+                    all_errors.push(diag_output);
+                }
+            }
+        }
+
         // Display results
         total_warnings = all_warnings.len();
         total_errors = all_errors.len();


### PR DESCRIPTION
## Summary

Implements full support for the `unused_fields` lint rule, which warns about schema fields that are never used in any operation or fragment across the project.

## Changes

### 1. CLI (lint.rs)
- Calls `project.lint_project()` to run project-wide lint rules
- Extracts file paths from diagnostic source field
- Displays warnings with proper file locations and line numbers

### 2. LSP (server.rs)
- Schema files now publish lint diagnostics when opened/changed
- Added `revalidate_schema_files()` method called on `did_save`
- Schema diagnostics update when field usage changes in documents
- Revalidation moved to save event (not keystroke) to avoid performance issues

### 3. unused_fields rule
- Uses `schema_index.find_field_definition()` for accurate field positions
- Stores file path in diagnostic source field (format: `graphql-linter:path`)
- Now processes both pure `.graphql` files and extracted TypeScript/JavaScript
- Detects field usage in all document types

### 4. Project API
- Added `get_schema_file_paths()` method
- Returns all schema files matching project patterns
- Used by LSP to find files needing revalidation

## Behavior

**CLI:**
```
schema.graphql:20:3: warning: Field 'Pokemon.captureRate' is defined in the schema but never used
schema.graphql:165:3: warning: Field 'Trainer.badges' is defined in the schema but never used
```

**LSP:**
- Warnings appear in schema files when opened with exact field locations
- Warnings update when documents are saved (Cmd+S / Ctrl+S)
- Works with GraphQL in `.graphql` files and embedded in `.ts`/`.tsx`/`.js`/`.jsx` files
- Performance optimized: no lag while typing

## Testing

Tested with the test-workspace:
- Pure `.graphql` files ✓
- Embedded GraphQL in TypeScript files ✓
- Real-time updates on save ✓
- No performance issues during typing ✓