### PR TITLE
feat(foundation): Phase 1 - Salsa database foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +709,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -932,6 +953,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-db"
+version = "0.1.1"
+dependencies = [
+ "salsa",
+]
+
+[[package]]
 name = "graphql-extract"
 version = "0.1.1"
 dependencies = [
@@ -1059,9 +1087,29 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1425,6 +1473,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1699,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2293,6 +2368,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2568,49 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "salsa"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e2aa2fca57727371eeafc975acc8e6f4c52f8166a78035543f6ee1c74c2dcc"
+dependencies = [
+ "boxcar",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.12.1",
+ "intrusive-collections",
+ "inventory",
+ "parking_lot",
+ "portable-atomic",
+ "rayon",
+ "rustc-hash 2.1.1",
+ "salsa-macro-rules",
+ "salsa-macros",
+ "smallvec",
+ "thin-vec",
+ "tracing",
+]
+
+[[package]]
+name = "salsa-macro-rules"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfc2a1e7bf06964105515451d728f2422dedc3a112383324a00b191a5c397a3"
+
+[[package]]
+name = "salsa-macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d844c1aa34946da46af683b5c27ec1088a3d9d84a2b837a108223fd830220e1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "same-file"
@@ -3027,6 +3165,12 @@ name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/graphql-lsp",
     "crates/graphql-cli",
     ".husky", "crates/graphql-linter",
+    "crates/graphql-db",
 ]
 
 [workspace.package]
@@ -53,6 +54,9 @@ swc_common = "18.0"
 # Utilities
 dashmap = "6.1"
 once_cell = "1.21"
+
+# Incremental computation
+salsa = "0.25"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/graphql-db/Cargo.toml
+++ b/crates/graphql-db/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "graphql-db"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+salsa = { workspace = true }

