### PR TITLE
refactor(linter): cache document parsing across lint rules

### DIFF
--- a/crates/graphql-cli/src/commands/lint.rs
+++ b/crates/graphql-cli/src/commands/lint.rs
@@ -2,7 +2,7 @@ use crate::commands::common::CommandContext;
 use crate::OutputFormat;
 use anyhow::Result;
 use colored::Colorize;
-use graphql_linter::{DocumentSchemaContext, LintConfig, Linter};
+use graphql_linter::{LintConfig, Linter};
 use graphql_project::Severity;
 use std::path::PathBuf;
 use std::process;
@@ -146,12 +146,8 @@ pub async fn run(
         // Run lints on each extracted block
         for block in &extracted {
             // Run standalone document rules (don't need schema, but need fragments)
-            let standalone_ctx = graphql_linter::StandaloneDocumentContext {
-                document: &block.source,
-                file_name: file_path,
-                fragments: Some(document_index),
-            };
-            let standalone_diagnostics = linter.lint_standalone_document(&standalone_ctx);
+            let standalone_diagnostics =
+                linter.lint_standalone_document(&block.source, file_path, Some(document_index));
 
             // Convert standalone diagnostics to output format
             for diag in standalone_diagnostics {
@@ -199,12 +195,7 @@ pub async fn run(
             }
 
             // Run document+schema rules
-            let ctx = DocumentSchemaContext {
-                document: &block.source,
-                file_name: file_path,
-                schema: schema_index,
-            };
-            let diagnostics = linter.lint_document(&ctx);
+            let diagnostics = linter.lint_document(&block.source, file_path, schema_index);
 
             // Convert diagnostics to output format
             for diag in diagnostics {

--- a/crates/graphql-linter/src/context.rs
+++ b/crates/graphql-linter/src/context.rs
@@ -6,6 +6,8 @@ pub struct StandaloneDocumentContext<'a> {
     pub file_name: &'a str,
     /// Optional access to the global fragment index for cross-file fragment resolution
     pub fragments: Option<&'a DocumentIndex>,
+    /// Pre-parsed syntax tree to avoid repeated parsing
+    pub parsed: &'a apollo_parser::SyntaxTree,
 }
 
 /// Context for linting a document against a schema
@@ -13,6 +15,8 @@ pub struct DocumentSchemaContext<'a> {
     pub document: &'a str,
     pub file_name: &'a str,
     pub schema: &'a SchemaIndex,
+    /// Pre-parsed syntax tree to avoid repeated parsing
+    pub parsed: &'a apollo_parser::SyntaxTree,
 }
 
 /// Context for linting a standalone schema

--- a/crates/graphql-linter/src/rules/deprecated.rs
+++ b/crates/graphql-linter/src/rules/deprecated.rs
@@ -1,6 +1,5 @@
 use crate::context::DocumentSchemaContext;
 use apollo_parser::cst::{self, CstNode};
-use apollo_parser::Parser;
 use graphql_project::{Diagnostic, Position, Range, SchemaIndex};
 
 use super::DocumentSchemaRule;
@@ -21,15 +20,8 @@ impl DocumentSchemaRule for DeprecatedFieldRule {
         let document = ctx.document;
         let schema_index = ctx.schema;
         let mut warnings = Vec::new();
-        let parser = Parser::new(document);
-        let tree = parser.parse();
 
-        // If there are syntax errors, we can't reliably check for deprecated fields
-        if tree.errors().len() > 0 {
-            return warnings;
-        }
-
-        let doc_cst = tree.document();
+        let doc_cst = ctx.parsed.document();
 
         // Walk through all definitions in the document
         for definition in doc_cst.definitions() {
@@ -241,10 +233,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let warnings = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(warnings.len(), 1, "Should have exactly one warning");
@@ -283,10 +277,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let warnings = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(warnings.len(), 2, "Should have two warnings");
@@ -331,10 +327,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let warnings = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(warnings.len(), 1, "Should have one warning");
@@ -370,10 +368,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let warnings = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(warnings.len(), 0, "Should have no warnings");
@@ -406,10 +406,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let warnings = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(

--- a/crates/graphql-linter/src/rules/redundant_fields.rs
+++ b/crates/graphql-linter/src/rules/redundant_fields.rs
@@ -1,6 +1,5 @@
 use crate::context::StandaloneDocumentContext;
 use apollo_parser::cst::{self, CstNode};
-use apollo_parser::Parser;
 use graphql_project::{Diagnostic, Position, Range};
 use std::collections::{HashMap, HashSet};
 
@@ -43,14 +42,8 @@ impl StandaloneDocumentRule for RedundantFieldsRule {
     fn check(&self, ctx: &StandaloneDocumentContext) -> Vec<Diagnostic> {
         let document = ctx.document;
         let mut diagnostics = Vec::new();
-        let parser = Parser::new(document);
-        let tree = parser.parse();
 
-        if tree.errors().len() > 0 {
-            return diagnostics;
-        }
-
-        let doc_cst = tree.document();
+        let doc_cst = ctx.parsed.document();
 
         // Collect fragment definitions - first from the document, then from the global index
         let mut fragments = FragmentRegistry::new();
@@ -366,10 +359,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 2);
@@ -391,10 +386,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 0);
@@ -418,10 +415,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 0);
@@ -450,10 +449,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 2);
@@ -481,10 +482,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 1);
@@ -514,10 +517,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 2);
@@ -551,10 +556,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         // Fragment A contains: id, ...B (which includes name and ...A recursively)
@@ -605,10 +612,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(
@@ -635,10 +644,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&StandaloneDocumentContext {
             document,
             file_name: "test.graphql",
             fragments: None,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 1);

--- a/crates/graphql-linter/src/rules/require_id_field.rs
+++ b/crates/graphql-linter/src/rules/require_id_field.rs
@@ -1,6 +1,5 @@
 use crate::context::DocumentSchemaContext;
 use apollo_parser::cst::{self, CstNode};
-use apollo_parser::Parser;
 use graphql_project::{Diagnostic, Position, Range, SchemaIndex};
 
 use super::DocumentSchemaRule;
@@ -21,14 +20,8 @@ impl DocumentSchemaRule for RequireIdFieldRule {
         let document = ctx.document;
         let schema_index = ctx.schema;
         let mut diagnostics = Vec::new();
-        let parser = Parser::new(document);
-        let tree = parser.parse();
 
-        if tree.errors().len() > 0 {
-            return diagnostics;
-        }
-
-        let doc_cst = tree.document();
+        let doc_cst = ctx.parsed.document();
 
         for definition in doc_cst.definitions() {
             match definition {
@@ -275,10 +268,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 1, "Should have exactly one diagnostic");
@@ -315,10 +310,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 0, "Should have no diagnostics");
@@ -350,10 +347,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(
@@ -400,10 +399,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(
@@ -439,10 +440,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(
@@ -493,10 +496,12 @@ mod tests {
             }
         ";
 
+        let parsed = apollo_parser::Parser::new(document).parse();
         let diagnostics = rule.check(&DocumentSchemaContext {
             document,
             file_name: "test.graphql",
             schema: &schema,
+            parsed: &parsed,
         });
 
         assert_eq!(diagnostics.len(), 0, "Should have no diagnostics");


### PR DESCRIPTION
## Summary

Optimizes the linting system to parse GraphQL documents once per linting session instead of once per rule. Previously, each lint rule was independently parsing the same document, resulting in 3-4x redundant parsing work.

## Changes

- Add `parsed: &'a apollo_parser::SyntaxTree` field to `DocumentSchemaContext` and `StandaloneDocumentContext`
- Update `Linter::lint_document()` and `Linter::lint_standalone_document()` to:
  - Parse documents once at the linter level
  - Pass the pre-parsed `SyntaxTree` to rules via context
  - Return early if parse errors are detected
- Update all lint rules to use `ctx.parsed` instead of calling `Parser::new()`
  - `deprecated.rs`
  - `require_id_field.rs`
  - `redundant_fields.rs`
- Update all test cases to provide the `parsed` field in context initialization
- Update CLI and LSP callsites to use the new linter API

## Performance Impact

With N enabled rules, this eliminates N-1 redundant document parses:
- **Before**: Each of 3-4 rules parses the document independently
- **After**: Parse once, all rules share the same syntax tree

For a typical configuration with 3-4 rules enabled, this reduces parsing overhead by **66-75%**.

## Technical Details

The `apollo_parser::SyntaxTree` is already created by every rule, so this change simply hoists that work out of the per-rule loop and into the linter itself. The syntax tree is passed by reference with the same `'a` lifetime as the context, so there's no additional memory overhead.

This is a textbook loop-invariant code motion optimization with no tradeoffs—just pure performance improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)