### PR TITLE
fix(cli): improve OpenTelemetry tracing for CLI validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "indicatif",
  "opentelemetry 0.27.1",
  "opentelemetry-otlp 0.27.0",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.27.1",
  "serde",
  "serde_json",
@@ -1790,6 +1791,12 @@ dependencies = [
  "tonic 0.14.2",
  "tonic-prost",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/crates/graphql-cli/Cargo.toml
+++ b/crates/graphql-cli/Cargo.toml
@@ -43,7 +43,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 opentelemetry = { version = "0.27", optional = true }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true }
 opentelemetry-otlp = { version = "0.27", features = ["default"], optional = true }
+opentelemetry-semantic-conventions = { version = "0.27", optional = true }
 tracing-opentelemetry = { version = "0.28", optional = true }
 
 [features]
-otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]
+otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "tracing-opentelemetry"]


### PR DESCRIPTION
## Summary

- Set proper service name for OpenTelemetry traces (graphql-cli instead of unknown_service)
- Use simple exporter instead of batch exporter to ensure immediate span export for short-lived CLI
- Fix async span context using `.instrument()` for Send-safe spans
- Add hierarchical tracing spans throughout validation process
- Improve trace flushing with explicit force_flush() before shutdown

## Details

This PR fixes OpenTelemetry tracing in the graphql-cli so that traces are properly exported to Jaeger and other OTLP collectors. The main issues were:

1. **Missing service name** - Traces showed as "unknown_service" in Jaeger
2. **Batch exporter timing** - CLI exits before batched spans can be exported
3. **Async span context** - Using `in_scope()` doesn't work with async functions

The fix uses:
- OpenTelemetry semantic conventions for proper service naming
- Simple exporter for immediate span transmission
- `Instrument` trait for Send-safe async span instrumentation
- Detailed hierarchical spans for performance analysis

Trace hierarchy:
- `run` (root span from instrument macro)
  - `load_schema` (per project)
  - `load_documents` (per project)
  - `validate_files` (entire validation loop)
    - `validate_file` (per file, debug level)
      - `extract_graphql` (debug level)
      - `validate_document` (debug level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)