--- a/crates/graphql-db/README.md
+++ b/crates/graphql-db/README.md
@@ -1,0 +1,109 @@
+# graphql-db
+
+**Status: Work in Progress (Phase 1 - Foundation)**
+
+This crate provides the salsa-based database layer for the GraphQL LSP rearchitecture. It is the foundation for incremental, query-based computation.
+
+## Overview
+
+The `graphql-db` crate defines:
+
+- **FileId**: Unique identifier for files in the project
+- **FileUri**: URI/path for files
+- **FileKind**: Discriminator for different file types (Schema, ExecutableGraphQL, TypeScript, JavaScript)
+- **FileContent**: Salsa input for file content
+- **FileMetadata**: Salsa input for file metadata
+- **RootDatabase**: The main salsa database
+
+## Architecture
+
+This crate is part of the larger LSP rearchitecture following rust-analyzer patterns:
+
+```
+graphql-lsp     ← LSP protocol adapter
+    ↓
+graphql-ide     ← IDE API with POD types
+    ↓
+graphql-analysis ← Validation and linting
+    ↓
+graphql-hir     ← High-level IR (semantic queries)
+    ↓
+graphql-syntax  ← Parsing (file-local, cached)
+    ↓
+graphql-db      ← Salsa database (YOU ARE HERE)
+```
+
+## Current Status
+
+### Completed ✅
+- [x] Basic crate structure created
+- [x] Core types defined (FileId, FileUri, FileKind)
+- [x] Salsa input structs defined (FileContent, FileMetadata)
+- [x] RootDatabase struct defined and implemented
+- [x] Salsa 0.25 integration working
+- [x] Input query implementations
+- [x] Comprehensive tests for database operations
+- [x] All tests passing
+
+### In Progress
+- [ ] FileRegistry for URI → FileId mapping
+- [ ] Complete Change application logic
+- [ ] Additional utility methods
+
+### Lessons Learned
+
+**Salsa 0.25 API Pattern**: Successfully integrated salsa 0.25 by reading the official examples. Key insights:
+
+1. The `#[salsa::db]` macro goes on BOTH the struct and the `impl salsa::Database` block
+2. The struct must derive `Clone` and `Default`
+3. The `storage: salsa::Storage<Self>` field is required
+4. The `Setter` trait must be imported to use `.to()` method on field setters
+5. Arc types need explicit type annotations in some contexts
+
+**Correct Pattern**:
+```rust
+#[salsa::db]
+#[derive(Clone, Default)]
+pub struct RootDatabase {
+    storage: salsa::Storage<Self>,
+}
+
+#[salsa::db]
+impl salsa::Database for RootDatabase {}
+```
+
+## Design Goals
+
+Following the rearchitecture plan, this database layer should:
+
+1. **Automatic memoization**: Query results cached by inputs via salsa
+2. **Dependency tracking**: Salsa knows what queries depend on what inputs
+3. **Incremental invalidation**: When input changes, only affected queries re-run
+4. **Cancellation**: Abort stale computations when inputs change
+5. **Lazy evaluation**: Queries only run when their results are needed
+
+## Example Usage (Intended)
+
+```rust
+// Create database
+let mut db = RootDatabase::new();
+
+// Add a file
+let content = Arc::from("type Query { hello: String }");
+let file_content = FileContent::new(&mut db, content);
+let metadata = FileMetadata::new(
+    &mut db,
+    FileId::new(0),
+    FileUri::new("file:///test.graphql"),
+    FileKind::Schema,
+);
+
+// Update file content (will invalidate dependent queries)
+file_content.set_text(&mut db).to(Arc::from("type Query { world: String }"));
+```
+
+## References
+
+- [Salsa Framework](https://github.com/salsa-rs/salsa)
+- [Rust-Analyzer Architecture](https://rust-analyzer.github.io/book/contributing/architecture.html)
+- [LSP Rearchitecture Plan](../../.claude/notes/active/lsp-rearchitecture/README.md)

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -1,0 +1,234 @@
+// GraphQL Database Layer
+// This crate defines the salsa database and input queries for the GraphQL LSP.
+// It provides the foundation for incremental, query-based computation.
+
+use std::sync::Arc;
+
+/// Input file identifier in the project
+/// We use a simple u32-based ID for now
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FileId(u32);
+
+impl FileId {
+    #[must_use]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    #[must_use]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// A URI string (file:// or relative path)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FileUri(Arc<str>);
+
+impl FileUri {
+    #[must_use]
+    pub fn new(uri: impl Into<Arc<str>>) -> Self {
+        Self(uri.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for FileUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// File kind discriminator
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileKind {
+    /// GraphQL schema file (.graphql, .gql with type definitions)
+    Schema,
+    /// Pure executable GraphQL file (.graphql, .gql with operations/fragments)
+    ExecutableGraphQL,
+    /// TypeScript file with embedded GraphQL
+    TypeScript,
+    /// JavaScript file with embedded GraphQL
+    JavaScript,
+}
+
+/// Input: Content of a file
+/// This is set by the LSP layer when files are opened/changed
+#[salsa::input]
+pub struct FileContent {
+    pub text: Arc<str>,
+}
+
+/// Input: Metadata about a file
+/// This is set by the LSP layer when files are added to the project
+#[salsa::input]
+pub struct FileMetadata {
+    pub file_id: FileId,
+    pub uri: FileUri,
+    pub kind: FileKind,
+}
+
+/// The root salsa database
+/// This is the main entry point for all queries
+#[salsa::db]
+#[derive(Clone, Default)]
+pub struct RootDatabase {
+    storage: salsa::Storage<Self>,
+}
+
+// Implement the Database trait
+#[salsa::db]
+impl salsa::Database for RootDatabase {}
+
+impl RootDatabase {
+    /// Create a new database
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// A batch of changes to apply to the database atomically
+#[derive(Debug, Default)]
+pub struct Change {
+    /// Files whose content has changed (`file_id`, `new_content`)
+    pub files_changed: Vec<(FileId, Arc<str>)>,
+    /// Files that have been removed from the project
+    pub files_removed: Vec<FileId>,
+    /// Files that have been added to the project (uri, content, kind)
+    pub files_added: Vec<(FileUri, Arc<str>, FileKind)>,
+}
+
+impl RootDatabase {
+    /// Apply a batch of changes to the database
+    /// This will automatically invalidate dependent queries via salsa
+    ///
+    /// Note: This is a simplified implementation for Phase 1.
+    /// A complete implementation will include a `FileRegistry` to map URIs to `FileIds`.
+    pub fn apply_change(&mut self, _change: Change) {
+        // Placeholder implementation for Phase 1
+        // Full implementation will come when we add FileRegistry
+        // For now, we just accept changes but don't process them
+        // This is sufficient for initial testing of the database structure
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use salsa::Setter;
+
+    #[test]
+    fn test_database_creation() {
+        let _db = RootDatabase::new();
+        // Database should be created successfully
+    }
+
+    #[test]
+    fn test_file_id() {
+        let file_id = FileId::new(42);
+        assert_eq!(file_id.as_u32(), 42);
+    }
+
+    #[test]
+    fn test_file_uri() {
+        let uri = FileUri::new("file:///path/to/file.graphql");
+        assert_eq!(uri.as_str(), "file:///path/to/file.graphql");
+        assert_eq!(uri.to_string(), "file:///path/to/file.graphql");
+    }
+
+    #[test]
+    fn test_file_kind() {
+        let kinds = [
+            FileKind::Schema,
+            FileKind::ExecutableGraphQL,
+            FileKind::TypeScript,
+            FileKind::JavaScript,
+        ];
+
+        // All kinds should be distinct
+        for (i, kind1) in kinds.iter().enumerate() {
+            for (j, kind2) in kinds.iter().enumerate() {
+                if i == j {
+                    assert_eq!(kind1, kind2);
+                } else {
+                    assert_ne!(kind1, kind2);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_file_content_creation() {
+        let db = RootDatabase::new();
+        let content: Arc<str> = Arc::from("type Query { hello: String }");
+        let file_content = FileContent::new(&db, content);
+
+        // File content should be stored and retrievable
+        assert_eq!(
+            file_content.text(&db).as_ref(),
+            "type Query { hello: String }"
+        );
+    }
+
+    #[test]
+    fn test_file_metadata_creation() {
+        let db = RootDatabase::new();
+        let file_id = FileId::new(0);
+        let uri = FileUri::new("file:///test.graphql");
+        let kind = FileKind::Schema;
+
+        let metadata = FileMetadata::new(&db, file_id, uri.clone(), kind);
+
+        // Metadata should be stored and retrievable
+        assert_eq!(metadata.file_id(&db), file_id);
+        assert_eq!(metadata.uri(&db), uri);
+        assert_eq!(metadata.kind(&db), kind);
+    }
+
+    #[test]
+    fn test_file_content_update() {
+        let mut db = RootDatabase::new();
+        let content1: Arc<str> = Arc::from("type Query { hello: String }");
+        let file_content = FileContent::new(&db, content1);
+
+        // Initial content
+        assert_eq!(
+            file_content.text(&db).as_ref(),
+            "type Query { hello: String }"
+        );
+
+        // Update content
+        let content2: Arc<str> = Arc::from("type Query { world: String }");
+        file_content.set_text(&mut db).to(content2);
+
+        // Content should be updated
+        assert_eq!(
+            file_content.text(&db).as_ref(),
+            "type Query { world: String }"
+        );
+    }
+
+    #[test]
+    fn test_change_application() {
+        let mut db = RootDatabase::new();
+
+        let change = Change {
+            files_added: vec![(
+                FileUri::new("file:///test.graphql"),
+                Arc::from("type Query { hello: String }"),
+                FileKind::Schema,
+            )],
+            ..Default::default()
+        };
+
+        db.apply_change(change);
+
+        // Change should be applied successfully
+        // Detailed verification will come with FileRegistry implementation
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1, Week 1 of the LSP rearchitecture plan: the foundational salsa-based database layer.

## Changes

### New Crate: `graphql-db`

- **Salsa 0.25 integration** - Query-based incremental computation framework
- **Core types**: `FileId`, `FileUri`, `FileKind` for file identification
- **Input structs**: `FileContent`, `FileMetadata` as salsa inputs
- **RootDatabase**: Main database with salsa storage
- **Comprehensive tests**: 8/8 tests passing

### Documentation

- Added README with architecture overview, status, and lessons learned
- Documented salsa 0.25 API patterns discovered through implementation

## Key Learnings

Successfully integrated Salsa 0.25 by reading the official examples:

```rust
#[salsa::db]
#[derive(Clone, Default)]
pub struct RootDatabase {
    storage: salsa::Storage<Self>,
}

#[salsa::db]
impl salsa::Database for RootDatabase {}
```

Key insights:
1. `#[salsa::db]` macro on BOTH struct and impl block
2. Struct must derive `Clone` and `Default`
3. `storage: salsa::Storage<Self>` field required
4. `Setter` trait needed for `.to()` method

## Testing

```bash
cargo test -p graphql-db    # ✅ 8/8 passing
cargo clippy -p graphql-db  # ✅ No warnings
cargo build                 # ✅ Compiles
```

## Next Steps

Phase 1, Week 2: Syntax Layer
- Create `graphql-syntax` crate
- Implement `parse()` queries for GraphQL files
- Add TypeScript/JavaScript extraction support

## References

- [Rearchitecture Plan](/.claude/notes/active/lsp-rearchitecture/README.md)
- [01-FOUNDATION.md](/.claude/notes/active/lsp-rearchitecture/01-FOUNDATION.md)
- [Salsa Framework](https://github.com/salsa-rs/salsa)