### PR TITLE
fix(project): apply extractConfig from project extensions

### DIFF
--- a/crates/graphql-project/src/dynamic_project.rs
+++ b/crates/graphql-project/src/dynamic_project.rs
@@ -235,6 +235,11 @@ impl DynamicGraphQLProject {
             if let Some(ref base_path) = self.base_dir {
                 document_loader = document_loader.with_base_path(base_path);
             }
+
+            // Apply extractConfig from project extensions
+            let extract_config = self.get_extract_config();
+            document_loader = document_loader.with_extract_config(extract_config);
+
             document_loader.load()?
         } else {
             DocumentIndex::new()

--- a/crates/graphql-project/src/static_project.rs
+++ b/crates/graphql-project/src/static_project.rs
@@ -88,6 +88,15 @@ impl StaticGraphQLProject {
                 document_loader = document_loader.with_base_path(base_path);
             }
 
+            // Apply extractConfig from project extensions
+            let extract_config = config
+                .extensions
+                .as_ref()
+                .and_then(|ext| ext.get("extractConfig"))
+                .and_then(|value| serde_json::from_value(value.clone()).ok())
+                .unwrap_or_default();
+            document_loader = document_loader.with_extract_config(extract_config);
+
             // Use the new load_with_contents method to get both index and contents
             let (index, files) = Self::load_documents_with_contents(&document_loader)?;
             (index, files)


### PR DESCRIPTION
## Summary

Fixes extraction configuration not being applied during project initialization, which prevented settings like `allowGlobalIdentifiers` from working.

## Problem

The `extractConfig` was defined in the configuration schema and could be specified in `.graphqlrc.yml` under `extensions.extractConfig`, but it was never actually read and applied during project loading. This caused settings to be ignored, resulting in extraction failures for projects using non-standard GraphQL imports.

For example, a config like this would be silently ignored:

```yaml
extensions:
  extractConfig:
    allowGlobalIdentifiers: true
```

## Solution

Updated both project types to read and apply the `extractConfig` from project extensions:

- **StaticGraphQLProject**: Reads `extractConfig` during `load()` and applies it to `DocumentLoader`
- **DynamicGraphQLProject**: Reads `extractConfig` during `load_documents()` via the existing `get_extract_config()` helper

## Use Case

This enables extraction from TypeScript/JavaScript files where the `graphql` template tag is imported from non-standard modules (e.g., code-generated helpers) by configuring:

```yaml
extensions:
  extractConfig:
    allowGlobalIdentifiers: true
```

## Testing

Tested with a multi-project repository using custom GraphQL imports. Before the fix, extraction found 0 operations. After the fix with `allowGlobalIdentifiers: true` configured:

- Project 1: 2838 operations, 552 fragments ✓
- Project 2: 13 operations, 7 fragments ✓