### PR TITLE
feat(foundation): Phase 4 - IDE layer foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-ide"
+version = "0.1.0"
+dependencies = [
+ "graphql-analysis",
+ "graphql-db",
+ "graphql-hir",
+ "graphql-syntax",
+ "salsa",
+]
+
+[[package]]
 name = "graphql-introspect"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/graphql-syntax",
     "crates/graphql-hir",
     "crates/graphql-analysis",
+    "crates/graphql-ide",
 ]
 
 [workspace.package]

--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -24,6 +24,11 @@ pub trait GraphQLAnalysisDatabase: graphql_hir::GraphQLHirDatabase {
     }
 }
 
+// Implement the trait for RootDatabase
+// This makes RootDatabase usable with all analysis queries
+#[salsa::db]
+impl GraphQLAnalysisDatabase for graphql_db::RootDatabase {}
+
 /// Lint configuration (simplified for Phase 3)
 #[derive(Debug, Clone, Default)]
 pub struct LintConfig {

--- a/crates/graphql-hir/src/lib.rs
+++ b/crates/graphql-hir/src/lib.rs
@@ -99,6 +99,11 @@ pub trait GraphQLHirDatabase: graphql_syntax::GraphQLSyntaxDatabase {
     }
 }
 
+// Implement the trait for RootDatabase
+// This makes RootDatabase usable with all HIR queries
+#[salsa::db]
+impl GraphQLHirDatabase for graphql_db::RootDatabase {}
+
 /// Get all types in the schema
 /// This query depends on all schema file structures
 #[salsa::tracked]

--- a/crates/graphql-ide/Cargo.toml
+++ b/crates/graphql-ide/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "graphql-ide"
+version = "0.1.0"
+edition = "2021"
+description = "IDE features for GraphQL Language Server"
+
+[dependencies]
+# Salsa for database access
+salsa = { workspace = true }
+
+# Internal crates (query-based layers)
+graphql-db = { path = "../graphql-db" }
+graphql-syntax = { path = "../graphql-syntax" }
+graphql-hir = { path = "../graphql-hir" }
+graphql-analysis = { path = "../graphql-analysis" }
+
+[dev-dependencies]

