### PR TITLE
refactor: extract position helpers and add O(1) field lookup

### DIFF
--- a/crates/graphql-linter/src/rules/unused_fields.rs
+++ b/crates/graphql-linter/src/rules/unused_fields.rs
@@ -225,22 +225,20 @@ fn collect_fields_from_selection_set(
                     // Recursively process nested selections
                     if let Some(nested_selection_set) = field.selection_set() {
                         // Get the field's return type from schema
-                        if let Some(fields) = schema_index.get_fields(parent_type_name) {
-                            if let Some(field_info) =
-                                fields.iter().find(|f| f.name == field_name_str)
-                            {
-                                // Extract the base type name (remove List/NonNull wrappers)
-                                let nested_type = field_info
-                                    .type_name
-                                    .trim_matches(|c| c == '[' || c == ']' || c == '!');
+                        if let Some(field_info) =
+                            schema_index.get_field(parent_type_name, &field_name_str)
+                        {
+                            // Extract the base type name (remove List/NonNull wrappers)
+                            let nested_type = field_info
+                                .type_name
+                                .trim_matches(|c| c == '[' || c == ']' || c == '!');
 
-                                collect_fields_from_selection_set(
-                                    &nested_selection_set,
-                                    nested_type,
-                                    schema_index,
-                                    used_fields,
-                                );
-                            }
+                            collect_fields_from_selection_set(
+                                &nested_selection_set,
+                                nested_type,
+                                schema_index,
+                                used_fields,
+                            );
                         }
                     }
                 }

--- a/crates/graphql-project/src/hover.rs
+++ b/crates/graphql-project/src/hover.rs
@@ -463,21 +463,15 @@ impl HoverProvider {
                             .name()
                             .map(|n| n.text().to_string())
                             .unwrap_or_default();
-                        let nested_type =
-                            if let Some(fields) = schema_index.get_fields(&parent_type) {
-                                fields
-                                    .iter()
-                                    .find(|f| f.name == field_name)
-                                    .map(|f| {
-                                        // Extract base type name (strip [], !)
-                                        f.type_name
-                                            .trim_matches(|c| c == '[' || c == ']' || c == '!')
-                                            .to_string()
-                                    })
-                                    .unwrap_or_default()
-                            } else {
-                                String::new()
-                            };
+                        let nested_type = schema_index
+                            .get_field(&parent_type, &field_name)
+                            .map(|f| {
+                                // Extract base type name (strip [], !)
+                                f.type_name
+                                    .trim_matches(|c| c == '[' || c == ']' || c == '!')
+                                    .to_string()
+                            })
+                            .unwrap_or_default();
 
                         if !nested_type.is_empty() {
                             if let Some(element) = Self::check_selection_set(
@@ -980,8 +974,7 @@ impl HoverProvider {
         parent_type: &str,
         schema_index: &SchemaIndex,
     ) -> Option<HoverInfo> {
-        let fields = schema_index.get_fields(parent_type)?;
-        let field_info = fields.iter().find(|f| f.name == field_name)?;
+        let field_info = schema_index.get_field(parent_type, field_name)?;
 
         let mut content = format!("### Field: `{field_name}`\n");
         content.push_str(&format!("**Type:** `{}`\n\n", field_info.type_name));
@@ -1065,8 +1058,7 @@ impl HoverProvider {
         parent_type: &str,
         schema_index: &SchemaIndex,
     ) -> Option<HoverInfo> {
-        let fields = schema_index.get_fields(parent_type)?;
-        let field_info = fields.iter().find(|f| f.name == field_name)?;
+        let field_info = schema_index.get_field(parent_type, field_name)?;
         let arg_info = field_info.arguments.iter().find(|a| a.name == arg_name)?;
 
         let mut content = format!("### Argument: `{arg_name}`\n");

--- a/crates/graphql-project/src/lib.rs
+++ b/crates/graphql-project/src/lib.rs
@@ -8,6 +8,7 @@ mod goto_definition;
 mod hover;
 mod index;
 mod line_index;
+mod position;
 mod schema;
 mod static_project;
 mod validation;
@@ -29,6 +30,7 @@ pub use index::{
     OperationType, SchemaIndex, TypeInfo,
 };
 pub use line_index::LineIndex;
+pub use position::{offset_to_line_col, position_to_offset, position_to_offset_with_index};
 pub use schema::SchemaLoader;
 pub use static_project::StaticGraphQLProject;
 pub use validation::Validator;

--- a/crates/graphql-project/src/position.rs
+++ b/crates/graphql-project/src/position.rs
@@ -1,0 +1,171 @@
+use crate::{LineIndex, Position};
+
+/// Convert a line/column position to a byte offset using a cached `LineIndex`
+///
+/// This is the fast path with O(1) complexity instead of O(N) character iteration.
+///
+/// Returns `None` if the position is out of bounds.
+#[must_use]
+pub fn position_to_offset_with_index(line_index: &LineIndex, position: Position) -> Option<usize> {
+    line_index.position_to_offset(position)
+}
+
+/// Convert a line/column position to a byte offset (fallback O(N) implementation)
+///
+/// This is the slow path used when no cached `LineIndex` is available.
+/// Prefers `position_to_offset_with_index` when possible.
+///
+/// Returns `None` if the position is beyond the end of the source.
+#[must_use]
+pub fn position_to_offset(source: &str, position: Position) -> Option<usize> {
+    let mut current_line = 0;
+    let mut current_col = 0;
+    let mut offset = 0;
+
+    for ch in source.chars() {
+        if current_line == position.line && current_col == position.character {
+            return Some(offset);
+        }
+
+        if ch == '\n' {
+            current_line += 1;
+            current_col = 0;
+        } else {
+            current_col += 1;
+        }
+
+        offset += ch.len_utf8();
+    }
+
+    if current_line == position.line && current_col == position.character {
+        Some(offset)
+    } else {
+        None
+    }
+}
+
+/// Convert a byte offset to a line and column (0-indexed)
+///
+/// This function iterates through the document character by character
+/// until it reaches the specified offset, counting newlines to determine
+/// the line number and characters to determine the column.
+///
+/// Returns a tuple of (line, column) both 0-indexed.
+#[must_use]
+pub fn offset_to_line_col(document: &str, offset: usize) -> (usize, usize) {
+    let mut line = 0;
+    let mut col = 0;
+    let mut current_offset = 0;
+
+    for ch in document.chars() {
+        if current_offset >= offset {
+            break;
+        }
+
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+
+        current_offset += ch.len_utf8();
+    }
+
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_position_to_offset() {
+        let source = "hello\nworld";
+
+        let offset = position_to_offset(
+            source,
+            Position {
+                line: 0,
+                character: 0,
+            },
+        );
+        assert_eq!(offset, Some(0));
+
+        let offset = position_to_offset(
+            source,
+            Position {
+                line: 1,
+                character: 0,
+            },
+        );
+        assert_eq!(offset, Some(6));
+
+        let offset = position_to_offset(
+            source,
+            Position {
+                line: 1,
+                character: 5,
+            },
+        );
+        assert_eq!(offset, Some(11));
+
+        let offset = position_to_offset(
+            source,
+            Position {
+                line: 2,
+                character: 0,
+            },
+        );
+        assert_eq!(offset, None);
+    }
+
+    #[test]
+    fn test_position_to_offset_with_index() {
+        let source = "hello\nworld";
+        let index = LineIndex::new(source);
+
+        let offset = position_to_offset_with_index(
+            &index,
+            Position {
+                line: 0,
+                character: 0,
+            },
+        );
+        assert_eq!(offset, Some(0));
+
+        let offset = position_to_offset_with_index(
+            &index,
+            Position {
+                line: 1,
+                character: 0,
+            },
+        );
+        assert_eq!(offset, Some(6));
+    }
+
+    #[test]
+    fn test_offset_to_line_col() {
+        let source = "hello\nworld";
+
+        let (line, col) = offset_to_line_col(source, 0);
+        assert_eq!((line, col), (0, 0));
+
+        let (line, col) = offset_to_line_col(source, 6);
+        assert_eq!((line, col), (1, 0));
+
+        let (line, col) = offset_to_line_col(source, 8);
+        assert_eq!((line, col), (1, 2));
+    }
+
+    #[test]
+    fn test_offset_to_line_col_utf8() {
+        let source = "hello 世界\nworld";
+
+        let (line, col) = offset_to_line_col(source, 0);
+        assert_eq!((line, col), (0, 0));
+
+        let (line, col) = offset_to_line_col(source, 13);
+        assert_eq!((line, col), (1, 0));
+    }
+}


### PR DESCRIPTION
## Summary

This PR combines two related performance and code quality improvements:

1. **Extract duplicated position conversion functions** into a shared module
2. **Add O(1) field lookups** to eliminate hundreds of linear searches in hot paths

## Position Helpers Extraction

Extracts duplicated position conversion functions into a shared `position` module:
- `position_to_offset()` - O(n) fallback for position to byte offset
- `position_to_offset_with_index()` - O(1) with cached LineIndex  
- `offset_to_line_col()` - Convert byte offset to line/column

**Previously** these functions were duplicated across **8 files**:
- `completion.rs`
- `goto_definition.rs`
- `find_references.rs`
- `hover.rs`
- `validation.rs`
- `deprecated.rs` (linter)
- `require_id_field.rs` (linter)
- `redundant_fields.rs` (linter)

**Now** all call sites use the shared implementation from `crate::position`.

## O(1) Field Lookup

Adds `SchemaIndex::get_field(type_name, field_name)` method for O(1) field lookups.

**Before**: O(n) linear search on every field access
```rust
schema_index.get_fields(type_name)?
    .iter()
    .find(|f| f.name == field_name)
```

**After**: O(1) HashMap lookup
```rust
schema_index.get_field(type_name, field_name)
```

This eliminates hundreds of O(n) searches in hot paths that run on every keystroke during LSP operations (goto definition, hover, etc.).

**Updated call sites**:
- [goto_definition.rs](crates/graphql-project/src/goto_definition.rs) - Field type resolution
- [hover.rs](crates/graphql-project/src/hover.rs) - Field hover info
- [validation.rs](crates/graphql-project/src/validation.rs) - Deprecated field checking
- [unused_fields.rs](crates/graphql-linter/src/rules/unused_fields.rs) - Field reference collection

## Impact

- **Maintainability**: 14 duplicate functions → 1 shared module  
- **Performance**: O(n) field searches → O(1) HashMap lookups in hot paths
- **Tests**: ✅ All existing tests pass

## New Tests

Added comprehensive tests for position conversion functions in [position.rs](crates/graphql-project/src/position.rs#L78-L171):
- Basic position to offset conversion
- Position to offset with LineIndex
- Offset to line/column conversion
- UTF-8 handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)