### PR TITLE
revert(cli): restore absolute paths in diagnostic output

### DIFF
--- a/crates/graphql-cli/src/commands/common.rs
+++ b/crates/graphql-cli/src/commands/common.rs
@@ -12,18 +12,6 @@ pub struct CommandContext {
 }
 
 impl CommandContext {
-    /// Convert an absolute path to be relative to the base directory
-    /// Returns the original path if it can't be made relative
-    pub fn relative_path(&self, path: &str) -> String {
-        let path_buf = PathBuf::from(path);
-
-        // Try to strip the base directory prefix
-        path_buf.strip_prefix(&self.base_dir).map_or_else(
-            |_| path.to_string(),
-            |relative| relative.to_string_lossy().to_string(),
-        )
-    }
-
     /// Load and validate config for a command.
     ///
     /// Enforces --project requirement for multi-project configs, unless a project

--- a/crates/graphql-cli/src/commands/lint.rs
+++ b/crates/graphql-cli/src/commands/lint.rs
@@ -391,10 +391,9 @@ pub async fn run(
         OutputFormat::Human => {
             // Print all warnings
             for warning in &all_warnings {
-                let display_path = ctx.relative_path(&warning.file_path);
                 println!(
                     "\n{}:{}:{}: {} {}",
-                    display_path,
+                    warning.file_path,
                     warning.line,
                     warning.column,
                     "warning:".yellow().bold(),
@@ -407,10 +406,9 @@ pub async fn run(
 
             // Print all errors
             for error in &all_errors {
-                let display_path = ctx.relative_path(&error.file_path);
                 println!(
                     "\n{}:{}:{}: {} {}",
-                    display_path,
+                    error.file_path,
                     error.line,
                     error.column,
                     "error:".red().bold(),

--- a/crates/graphql-cli/src/commands/validate.rs
+++ b/crates/graphql-cli/src/commands/validate.rs
@@ -121,11 +121,10 @@ pub async fn run(
         OutputFormat::Human => {
             // Print all errors
             for error in &all_errors {
-                let display_path = ctx.relative_path(&error.file_path);
                 if error.line > 0 {
                     println!(
                         "\n{}:{}:{}: {} {}",
-                        display_path,
+                        error.file_path,
                         error.line,
                         error.column,
                         "error:".red().bold(),


### PR DESCRIPTION
## Summary

Reverts the relative path changes from commit 7321048 that were causing more problems than they solved.

## Changes

- Remove `relative_path()` method from `CommandContext` 
- Restore absolute file paths in `lint` command diagnostic output
- Restore absolute file paths in `validate` command diagnostic output

## Before

```
apps/web-client/src/components/access-page.tsx:190:9: error ...
```

## After

```
/Users/trevor/obsidian/apps/web-client/src/components/access-page.tsx:190:9: error ...
```

Absolute paths provide better consistency with tooling expectations and IDE integrations.