### PR TITLE
feat(lsp): add config file watching and hot reloading

### DIFF
--- a/test-workspace/graphql.config.yaml
+++ b/test-workspace/graphql.config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../crates/graphql-config/schema/graphqlrc.schema.json
 schema: schema.graphql
-documents: "src/**/*.{graphql,gql,ts,tsx}"
+documents: "src/**/*.{graphql,gql,ts,tsx,js,jsx}"
 
 # Global lint configuration (applies to all tools by default)
 lint:


### PR DESCRIPTION
## Summary

Implements automatic detection and reloading of GraphQL config files when they change on disk. The LSP now watches config files and hot-reloads projects without requiring a restart.

## Key Features

- **Automatic File Watching**: Uses LSP's `workspace/didChangeWatchedFiles` to monitor config files
- **Debounced Reloading**: 500ms debounce prevents reload spam during rapid config edits
- **User Feedback**: Progress notifications and toast messages keep users informed
- **Full Revalidation**: All open documents are automatically revalidated after reload
- **Graceful Error Handling**: Parse errors and deletions show helpful messages

## User Experience

**Success flow:**
1. User edits `.graphqlrc.yaml` and saves
2. Toast appears: "GraphQL" with message "Config changed, reloading..."
3. Progress indicator shows reload status
4. On completion: "GraphQL config reloaded successfully" toast
5. All open GraphQL files are automatically revalidated

**Error handling:**
- Config parse errors show error toast with details
- Config deletion shows warning: "GraphQL config file was deleted"
- Failed project initialization shows specific error messages

## Technical Details

- Tracks config file paths per workspace in `config_paths: Arc<DashMap<String, PathBuf>>`
- Registers file watchers using **glob patterns** (e.g., `**/.graphqlrc.yaml`) instead of absolute URIs
  - This is the standard way LSP file watchers work in VSCode
  - More reliable than absolute `file://` URIs
- Debounced reload tasks stored in `reload_tasks` to prevent duplicate reloads
- Full project re-initialization: reloads schema, documents, and lint config
- Uses LSP progress notifications with unique tokens per workspace

## Implementation Notes

**Why glob patterns instead of absolute URIs?**
- Initial implementation used `file:///absolute/path/to/.graphqlrc.yaml`
- VSCode's file watchers expect workspace-relative glob patterns
- Changed to `**/.graphqlrc.yaml` which matches the file anywhere in the workspace
- This fixed the issue where `didChangeWatchedFiles` wasn't being called

**Why not use the `notify` crate?**
- Uses LSP's built-in file watching capabilities (`didChangeWatchedFiles`)
- More reliable across different editors and platforms
- No additional dependencies needed
- Standard LSP protocol approach

**Debouncing:**
- 500ms delay batches rapid saves (e.g., auto-save, multiple edits)
- Cancels pending reload if new change detected
- Each workspace has independent debounce state

## Testing

Manually tested:
- ✅ Config file modification triggers reload
- ✅ Toast notifications appear correctly
- ✅ Progress indicators work as expected
- ✅ Documents revalidate after reload
- ✅ Multiple workspaces work independently
- ✅ Parse errors show proper error messages
- ✅ Config deletion handled gracefully
- ✅ Glob pattern matching works correctly

## Known Issue

There's a performance issue where project-wide linting runs multiple times during `revalidate_all_documents` (once per open document). This is a pre-existing issue not introduced by this PR. Will address in a separate optimization PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)