### PR TITLE
feat(vscode): add syntax highlighting for function call style GraphQL

### DIFF
--- a/editors/vscode/syntaxes/graphql.injection.tmLanguage.json
+++ b/editors/vscode/syntaxes/graphql.injection.tmLanguage.json
@@ -11,7 +11,35 @@
       "patterns": [
         {
           "name": "meta.embedded.block.graphql",
-          "begin": "(?x)\n  (gql|graphql|gqltag)\\s*\n  (`)",
+          "comment": "Function call with template literal: graphql(`query { ... }`)",
+          "begin": "(gql|graphql|gqltag)\\s*\\(\\s*(`)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.js"
+            },
+            "2": {
+              "name": "punctuation.definition.string.template.begin.js"
+            }
+          },
+          "end": "`",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.template.end.js"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#template-substitution-element"
+            },
+            {
+              "include": "source.graphql"
+            }
+          ]
+        },
+        {
+          "name": "meta.embedded.block.graphql",
+          "comment": "Tagged template literal: gql`query { ... }`",
+          "begin": "(gql|graphql|gqltag)\\s*(`)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
## Summary

- Adds support for function call syntax: `graphql(`query { ... }`)`
- Maintains existing tagged template literal support: `graphql`query { ... }``
- Both syntax styles now get full syntax highlighting and LSP features

## Technical Details

The VSCode extension's TextMate grammar now handles both GraphQL syntax patterns:

1. **Function calls**: `graphql(`query...`)` - common in code generators
2. **Tagged templates**: `graphql`query...`` - traditional Apollo/Relay style

The fix involved reordering grammar patterns - TextMate processes patterns sequentially, so the more specific pattern (with parentheses) must come first.

## Example

```typescript
export const GetUserActionsQueryDoc = graphql(`
  query getUserActions($namespace: UserActionNamespace!) {
    organization {
      id
    }
  }
`);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)