### PR TITLE
feat(vscode): add startup notifications and restart command

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -18,6 +18,13 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "graphql-lsp.restartServer",
+        "title": "Restart GraphQL Language Server",
+        "category": "GraphQL"
+      }
+    ],
     "languages": [
       {
         "id": "graphql",


### PR DESCRIPTION
## Summary

Adds user-facing feedback when the VSCode extension loads and a command to restart the language server:

- **Progress notification** during LSP startup and config loading
- **Toast notification** when GraphQL config is successfully loaded
- **New command**: "Restart GraphQL Language Server" (`graphql-lsp.restartServer`)

## Changes

### VSCode Extension
- Refactored activation logic into reusable `startLanguageServer()` function
- Added `window.withProgress()` wrapper around LSP startup with status messages
- Added notification listener for config load success message from LSP server
- Registered new command to stop and restart the language server
- Updated `package.json` to expose the restart command in command palette

## User Experience

### On Extension Activation
1. Progress notification appears: "GraphQL LSP: Starting language server..."
2. Updates to: "GraphQL LSP: Loading GraphQL configuration..."
3. Toast notification: "GraphQL LSP: Configuration loaded successfully"

### Restart Command
Users can now run "GraphQL: Restart GraphQL Language Server" from the command palette to manually reload the language server without restarting VSCode. This is useful when:
- Switching between projects with different configs
- Making config changes that require a fresh start
- Troubleshooting LSP issues