### PR TITLE
feat(linter): add require_id_field lint rule

### DIFF
--- a/crates/graphql-linter/src/rules/mod.rs
+++ b/crates/graphql-linter/src/rules/mod.rs
@@ -1,11 +1,13 @@
 mod deprecated;
 mod redundant_fields;
+mod require_id_field;
 mod unique_names;
 mod unused_fields;
 mod unused_fragments;
 
 pub use deprecated::DeprecatedFieldRule;
 pub use redundant_fields::RedundantFieldsRule;
+pub use require_id_field::RequireIdFieldRule;
 pub use unique_names::UniqueNamesRule;
 pub use unused_fields::UnusedFieldsRule;
 pub use unused_fragments::UnusedFragmentsRule;
@@ -76,7 +78,7 @@ pub fn all_standalone_document_rules() -> Vec<Box<dyn StandaloneDocumentRule>> {
 
 /// Get all available document+schema lint rules
 pub fn all_document_schema_rules() -> Vec<Box<dyn DocumentSchemaRule>> {
-    vec![Box::new(DeprecatedFieldRule)]
+    vec![Box::new(DeprecatedFieldRule), Box::new(RequireIdFieldRule)]
 }
 
 /// Get all available standalone schema lint rules


### PR DESCRIPTION
## Summary

Adds a new **document+schema** lint rule that enforces requesting the `id` field when it's available on a GraphQL type. This helps ensure consistent data fetching patterns and enables better client-side caching strategies (e.g., normalized caches in Apollo Client, Relay, etc.).

## Implementation Details

The `require_id_field` rule:
- Recursively checks all selection sets for types that have an `id` field
- Reports warnings when selection sets omit the `id` field on types that have one
- Properly handles inline fragments (doesn't require `id` in inline fragments since the parent selection may already include it)
- Validates nested object types throughout the query tree
- Includes comprehensive test coverage (6 test cases)

## Usage

Enable in `.graphqlrc.yaml`:

```yaml
lint:
  require_id_field: error  # or 'warn'
```

## Example

**Before** (triggers warning):
```graphql
query GetUser($userId: ID!) {
  user(id: $userId) {
    name
    email
  }
}
```

**After** (passes validation):
```graphql
query GetUser($userId: ID!) {
  user(id: $userId) {
    id
    name
    email
  }
}
```

## Test Coverage

- ✅ Missing `id` field detection
- ✅ Valid queries with `id` field present
- ✅ Types without `id` fields (no false positives)
- ✅ Nested selection sets
- ✅ Fragment definitions
- ✅ Inline fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)