### PR TITLE
feat: add gitignore-style negation pattern support for document matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +413,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -758,6 +787,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "graphql-cli"
 version = "0.1.1"
 dependencies = [
@@ -864,6 +906,7 @@ dependencies = [
  "graphql-config",
  "graphql-extract",
  "graphql-introspect",
+ "ignore",
  "insta",
  "notify",
  "reqwest",
@@ -1183,6 +1226,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ clap = { version = "4.5", features = ["derive"] }
 glob = "0.3"
 walkdir = "2.5"
 notify = "8.2"
+ignore = "0.4"
 
 # HTTP
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/graphql-config/schema/example-multi-project.graphqlrc.yaml
+++ b/crates/graphql-config/schema/example-multi-project.graphqlrc.yaml
@@ -17,13 +17,16 @@ projects:
     schema:
       - client/schema.graphql
       - client/fragments/*.graphql
+    # Use gitignore-style negation patterns (recommended)
     documents:
-      - "client/**/*.ts"
-      - "client/**/*.tsx"
-    include:
-      - "client/src/**/*"
-    exclude:
-      - "client/**/*.test.ts"
+      - "client/**/*.{ts,tsx}"
+      - "!client/**/*.test.{ts,tsx}"
+      - "!client/**/__tests__/**"
+    # Alternative: use include/exclude (legacy approach)
+    # include:
+    #   - "client/src/**/*"
+    # exclude:
+    #   - "client/**/*.test.ts"
     extensions:
       extractConfig:
         tagIdentifiers: ["gql"]

--- a/crates/graphql-config/schema/example.graphqlrc.yaml
+++ b/crates/graphql-config/schema/example.graphqlrc.yaml
@@ -5,14 +5,23 @@
 # This file demonstrates all supported configuration options
 
 schema: schema.graphql
-documents: "**/*.{graphql,gql,ts,tsx,js,jsx}"
 
-# Optional: include/exclude patterns
-include:
-  - "src/**/*"
-exclude:
-  - "**/*.test.ts"
-  - "**/__tests__/**"
+# Document patterns support gitignore-style negation (patterns starting with !)
+# Patterns are processed in order, like .gitignore files
+documents:
+  - "**/*.{graphql,gql,ts,tsx,js,jsx}"
+  # Exclude test files using negation
+  - "!**/*.test.ts"
+  - "!**/*.test.tsx"
+  - "!**/__tests__/**"
+  - "!**/__mocks__/**"
+
+# Alternative: use include/exclude fields (legacy, less flexible)
+# include:
+#   - "src/**/*"
+# exclude:
+#   - "**/*.test.ts"
+#   - "**/__tests__/**"
 
 # Tool-specific extensions
 extensions:

--- a/crates/graphql-project/Cargo.toml
+++ b/crates/graphql-project/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true }
 glob = { workspace = true }
 walkdir = { workspace = true }
 notify = { workspace = true }
+ignore = { workspace = true }
 
 # HTTP for schema introspection
 reqwest = { workspace = true }


### PR DESCRIPTION
## Summary

Add support for gitignore-style negation patterns (starting with `!`) in document configuration, enabling more intuitive file exclusion similar to `.gitignore` files.

## Motivation

Large codebases can have 10k+ files matching initial patterns, causing performance issues. Negation patterns provide an intuitive, `.gitignore`-style way to exclude unwanted files inline with the pattern list.

## Changes

- Add `ignore` crate dependency (used by ripgrep) for gitignore-style pattern matching
- Refactor document loading to process all patterns together (required for negation support)
- Add fast path for non-negation patterns using existing glob matching (no performance regression)
- Add gitignore-style matching when negation patterns are present
- Update example configs to demonstrate negation pattern usage
- Maintain backward compatibility with `include`/`exclude` fields

## Usage

```yaml
documents:
  - "**/*.{ts,tsx,graphql}"
  - "!**/*.test.ts"         # Exclude test files
  - "!**/*.test.tsx"
  - "!**/__tests__/**"      # Exclude test directories
  - "!**/__mocks__/**"
```

## Pattern Semantics

Negation patterns follow standard gitignore semantics:
- Patterns are processed in order
- Later patterns can override earlier ones
- Negation patterns (starting with `!`) exclude files from the matched set
- Fast path: if no negation patterns are present, uses existing glob matching (no performance impact)
- Slow path: uses `ignore` crate for full gitignore-style matching when negations are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)