### PR TITLE
perf(cli): optimize lint command to use cached parsed ASTs

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -1106,12 +1106,13 @@ impl GraphQLLanguageServer {
             content,
             "document.graphql",
             Some(&document_index_guard),
+            None,
         );
         project_diagnostics.extend(standalone_diagnostics);
 
         // Run document+schema rules
         let lint_diagnostics =
-            linter.lint_document(content, "document.graphql", &schema_index_guard);
+            linter.lint_document(content, "document.graphql", &schema_index_guard, None);
         project_diagnostics.extend(lint_diagnostics);
 
         // Convert graphql-project diagnostics to LSP diagnostics
@@ -1195,6 +1196,7 @@ impl GraphQLLanguageServer {
                 &block.source,
                 &file_path,
                 Some(&document_index_guard),
+                None,
             );
 
             // Adjust positions for extracted blocks
@@ -1214,7 +1216,7 @@ impl GraphQLLanguageServer {
 
             // Run document+schema rules
             let lint_diagnostics =
-                linter.lint_document(&block.source, &file_path, &schema_index_guard);
+                linter.lint_document(&block.source, &file_path, &schema_index_guard, None);
 
             // Adjust positions for extracted blocks
             for mut diag in lint_diagnostics {


### PR DESCRIPTION
## Summary

Eliminates redundant parsing in the `graphql lint` command by reusing ASTs that are already cached during the project loading phase. This was identified as a significant performance bottleneck where files were being extracted and parsed twice - once when loading the project, and again when linting.

## Changes

### graphql-linter
- Updated `lint_standalone_document()` and `lint_document()` to accept an optional pre-parsed AST via `Option<&apollo_parser::SyntaxTree>`
- When an AST is provided, it's used directly; otherwise falls back to parsing the document
- Maintains full backward compatibility

### graphql-cli
- Refactored lint command to leverage cached ASTs from `DocumentIndex`:
  - For TypeScript/JavaScript files: Uses `extracted_blocks` with pre-parsed ASTs
  - For pure `.graphql` files: Uses `parsed_asts` with cached ASTs
- Removed redundant `extract_from_file()` calls
- Removed unused `extract_config` variable

### graphql-lsp
- Updated all lint method calls to pass `None` for the new AST parameter
- LSP continues to parse on-demand (appropriate for real-time editing)

## Performance Impact

**Before:**
1. Step 3 (Loading): Extract & parse all files → Build index
2. Step 6 (Linting): Extract & parse all files **again** → Run lints

**After:**
1. Step 3 (Loading): Extract & parse all files → Build index & **cache ASTs**
2. Step 6 (Linting): **Reuse cached ASTs** → Run lints

**Result**: Approximately **50% reduction in lint execution time** for the extraction + parsing phase, as all redundant work has been eliminated.

## Testing

- ✅ All 41 linter unit tests pass
- ✅ CLI lint command verified working with test fixtures
- ✅ Clippy and formatting checks pass
- ✅ Fully backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)