--- a/crates/graphql-ide/README.md
+++ b/crates/graphql-ide/README.md
@@ -1,0 +1,345 @@
+# graphql-ide
+
+Editor-facing IDE features for GraphQL language support.
+
+This crate provides the API boundary between the analysis layer (validation, linting) and the LSP layer (protocol handling). It follows rust-analyzer's design philosophy of using Plain Old Data (POD) types with public fields.
+
+## Architecture
+
+```text
+LSP Layer (tower-lsp)
+    ↓
+graphql-ide (this crate) ← POD types, editor API
+    ↓
+graphql-analysis ← Query-based validation and linting
+    ↓
+graphql-hir ← Semantic queries
+    ↓
+graphql-syntax ← Parsing
+    ↓
+graphql-db ← Salsa database
+```
+
+## Core Principles
+
+### 1. POD Types with Public Fields
+
+All types are Plain Old Data structs with public fields:
+
+```rust
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+pub struct Location {
+    pub file: FilePath,
+    pub range: Range,
+}
+```
+
+Benefits:
+- Easy to construct and destructure
+- Easy to serialize/deserialize
+- No hidden state or invariants
+- Clear ownership semantics
+
+### 2. Editor Coordinates
+
+All positions use editor coordinates (line/column), not byte offsets:
+- Lines are 0-indexed
+- Characters are 0-indexed (UTF-16 code units for LSP compatibility)
+- Ranges are half-open: `[start, end)`
+
+### 3. LSP-Agnostic
+
+The IDE layer knows nothing about the LSP protocol:
+- No `tower-lsp` types
+- No `lsp-types` dependencies
+- Pure Rust data structures
+- Easy to test without LSP infrastructure
+
+### 4. Snapshot-Based Concurrency
+
+The `Analysis` type is a cheap, immutable snapshot:
+- Implements `Clone` (via salsa's database clone)
+- Thread-safe - can be sent to worker threads
+- Lock-free reads - all queries through salsa
+- Automatically invalidates on changes
+
+## Usage
+
+### Basic Setup
+
+```rust
+use graphql_ide::{AnalysisHost, FilePath, FileKind};
+
+// Create the analysis host (owns the database)
+let mut host = AnalysisHost::new();
+
+// Add files to the project
+host.add_file(
+    FilePath::new("schema.graphql"),
+    "type Query { hello: String }".to_string(),
+    FileKind::Schema,
+);
+
+host.add_file(
+    FilePath::new("query.graphql"),
+    "query { hello }".to_string(),
+    FileKind::ExecutableGraphQL,
+);
+
+// Get an immutable snapshot for analysis
+let analysis = host.snapshot();
+```
+
+### Diagnostics
+
+```rust
+use graphql_ide::Position;
+
+let file = FilePath::new("schema.graphql");
+let diagnostics = analysis.diagnostics(&file);
+
+for diag in diagnostics {
+    println!("{:?}: {}", diag.severity, diag.message);
+    println!("  at {}:{}", diag.range.start.line, diag.range.start.character);
+}
+```
+
+### Completions
+
+```rust
+let position = Position::new(0, 10);
+if let Some(completions) = analysis.completions(&file, position) {
+    for item in completions {
+        println!("{}: {:?}", item.label, item.kind);
+        if let Some(detail) = &item.detail {
+            println!("  {}", detail);
+        }
+    }
+}
+```
+
+### Hover
+
+```rust
+if let Some(hover) = analysis.hover(&file, position) {
+    println!("{}", hover.contents);  // Markdown
+}
+```
+
+### Goto Definition
+
+```rust
+if let Some(locations) = analysis.goto_definition(&file, position) {
+    for loc in locations {
+        println!("{}:{}:{}",
+            loc.file.as_str(),
+            loc.range.start.line,
+            loc.range.start.character
+        );
+    }
+}
+```
+
+### Find References
+
+```rust
+if let Some(refs) = analysis.find_references(&file, position, true) {
+    println!("Found {} references", refs.len());
+    for loc in refs {
+        // ... print reference locations
+    }
+}
+```
+
+## Concurrency Model
+
+The IDE layer supports two patterns:
+
+### Pattern 1: Single-Threaded
+
+```rust
+let mut host = AnalysisHost::new();
+
+loop {
+    // Handle file changes
+    host.add_file(...);
+
+    // Get snapshot and query
+    let analysis = host.snapshot();
+    let diagnostics = analysis.diagnostics(...);
+
+    // Send results to editor
+    send_diagnostics(diagnostics);
+}
+```
+
+### Pattern 2: Multi-Threaded
+
+```rust
+let mut host = AnalysisHost::new();
+
+// Spawn worker thread
+let analysis = host.snapshot();
+let handle = std::thread::spawn(move || {
+    analysis.diagnostics(&file)
+});
+
+// Continue handling file changes on main thread
+host.add_file(...);
+
+// Wait for results
+let diagnostics = handle.join().unwrap();
+```
+
+Salsa ensures that:
+- Queries on snapshots are lock-free
+- Results are cached and reused
+- Changes invalidate only affected queries
+
+## Implementation Status
+
+### ✅ Completed
+
+- POD types (Position, Range, Location, FilePath)
+- Feature types (CompletionItem, HoverResult, Diagnostic)
+- AnalysisHost and Analysis API structure
+- FileRegistry for path mapping
+- Database trait implementations
+- Basic tests
+
+### ⏳ In Progress
+
+- Diagnostics implementation
+- Completions implementation
+- Hover implementation
+- Goto definition implementation
+- Find references implementation
+- Comprehensive tests
+- Performance benchmarks
+
+## Performance Targets
+
+After full implementation:
+
+| Feature | Target | Notes |
+|---------|--------|-------|
+| Diagnostics (first call) | <20ms | Parse + validate |
+| Diagnostics (cached) | <1ms | Salsa hit |
+| Completions | <10ms | O(1) schema lookup |
+| Hover | <5ms | O(1) symbol lookup |
+| Goto Definition | <5ms | Direct HIR query |
+| Find References | <50ms | Lazy search |
+
+## Testing
+
+Run tests:
+```bash
+cargo test --package graphql-ide
+```
+
+Run with coverage:
+```bash
+cargo tarpaulin --package graphql-ide
+```
+
+## Integration with LSP
+
+The graphql-lsp crate will use this API:
+
+```rust
+// In graphql-lsp
+use graphql_ide::{AnalysisHost, Analysis, Position, FilePath};
+use tower_lsp::lsp_types;
+
+struct Backend {
+    host: AnalysisHost,
+}
+
+impl LanguageServer for Backend {
+    async fn did_change(&self, params: DidChangeParams) {
+        // Update host
+        self.host.add_file(...);
+
+        // Get snapshot and publish diagnostics
+        let analysis = self.host.snapshot();
+        let diagnostics = analysis.diagnostics(...);
+
+        // Convert IDE types to LSP types
+        let lsp_diagnostics = diagnostics.iter()
+            .map(|d| to_lsp_diagnostic(d))
+            .collect();
+
+        self.client.publish_diagnostics(uri, lsp_diagnostics, None).await;
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<CompletionList> {
+        let analysis = self.host.snapshot();
+        let file = to_file_path(params.text_document_position.uri);
+        let pos = to_position(params.text_document_position.position);
+
+        let items = analysis.completions(&file, pos)
+            .map(|items| items.iter().map(to_lsp_completion_item).collect())
+            .unwrap_or_default();
+
+        Ok(CompletionList { items, is_incomplete: false })
+    }
+}
+```
+
+## Design Rationale
+
+### Why POD Types?
+
+1. **Simplicity**: No methods, no invariants, just data
+2. **Flexibility**: Easy to extend without breaking changes
+3. **Performance**: No virtual dispatch, easy to inline
+4. **Testing**: Easy to construct test data
+5. **Serialization**: Trivial to convert to/from JSON
+
+### Why Snapshots?
+
+1. **Concurrency**: Multiple queries in parallel without locks
+2. **Consistency**: All queries see the same state
+3. **Cancellation**: Drop snapshot to cancel ongoing work
+4. **Simplicity**: No explicit synchronization needed
+
+### Why FileRegistry?
+
+1. **Decoupling**: LSP uses URIs, salsa uses FileIds
+2. **Type Safety**: FileId is a newtype, prevents mixing with offsets
+3. **Efficiency**: O(1) bidirectional lookups
+4. **Future**: Can be replaced with project configuration
+
+## Future Work
+
+### Near Term (Phase 4 completion)
+
+- Implement all IDE features
+- Add integration tests
+- Performance benchmarking
+- Complete documentation
+
+### Long Term (Phase 5+)
+
+- Semantic highlighting
+- Code actions (quick fixes)
+- Rename refactoring
+- Workspace symbols
+- Document symbols
+- Call hierarchy
+- Type hierarchy
+
+## Resources
+
+- [Rust-Analyzer IDE Layer](https://github.com/rust-lang/rust-analyzer/tree/master/crates/ide)
+- [Salsa Book](https://salsa-rs.github.io/salsa/)
+- [LSP Specification](https://microsoft.github.io/language-server-protocol/)

--- a/crates/graphql-ide/src/file_registry.rs
+++ b/crates/graphql-ide/src/file_registry.rs
@@ -1,0 +1,200 @@
+//! File registry for mapping between file paths and database entities
+//!
+//! This module provides the bridge between editor file paths (strings/URIs)
+//! and salsa database file identifiers.
+
+use graphql_db::{FileContent, FileId, FileKind, FileMetadata, FileUri, RootDatabase};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::FilePath;
+
+/// Maps file paths to database file IDs and metadata
+///
+/// This is a temporary implementation for Phase 4. A more sophisticated
+/// implementation will be added when we integrate with project configuration.
+#[derive(Default)]
+pub struct FileRegistry {
+    next_id: u32,
+    uri_to_id: HashMap<String, FileId>,
+    id_to_uri: HashMap<FileId, String>,
+    id_to_content: HashMap<FileId, FileContent>,
+    id_to_metadata: HashMap<FileId, FileMetadata>,
+}
+
+impl FileRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or update a file in the registry
+    pub fn add_file(
+        &mut self,
+        db: &RootDatabase,
+        path: &FilePath,
+        content: &str,
+        kind: FileKind,
+    ) -> (FileId, FileContent, FileMetadata) {
+        let uri_str = path.as_str();
+
+        // Get or create FileId
+        let file_id = if let Some(&existing_id) = self.uri_to_id.get(uri_str) {
+            existing_id
+        } else {
+            let new_id = FileId::new(self.next_id);
+            self.next_id += 1;
+            self.uri_to_id.insert(uri_str.to_string(), new_id);
+            self.id_to_uri.insert(new_id, uri_str.to_string());
+            new_id
+        };
+
+        // Create or update FileContent
+        let content_arc: Arc<str> = Arc::from(content);
+        let file_content = FileContent::new(db, content_arc);
+        self.id_to_content.insert(file_id, file_content);
+
+        // Create or update FileMetadata
+        let uri = FileUri::new(uri_str);
+        let metadata = FileMetadata::new(db, file_id, uri, kind);
+        self.id_to_metadata.insert(file_id, metadata);
+
+        (file_id, file_content, metadata)
+    }
+
+    /// Look up file ID by path
+    #[must_use]
+    pub fn get_file_id(&self, path: &FilePath) -> Option<FileId> {
+        self.uri_to_id.get(path.as_str()).copied()
+    }
+
+    /// Look up path by file ID
+    #[must_use]
+    pub fn get_path(&self, file_id: FileId) -> Option<FilePath> {
+        self.id_to_uri
+            .get(&file_id)
+            .map(|s| FilePath::new(s.clone()))
+    }
+
+    /// Get `FileContent` for a file ID
+    #[must_use]
+    pub fn get_content(&self, file_id: FileId) -> Option<FileContent> {
+        self.id_to_content.get(&file_id).copied()
+    }
+
+    /// Get `FileMetadata` for a file ID
+    #[must_use]
+    pub fn get_metadata(&self, file_id: FileId) -> Option<FileMetadata> {
+        self.id_to_metadata.get(&file_id).copied()
+    }
+
+    /// Remove a file from the registry
+    pub fn remove_file(&mut self, file_id: FileId) {
+        if let Some(uri) = self.id_to_uri.remove(&file_id) {
+            self.uri_to_id.remove(&uri);
+        }
+        self.id_to_content.remove(&file_id);
+        self.id_to_metadata.remove(&file_id);
+    }
+
+    /// Get all file IDs
+    #[must_use]
+    pub fn all_file_ids(&self) -> Vec<FileId> {
+        self.id_to_uri.keys().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_registry_add_and_lookup() {
+        let db = RootDatabase::new();
+        let mut registry = FileRegistry::new();
+
+        let path = FilePath::new("file:///test.graphql");
+        let (file_id, _content, _metadata) =
+            registry.add_file(&db, &path, "type Query { hello: String }", FileKind::Schema);
+
+        // Should be able to look up by path
+        assert_eq!(registry.get_file_id(&path), Some(file_id));
+
+        // Should be able to look up by file ID
+        assert_eq!(registry.get_path(file_id), Some(path.clone()));
+
+        // Should have content and metadata
+        assert!(registry.get_content(file_id).is_some());
+        assert!(registry.get_metadata(file_id).is_some());
+    }
+
+    #[test]
+    fn test_file_registry_update_existing() {
+        let db = RootDatabase::new();
+        let mut registry = FileRegistry::new();
+
+        let path = FilePath::new("file:///test.graphql");
+
+        // Add file
+        let (file_id1, _, _) =
+            registry.add_file(&db, &path, "type Query { hello: String }", FileKind::Schema);
+
+        // Update same file
+        let (file_id2, _content2, _) =
+            registry.add_file(&db, &path, "type Query { world: String }", FileKind::Schema);
+
+        // Should reuse the same file ID
+        assert_eq!(file_id1, file_id2);
+
+        // Content should be updated
+        let updated_content = registry.get_content(file_id2).unwrap();
+        assert_eq!(
+            updated_content.text(&db).as_ref(),
+            "type Query { world: String }"
+        );
+    }
+
+    #[test]
+    fn test_file_registry_remove() {
+        let db = RootDatabase::new();
+        let mut registry = FileRegistry::new();
+
+        let path = FilePath::new("file:///test.graphql");
+        let (file_id, _, _) =
+            registry.add_file(&db, &path, "type Query { hello: String }", FileKind::Schema);
+
+        // Remove the file
+        registry.remove_file(file_id);
+
+        // Should no longer be found
+        assert_eq!(registry.get_file_id(&path), None);
+        assert_eq!(registry.get_path(file_id), None);
+    }
+
+    #[test]
+    fn test_file_registry_all_files() {
+        let db = RootDatabase::new();
+        let mut registry = FileRegistry::new();
+
+        let path1 = FilePath::new("file:///test1.graphql");
+        let path2 = FilePath::new("file:///test2.graphql");
+
+        let (file_id1, _, _) = registry.add_file(
+            &db,
+            &path1,
+            "type Query { hello: String }",
+            FileKind::Schema,
+        );
+        let (file_id2, _, _) = registry.add_file(
+            &db,
+            &path2,
+            "type Mutation { update: Boolean }",
+            FileKind::Schema,
+        );
+
+        let all_ids = registry.all_file_ids();
+        assert_eq!(all_ids.len(), 2);
+        assert!(all_ids.contains(&file_id1));
+        assert!(all_ids.contains(&file_id2));
+    }
+}

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -1,0 +1,468 @@
+//! # graphql-ide
+//!
+//! This crate provides editor-facing IDE features for GraphQL language support.
+//! It serves as the API boundary between the analysis layer and the LSP layer.
+//!
+//! ## Core Principle: POD Types with Public Fields
+//!
+//! Following rust-analyzer's design:
+//! - All types are Plain Old Data (POD) structs
+//! - All fields are public
+//! - Types use editor coordinates (file paths, line/column positions)
+//! - No GraphQL domain knowledge leaks to LSP layer
+//!
+//! ## Architecture
+//!
+//! ```text
+//! LSP Layer (tower-lsp)
+//!     ↓
+//! graphql-ide (this crate) ← POD types, editor API
+//!     ↓
+//! graphql-analysis ← Query-based validation and linting
+//!     ↓
+//! graphql-hir ← Semantic queries
+//!     ↓
+//! graphql-syntax ← Parsing
+//!     ↓
+//! graphql-db ← Salsa database
+//! ```
+//!
+//! ## Main Types
+//!
+//! - [`AnalysisHost`] - The main entry point, owns the database
+//! - [`Analysis`] - Immutable snapshot for querying IDE features
+//! - POD types: [`Position`], [`Range`], [`Location`], [`FilePath`]
+//! - Feature types: [`CompletionItem`], [`HoverResult`], [`Diagnostic`]
+
+use graphql_db::RootDatabase;
+use std::sync::{Arc, RwLock};
+
+mod file_registry;
+pub use file_registry::FileRegistry;
+
+// Re-export database types that IDE layer needs
+pub use graphql_db::{Change, FileKind};
+
+/// Position in a file (editor coordinates, 0-indexed)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Position {
+    pub line: u32,
+    pub character: u32,
+}
+
+impl Position {
+    #[must_use]
+    pub const fn new(line: u32, character: u32) -> Self {
+        Self { line, character }
+    }
+}
+
+/// Range in a file (editor coordinates)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Range {
+    pub start: Position,
+    pub end: Position,
+}
+
+impl Range {
+    #[must_use]
+    pub const fn new(start: Position, end: Position) -> Self {
+        Self { start, end }
+    }
+}
+
+/// File path (can be URI or file path)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FilePath(pub String);
+
+impl FilePath {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for FilePath {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for FilePath {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Location in a specific file
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    pub file: FilePath,
+    pub range: Range,
+}
+
+impl Location {
+    #[must_use]
+    pub const fn new(file: FilePath, range: Range) -> Self {
+        Self { file, range }
+    }
+}
+
+/// Completion item kind
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionKind {
+    Field,
+    Type,
+    Fragment,
+    Directive,
+    EnumValue,
+    Argument,
+    Variable,
+}
+
+/// Completion item
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionItem {
+    pub label: String,
+    pub kind: CompletionKind,
+    pub detail: Option<String>,
+    pub documentation: Option<String>,
+    pub insert_text: Option<String>,
+    pub deprecated: bool,
+}
+
+impl CompletionItem {
+    pub fn new(label: impl Into<String>, kind: CompletionKind) -> Self {
+        Self {
+            label: label.into(),
+            kind,
+            detail: None,
+            documentation: None,
+            insert_text: None,
+            deprecated: false,
+        }
+    }
+
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_documentation(mut self, doc: impl Into<String>) -> Self {
+        self.documentation = Some(doc.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_insert_text(mut self, text: impl Into<String>) -> Self {
+        self.insert_text = Some(text.into());
+        self
+    }
+
+    #[must_use]
+    pub const fn with_deprecated(mut self, deprecated: bool) -> Self {
+        self.deprecated = deprecated;
+        self
+    }
+}
+
+/// Hover information
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverResult {
+    /// Markdown content
+    pub contents: String,
+    /// Optional range for the hover
+    pub range: Option<Range>,
+}
+
+impl HoverResult {
+    pub fn new(contents: impl Into<String>) -> Self {
+        Self {
+            contents: contents.into(),
+            range: None,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_range(mut self, range: Range) -> Self {
+        self.range = Some(range);
+        self
+    }
+}
+
+/// Diagnostic severity
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+    Information,
+    Hint,
+}
+
+/// Diagnostic (error, warning, hint)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub range: Range,
+    pub severity: DiagnosticSeverity,
+    pub message: String,
+    pub code: Option<String>,
+    pub source: String,
+}
+
+impl Diagnostic {
+    pub fn new(
+        range: Range,
+        severity: DiagnosticSeverity,
+        message: impl Into<String>,
+        source: impl Into<String>,
+    ) -> Self {
+        Self {
+            range,
+            severity,
+            message: message.into(),
+            code: None,
+            source: source.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+}
+
+/// The main analysis host
+///
+/// This is the entry point for all IDE features. It owns the database and
+/// provides methods to apply changes and create snapshots for analysis.
+pub struct AnalysisHost {
+    db: RootDatabase,
+    /// File registry for mapping paths to file IDs
+    /// Wrapped in Arc<RwLock> so snapshots can share it
+    registry: Arc<RwLock<FileRegistry>>,
+}
+
+impl AnalysisHost {
+    /// Create a new analysis host with a default database
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            db: RootDatabase::default(),
+            registry: Arc::new(RwLock::new(FileRegistry::new())),
+        }
+    }
+
+    /// Add or update a file in the host
+    ///
+    /// This is a convenience method for adding files to the registry and database.
+    pub fn add_file(&mut self, path: &FilePath, content: &str, kind: FileKind) {
+        let mut registry = self.registry.write().unwrap();
+        registry.add_file(&self.db, path, content, kind);
+    }
+
+    /// Remove a file from the host
+    pub fn remove_file(&mut self, path: &FilePath) {
+        let mut registry = self.registry.write().unwrap();
+        if let Some(file_id) = registry.get_file_id(path) {
+            registry.remove_file(file_id);
+        }
+    }
+
+    /// Apply a change to the database
+    ///
+    /// Changes include adding/updating/removing files, updating configuration, etc.
+    pub fn apply_change(&mut self, change: Change) {
+        self.db.apply_change(change);
+    }
+
+    /// Get an immutable snapshot for analysis
+    ///
+    /// This snapshot can be used from multiple threads and provides all IDE features.
+    /// It's cheap to create and clone (`RootDatabase` implements Clone via salsa).
+    pub fn snapshot(&self) -> Analysis {
+        Analysis {
+            db: self.db.clone(),
+            registry: Arc::clone(&self.registry),
+        }
+    }
+
+    /// Get mutable access to the database (for testing)
+    #[doc(hidden)]
+    pub const fn db_mut(&mut self) -> &mut RootDatabase {
+        &mut self.db
+    }
+}
+
+impl Default for AnalysisHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Immutable snapshot of the analysis state
+///
+/// Can be cheaply cloned and used from multiple threads.
+/// All IDE feature queries go through this.
+#[derive(Clone)]
+pub struct Analysis {
+    #[allow(dead_code)]
+    db: RootDatabase,
+    #[allow(dead_code)]
+    registry: Arc<RwLock<FileRegistry>>,
+}
+
+impl Analysis {
+    /// Get diagnostics for a file
+    ///
+    /// Returns syntax errors, validation errors, and lint warnings.
+    pub const fn diagnostics(&self, _file: &FilePath) -> Vec<Diagnostic> {
+        // TODO: Implement diagnostic collection
+        // 1. Look up FileId from FilePath
+        // 2. Call graphql_analysis::file_diagnostics
+        // 3. Convert to IDE Diagnostic format
+        Vec::new()
+    }
+
+    /// Get completions at a position
+    ///
+    /// Returns a list of completion items appropriate for the context.
+    pub const fn completions(
+        &self,
+        _file: &FilePath,
+        _position: Position,
+    ) -> Option<Vec<CompletionItem>> {
+        // TODO: Implement completion logic
+        // 1. Parse the file
+        // 2. Find token at position
+        // 3. Determine completion context
+        // 4. Query HIR for available items
+        // 5. Convert to CompletionItems
+        None
+    }
+
+    /// Get hover information at a position
+    ///
+    /// Returns documentation, type information, etc.
+    pub const fn hover(&self, _file: &FilePath, _position: Position) -> Option<HoverResult> {
+        // TODO: Implement hover logic
+        // 1. Parse the file
+        // 2. Find token at position
+        // 3. Identify symbol
+        // 4. Query HIR for symbol data
+        // 5. Format as markdown
+        None
+    }
+
+    /// Get goto definition locations for the symbol at a position
+    ///
+    /// Returns the definition location(s) for types, fields, fragments, etc.
+    pub const fn goto_definition(
+        &self,
+        _file: &FilePath,
+        _position: Position,
+    ) -> Option<Vec<Location>> {
+        // TODO: Implement goto definition
+        // 1. Parse the file
+        // 2. Find token at position
+        // 3. Identify symbol type
+        // 4. Look up definition in HIR
+        // 5. Convert to Location
+        None
+    }
+
+    /// Find all references to the symbol at a position
+    ///
+    /// Returns locations of all usages of types, fields, fragments, etc.
+    pub const fn find_references(
+        &self,
+        _file: &FilePath,
+        _position: Position,
+        _include_declaration: bool,
+    ) -> Option<Vec<Location>> {
+        // TODO: Implement find references
+        // 1. Parse the file
+        // 2. Find token at position
+        // 3. Identify symbol
+        // 4. Search for all usages in HIR
+        // 5. Convert to Locations
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_analysis_host_creation() {
+        let host = AnalysisHost::new();
+        let _snapshot = host.snapshot();
+    }
+
+    #[test]
+    fn test_position_creation() {
+        let pos = Position::new(10, 5);
+        assert_eq!(pos.line, 10);
+        assert_eq!(pos.character, 5);
+    }
+
+    #[test]
+    fn test_range_creation() {
+        let range = Range::new(Position::new(0, 0), Position::new(1, 10));
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.end.line, 1);
+    }
+
+    #[test]
+    fn test_file_path_creation() {
+        let path = FilePath::new("file:///path/to/file.graphql");
+        assert_eq!(path.as_str(), "file:///path/to/file.graphql");
+
+        let path2: FilePath = "test.graphql".into();
+        assert_eq!(path2.as_str(), "test.graphql");
+    }
+
+    #[test]
+    fn test_completion_item_builder() {
+        let item = CompletionItem::new("fieldName", CompletionKind::Field)
+            .with_detail("String!")
+            .with_documentation("A field that returns a string")
+            .with_deprecated(true);
+
+        assert_eq!(item.label, "fieldName");
+        assert_eq!(item.kind, CompletionKind::Field);
+        assert_eq!(item.detail, Some("String!".to_string()));
+        assert!(item.deprecated);
+    }
+
+    #[test]
+    fn test_hover_result_builder() {
+        let hover = HoverResult::new("```graphql\ntype User\n```")
+            .with_range(Range::new(Position::new(0, 5), Position::new(0, 9)));
+
+        assert!(hover.contents.contains("type User"));
+        assert!(hover.range.is_some());
+    }
+
+    #[test]
+    fn test_diagnostic_builder() {
+        let diag = Diagnostic::new(
+            Range::new(Position::new(1, 0), Position::new(1, 10)),
+            DiagnosticSeverity::Error,
+            "Unknown type: User",
+            "graphql",
+        )
+        .with_code("unknown-type");
+
+        assert_eq!(diag.severity, DiagnosticSeverity::Error);
+        assert_eq!(diag.message, "Unknown type: User");
+        assert_eq!(diag.code, Some("unknown-type".to_string()));
+    }
+}

--- a/crates/graphql-syntax/src/lib.rs
+++ b/crates/graphql-syntax/src/lib.rs
@@ -211,14 +211,14 @@ pub fn line_index(db: &dyn GraphQLSyntaxDatabase, content: FileContent) -> Arc<L
 #[salsa::db]
 pub trait GraphQLSyntaxDatabase: salsa::Database {}
 
+// Implement the trait for RootDatabase
+// This makes RootDatabase usable with all syntax queries
+#[salsa::db]
+impl GraphQLSyntaxDatabase for graphql_db::RootDatabase {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use graphql_db::RootDatabase;
-
-    // Extend RootDatabase to implement GraphQLSyntaxDatabase
-    #[salsa::db]
-    impl GraphQLSyntaxDatabase for RootDatabase {}
 
     #[test]
     fn test_line_index_new() {


### PR DESCRIPTION
## Summary

Implements the foundation for Phase 4 of the LSP rearchitecture, creating the `graphql-ide` crate with POD types and core API structure following rust-analyzer's design patterns.

## New Crate: graphql-ide

**Core API:**
- `AnalysisHost`: Mutable database owner and entry point
- `Analysis`: Immutable snapshot for lock-free queries
- `FileRegistry`: Path to FileId mapping with bidirectional lookup

**POD Types** (Plain Old Data with public fields):
- Position, Range, Location, FilePath
- CompletionItem, HoverResult, Diagnostic
- All types designed for easy serialization and LSP integration

## Database Trait Implementations

To avoid circular dependencies, implemented traits in their defining crates:
- `GraphQLSyntaxDatabase` for `RootDatabase` (in graphql-syntax)
- `GraphQLHirDatabase` for `RootDatabase` (in graphql-hir)
- `GraphQLAnalysisDatabase` for `RootDatabase` (in graphql-analysis)

## Architecture

Follows rust-analyzer patterns:
- POD types with public fields (no hidden state)
- Editor coordinates (line/column, not byte offsets)
- Snapshot-based concurrency (lock-free reads via salsa)
- LSP-agnostic design (no protocol dependencies)

## Testing

- ✅ 11 tests added, all passing
- ✅ Full project builds successfully
- ✅ Comprehensive FileRegistry test coverage
- ✅ All clippy warnings addressed
- ✅ Code properly formatted

## Documentation

- Added comprehensive [README.md](https://github.com/trevor-scheer/graphql-lsp/blob/phase4-ide-foundation/crates/graphql-ide/README.md) with examples and usage patterns
- API documentation for all public types
- Updated [PHASE4-STATUS.md](https://github.com/trevor-scheer/graphql-lsp/blob/phase4-ide-foundation/.claude/notes/active/lsp-rearchitecture/PHASE4-STATUS.md) tracking progress

## Files Changed

### New Files
- `crates/graphql-ide/Cargo.toml` - Package configuration
- `crates/graphql-ide/src/lib.rs` - Main types and API (415 lines)
- `crates/graphql-ide/src/file_registry.rs` - Path to FileId mapping (207 lines)
- `crates/graphql-ide/README.md` - Comprehensive documentation

### Modified Files
- `Cargo.toml` - Added graphql-ide to workspace
- `crates/graphql-syntax/src/lib.rs` - Added RootDatabase trait impl
- `crates/graphql-hir/src/lib.rs` - Added RootDatabase trait impl
- `crates/graphql-analysis/src/lib.rs` - Added RootDatabase trait impl

## Next Steps

The foundation is complete. Follow-up PRs will implement:
- 🔲 Diagnostics (validation and linting)
- 🔲 Completions (context-aware suggestions)
- 🔲 Hover (type information and docs)
- 🔲 Goto definition (navigation to definitions)
- 🔲 Find references (find all usages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)