### PR TITLE
feat(lsp): add check status command for debugging

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -23,6 +23,11 @@
         "command": "graphql-lsp.restartServer",
         "title": "Restart GraphQL Language Server",
         "category": "GraphQL"
+      },
+      {
+        "command": "graphql-lsp.checkStatus",
+        "title": "Check Status",
+        "category": "GraphQL"
       }
     ],
     "languages": [

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -128,7 +128,30 @@ export async function activate(context: ExtensionContext) {
       }
     });
 
-    context.subscriptions.push(reloadCommand);
+    const checkStatusCommand = commands.registerCommand("graphql-lsp.checkStatus", async () => {
+      outputChannel.appendLine("=== Checking GraphQL LSP Status ===");
+
+      try {
+        if (!client) {
+          window.showWarningMessage("GraphQL LSP is not running");
+          return;
+        }
+
+        // Show the output channel so users can see the detailed status
+        outputChannel.show(true);
+
+        await client.sendRequest("workspace/executeCommand", {
+          command: "graphql.checkStatus",
+          arguments: [],
+        });
+      } catch (error) {
+        const errorMessage = `Failed to check status: ${error}`;
+        outputChannel.appendLine(errorMessage);
+        window.showErrorMessage(errorMessage);
+      }
+    });
+
+    context.subscriptions.push(reloadCommand, checkStatusCommand);
   } catch (error) {
     const errorMessage = `Failed to start GraphQL LSP: ${error}`;
     outputChannel.appendLine(errorMessage);


### PR DESCRIPTION
Adds a custom LSP command `graphql.checkStatus` that provides a concise summary of loaded schemas and operations for debugging purposes.

## Changes

- Added `execute_command` handler in LSP server to handle custom commands
- Registered `graphql.checkStatus` command in server capabilities
- Added VSCode command `GraphQL: Check Status` accessible from command palette
- Command automatically opens the output channel to show formatted status

## Status Output

The command displays:
- Workspace and config file locations
- Per-project schema statistics (types, fields)
- Operation and fragment counts  
- Open file count

Example output:
```
Workspace: /Users/trevor/obsidian
  Config: .graphqlrc.yml
  Project 'webclient': 10630 types, 50101 fields
    2837 operations, 552 fragments
  Project 'graphqlmocker': 39 types, 113 fields
    13 operations, 7 fragments

1 files open in editor
```

The detailed status is logged to the output channel, while a brief summary notification shows workspace/project counts.

## Usage

Run `GraphQL: Check Status` from the command palette to debug what the LSP has loaded.