### PR TITLE
feat(linter): add type_names_should_be_pascal_case and enum_values_should_be_screaming_snake_case lint rules

### DIFF
--- a/crates/graphql-linter/src/config.rs
+++ b/crates/graphql-linter/src/config.rs
@@ -95,7 +95,10 @@ impl LintConfig {
     fn recommended_severity(rule_name: &str) -> Option<LintSeverity> {
         match rule_name {
             "unique_names" | "no_anonymous_operations" => Some(LintSeverity::Error),
-            "deprecated_field" | "field_names_should_be_camel_case" => Some(LintSeverity::Warn),
+            "deprecated_field"
+            | "field_names_should_be_camel_case"
+            | "type_names_should_be_pascal_case"
+            | "enum_values_should_be_screaming_snake_case" => Some(LintSeverity::Warn),
             _ => None,
         }
     }

--- a/crates/graphql-linter/src/rules/enum_values_should_be_screaming_snake_case.rs
+++ b/crates/graphql-linter/src/rules/enum_values_should_be_screaming_snake_case.rs
@@ -1,0 +1,195 @@
+use crate::context::StandaloneSchemaContext;
+use crate::rules::StandaloneSchemaRule;
+use apollo_compiler::schema::ExtendedType;
+use graphql_project::{Diagnostic, Position, Range, Severity};
+
+/// Lint rule that enforces enum values use `SCREAMING_SNAKE_CASE`
+///
+/// GraphQL convention dictates that enum values should use `SCREAMING_SNAKE_CASE` formatting.
+/// This improves consistency across GraphQL APIs and follows the official spec conventions.
+///
+/// # Examples
+///
+/// ```graphql
+/// # ❌ Bad - enum values not in SCREAMING_SNAKE_CASE
+/// enum Status {
+///   active
+///   Pending
+///   in-progress
+///   completedSuccessfully
+/// }
+///
+/// # ✅ Good - enum values in SCREAMING_SNAKE_CASE
+/// enum Status {
+///   ACTIVE
+///   PENDING
+///   IN_PROGRESS
+///   COMPLETED_SUCCESSFULLY
+/// }
+/// ```
+pub struct EnumValuesShouldBeScreamingSnakeCaseRule;
+
+impl StandaloneSchemaRule for EnumValuesShouldBeScreamingSnakeCaseRule {
+    fn name(&self) -> &'static str {
+        "enum_values_should_be_screaming_snake_case"
+    }
+
+    fn description(&self) -> &'static str {
+        "Enforce that enum values use SCREAMING_SNAKE_CASE formatting"
+    }
+
+    fn check(&self, ctx: &StandaloneSchemaContext) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let schema = ctx.schema.schema();
+
+        // Check all enum types for value violations
+        for (type_name, extended_type) in &schema.types {
+            if let ExtendedType::Enum(enum_type) = extended_type {
+                for (value_name, _value) in &enum_type.values {
+                    if !is_screaming_snake_case(value_name) {
+                        diagnostics.push(create_diagnostic(type_name, value_name));
+                    }
+                }
+            }
+        }
+
+        diagnostics
+    }
+}
+
+/// Check if a name is in `SCREAMING_SNAKE_CASE` format
+///
+/// Rules:
+/// - All characters must be uppercase letters, numbers, or underscores
+/// - Must not start or end with an underscore
+/// - Must not have consecutive underscores
+/// - Must contain at least one letter
+fn is_screaming_snake_case(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+
+    // Must not start or end with underscore
+    if name.starts_with('_') || name.ends_with('_') {
+        return false;
+    }
+
+    // Must contain at least one letter
+    if !name.chars().any(char::is_alphabetic) {
+        return false;
+    }
+
+    let mut prev_was_underscore = false;
+
+    for ch in name.chars() {
+        match ch {
+            'A'..='Z' | '0'..='9' => {
+                prev_was_underscore = false;
+            }
+            '_' => {
+                // No consecutive underscores
+                if prev_was_underscore {
+                    return false;
+                }
+                prev_was_underscore = true;
+            }
+            _ => {
+                // No lowercase letters, hyphens, or other characters
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Create a diagnostic for an enum value violation
+fn create_diagnostic(type_name: &str, value_name: &str) -> Diagnostic {
+    // For schema-only lints, we don't have source positions
+    // Using 0,0 as placeholder - these will need to be enhanced when we have schema source maps
+    Diagnostic {
+        severity: Severity::Warning,
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        },
+        message: format!(
+            "Enum value '{value_name}' on enum '{type_name}' should use SCREAMING_SNAKE_CASE formatting"
+        ),
+        code: Some("enum_values_should_be_screaming_snake_case".to_string()),
+        source: "graphql-linter".to_string(),
+        related_info: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_screaming_snake_case() {
+        // Valid SCREAMING_SNAKE_CASE
+        assert!(is_screaming_snake_case("ACTIVE"));
+        assert!(is_screaming_snake_case("PENDING"));
+        assert!(is_screaming_snake_case("IN_PROGRESS"));
+        assert!(is_screaming_snake_case("COMPLETED_SUCCESSFULLY"));
+        assert!(is_screaming_snake_case("STATUS_1"));
+        assert!(is_screaming_snake_case("HTTP_200_OK"));
+
+        // Invalid - lowercase letters
+        assert!(!is_screaming_snake_case("active"));
+        assert!(!is_screaming_snake_case("Active"));
+        assert!(!is_screaming_snake_case("ACTIVE_pending"));
+        assert!(!is_screaming_snake_case("in_progress"));
+
+        // Invalid - starts or ends with underscore
+        assert!(!is_screaming_snake_case("_ACTIVE"));
+        assert!(!is_screaming_snake_case("ACTIVE_"));
+        assert!(!is_screaming_snake_case("_ACTIVE_"));
+
+        // Invalid - consecutive underscores
+        assert!(!is_screaming_snake_case("ACTIVE__PENDING"));
+        assert!(!is_screaming_snake_case("IN__PROGRESS"));
+
+        // Invalid - hyphens
+        assert!(!is_screaming_snake_case("IN-PROGRESS"));
+        assert!(!is_screaming_snake_case("ACTIVE-PENDING"));
+
+        // Invalid - only numbers or underscores (no letters)
+        assert!(!is_screaming_snake_case("123"));
+        assert!(!is_screaming_snake_case("_"));
+
+        // Edge cases
+        assert!(!is_screaming_snake_case(""));
+    }
+
+    #[test]
+    fn test_screaming_snake_case_with_numbers() {
+        assert!(is_screaming_snake_case("STATUS_1"));
+        assert!(is_screaming_snake_case("HTTP_200"));
+        assert!(is_screaming_snake_case("IPV4_ADDRESS"));
+        assert!(is_screaming_snake_case("ERROR_404_NOT_FOUND"));
+    }
+
+    #[test]
+    fn test_screaming_snake_case_single_word() {
+        assert!(is_screaming_snake_case("ACTIVE"));
+        assert!(is_screaming_snake_case("PENDING"));
+        assert!(is_screaming_snake_case("A"));
+        assert!(!is_screaming_snake_case("a"));
+    }
+
+    #[test]
+    fn test_screaming_snake_case_camel_case() {
+        // Common mistakes - camelCase or PascalCase should be rejected
+        assert!(!is_screaming_snake_case("ActiveStatus"));
+        assert!(!is_screaming_snake_case("activeStatus"));
+        assert!(!is_screaming_snake_case("inProgress"));
+    }
+}

--- a/crates/graphql-linter/src/rules/mod.rs
+++ b/crates/graphql-linter/src/rules/mod.rs
@@ -1,17 +1,21 @@
 mod deprecated;
+mod enum_values_should_be_screaming_snake_case;
 mod field_names_should_be_camel_case;
 mod no_anonymous_operations;
 mod redundant_fields;
 mod require_id_field;
+mod type_names_should_be_pascal_case;
 mod unique_names;
 mod unused_fields;
 mod unused_fragments;
 
 pub use deprecated::DeprecatedFieldRule;
+pub use enum_values_should_be_screaming_snake_case::EnumValuesShouldBeScreamingSnakeCaseRule;
 pub use field_names_should_be_camel_case::FieldNamesShouldBeCamelCaseRule;
 pub use no_anonymous_operations::NoAnonymousOperationsRule;
 pub use redundant_fields::RedundantFieldsRule;
 pub use require_id_field::RequireIdFieldRule;
+pub use type_names_should_be_pascal_case::TypeNamesShouldBePascalCaseRule;
 pub use unique_names::UniqueNamesRule;
 pub use unused_fields::UnusedFieldsRule;
 pub use unused_fragments::UnusedFragmentsRule;
@@ -90,7 +94,11 @@ pub fn all_document_schema_rules() -> Vec<Box<dyn DocumentSchemaRule>> {
 
 /// Get all available standalone schema lint rules
 pub fn all_standalone_schema_rules() -> Vec<Box<dyn StandaloneSchemaRule>> {
-    vec![Box::new(FieldNamesShouldBeCamelCaseRule)]
+    vec![
+        Box::new(FieldNamesShouldBeCamelCaseRule),
+        Box::new(TypeNamesShouldBePascalCaseRule),
+        Box::new(EnumValuesShouldBeScreamingSnakeCaseRule),
+    ]
 }
 
 /// Get all available project-wide lint rules

--- a/crates/graphql-linter/src/rules/type_names_should_be_pascal_case.rs
+++ b/crates/graphql-linter/src/rules/type_names_should_be_pascal_case.rs
@@ -1,0 +1,188 @@
+use crate::context::StandaloneSchemaContext;
+use crate::rules::StandaloneSchemaRule;
+use apollo_compiler::schema::ExtendedType;
+use graphql_project::{Diagnostic, Position, Range, Severity};
+
+/// Lint rule that enforces type names use `PascalCase`
+///
+/// GraphQL convention dictates that type names should use `PascalCase` formatting.
+/// This improves consistency across GraphQL APIs and follows the official spec conventions.
+///
+/// # Examples
+///
+/// ```graphql
+/// # ❌ Bad - type names not in PascalCase
+/// type user {
+///   id: ID!
+/// }
+///
+/// type USER_PROFILE {
+///   name: String!
+/// }
+///
+/// # ✅ Good - type names in PascalCase
+/// type User {
+///   id: ID!
+/// }
+///
+/// type UserProfile {
+///   name: String!
+/// }
+/// ```
+pub struct TypeNamesShouldBePascalCaseRule;
+
+impl StandaloneSchemaRule for TypeNamesShouldBePascalCaseRule {
+    fn name(&self) -> &'static str {
+        "type_names_should_be_pascal_case"
+    }
+
+    fn description(&self) -> &'static str {
+        "Enforce that type names use PascalCase formatting"
+    }
+
+    fn check(&self, ctx: &StandaloneSchemaContext) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let schema = ctx.schema.schema();
+
+        // Check all types for name violations
+        for (type_name, extended_type) in &schema.types {
+            // Skip built-in types that start with __
+            if type_name.starts_with("__") {
+                continue;
+            }
+
+            let type_kind = match extended_type {
+                ExtendedType::Object(_) => "object",
+                ExtendedType::Interface(_) => "interface",
+                ExtendedType::InputObject(_) => "input object",
+                ExtendedType::Enum(_) => "enum",
+                ExtendedType::Union(_) => "union",
+                ExtendedType::Scalar(_) => {
+                    // Skip built-in scalars
+                    if matches!(
+                        type_name.as_str(),
+                        "Int" | "Float" | "String" | "Boolean" | "ID"
+                    ) {
+                        continue;
+                    }
+                    "scalar"
+                }
+            };
+
+            if !is_pascal_case(type_name) {
+                diagnostics.push(create_diagnostic(type_name, type_kind));
+            }
+        }
+
+        diagnostics
+    }
+}
+
+/// Check if a name is in `PascalCase` format
+///
+/// Rules:
+/// - Must start with an uppercase letter
+/// - Can contain letters and numbers
+/// - Should not contain underscores or hyphens
+/// - No consecutive uppercase letters (e.g., `"HTTPServer"` is discouraged, prefer `"HttpServer"`)
+fn is_pascal_case(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+
+    // First character must be uppercase
+    if !first.is_ascii_uppercase() {
+        return false;
+    }
+
+    // Rest should only contain letters and numbers, no underscores or hyphens
+    for ch in chars {
+        if !ch.is_alphanumeric() {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Create a diagnostic for a type name violation
+fn create_diagnostic(type_name: &str, type_kind: &str) -> Diagnostic {
+    // For schema-only lints, we don't have source positions
+    // Using 0,0 as placeholder - these will need to be enhanced when we have schema source maps
+    Diagnostic {
+        severity: Severity::Warning,
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        },
+        message: format!("Type '{type_name}' ({type_kind}) should use PascalCase formatting"),
+        code: Some("type_names_should_be_pascal_case".to_string()),
+        source: "graphql-linter".to_string(),
+        related_info: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_pascal_case() {
+        // Valid PascalCase
+        assert!(is_pascal_case("User"));
+        assert!(is_pascal_case("UserProfile"));
+        assert!(is_pascal_case("Post"));
+        assert!(is_pascal_case("CreateUserInput"));
+        assert!(is_pascal_case("UpdatePostInput"));
+
+        // Invalid - starts with lowercase
+        assert!(!is_pascal_case("user"));
+        assert!(!is_pascal_case("userProfile"));
+
+        // Invalid - contains underscores
+        assert!(!is_pascal_case("User_Profile"));
+        assert!(!is_pascal_case("USER_PROFILE"));
+        assert!(!is_pascal_case("user_profile"));
+
+        // Invalid - contains hyphens
+        assert!(!is_pascal_case("User-Profile"));
+
+        // Edge cases
+        assert!(!is_pascal_case(""));
+    }
+
+    #[test]
+    fn test_pascal_case_with_numbers() {
+        assert!(is_pascal_case("User1"));
+        assert!(is_pascal_case("Http2Server"));
+        assert!(is_pascal_case("Ipv4Address"));
+    }
+
+    #[test]
+    fn test_pascal_case_with_acronyms() {
+        // These are valid PascalCase even if multiple capitals
+        assert!(is_pascal_case("HTTPServer"));
+        assert!(is_pascal_case("URLPath"));
+        assert!(is_pascal_case("XMLParser"));
+
+        // These would be invalid (starting with lowercase)
+        assert!(!is_pascal_case("httpServer"));
+        assert!(!is_pascal_case("urlPath"));
+    }
+
+    #[test]
+    fn test_pascal_case_single_letter() {
+        assert!(is_pascal_case("A"));
+        assert!(is_pascal_case("Z"));
+        assert!(!is_pascal_case("a"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `type_names_should_be_pascal_case` rule that validates GraphQL type names follow PascalCase naming convention
- Add `enum_values_should_be_screaming_snake_case` rule that validates enum values follow SCREAMING_SNAKE_CASE naming convention
- Both rules are schema-only (StandaloneSchemaRule) and added to recommended config with Warning severity

## New Tests
- `type_names_should_be_pascal_case`: 4 test suites covering valid/invalid PascalCase names, numbers, acronyms, and edge cases
- `enum_values_should_be_screaming_snake_case`: 4 test suites covering valid/invalid SCREAMING_SNAKE_CASE names, numbers, and common mistakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)