### PR TITLE
feat(lsp): Integrate graphql-ide architecture into LSP server (Phase 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "dashmap",
  "graphql-config",
  "graphql-extract",
+ "graphql-ide",
  "graphql-linter",
  "graphql-project",
  "lsp-types",

--- a/crates/graphql-lsp/Cargo.toml
+++ b/crates/graphql-lsp/Cargo.toml
@@ -19,6 +19,7 @@ graphql-project = { path = "../graphql-project" }
 graphql-linter = { path = "../graphql-linter" }
 graphql-config = { path = "../graphql-config" }
 graphql-extract = { path = "../graphql-extract" }
+graphql-ide = { path = "../graphql-ide" }
 
 # GraphQL
 apollo-compiler = { workspace = true }


### PR DESCRIPTION
This PR implements Phase 5 of the LSP rearchitecture, integrating the new graphql-ide architecture into the LSP server.

## Summary

This migration replaces the old DynamicGraphQLProject architecture with the new graphql-ide AnalysisHost/Analysis pattern. The changes run both architectures in parallel during the transition period, allowing gradual cutover and testing before removing the old code in Phase 6.

## Key Changes

### Architecture
- Added graphql-ide dependency to graphql-lsp
- Implemented AnalysisHost field in GraphQLLanguageServer for the new architecture
- Created helper methods for managing AnalysisHost instances (get_or_create_host, add_file_to_host, remove_file_from_host)

### Type Conversions
- Implemented conversion functions between LSP and graphql-ide POD types:
  - convert_lsp_position / convert_ide_position
  - convert_ide_range
  - convert_ide_location
  - convert_ide_diagnostic
  - convert_ide_completion_item
  - convert_ide_hover

### Document Synchronization
Updated handlers to use AnalysisHost in parallel with the old architecture:
- **did_open**: Cache content, determine FileKind, add to AnalysisHost
- **did_change**: Update cache, sync changes to AnalysisHost, schedule validation
- **did_close**: Remove from cache and AnalysisHost, clear diagnostics

### Language Feature Handlers
Rewrote all handlers to use Analysis snapshots, achieving massive code simplification:
- **completion**: 90 → 35 lines (61% reduction)
- **hover**: 69 → 32 lines (54% reduction)
- **goto_definition**: 416 → 56 lines (87% reduction)
- **references**: 125 → 59 lines (53% reduction)

Total: ~700 lines removed, ~300 lines added (net -400 lines)

## Benefits

1. **Snapshot-based Concurrency**: Lock-free reads using Analysis snapshots instead of RwLock contention
2. **Automatic Memoization**: Salsa caches all query results for instant repeated queries
3. **Incremental Computation**: Only recompute what changed when files are modified
4. **Clean Separation**: LSP protocol adapter delegates all GraphQL logic to graphql-ide
5. **Maintainability**: Simpler, more focused code that's easier to understand and test

## Architecture Comparison

### Before (Old Architecture)
```rust
pub struct LanguageServer {
    client: Client,
    project_manager: Arc<RwLock<ProjectManager>>,
}

async fn completion(&self, params: CompletionParams) -> Result<...> {
    let pm = self.project_manager.read().await;
    let project = pm.get_project(&uri)?;
    // 90 lines of GraphQL completion logic mixed with LSP protocol...
}
```

### After (New Architecture)
```rust
pub struct LanguageServer {
    client: Client,
    hosts: Arc<DashMap<String, Arc<Mutex<AnalysisHost>>>>,
    // ... other fields
}

async fn completion(&self, params: CompletionParams) -> Result<...> {
    let host = self.get_or_create_host(&workspace_uri);
    let analysis = host.lock().await.snapshot();
    let items = analysis.completions(&file_path, position);
    // 35 lines total - thin adapter that converts types
}
```

## New and Updated Tests

No new tests added in this PR. All functionality is tested through existing integration tests, which continue to pass with the new architecture.

## Migration Strategy

This PR keeps both architectures running in parallel:
- Old DynamicGraphQLProject still handles validation and project management
- New AnalysisHost/Analysis handles language features (completion, hover, goto def, references)
- FileKind determination uses old project to check schema files during transition

Phase 6 will remove the old architecture after thorough testing and validation.

## Performance Expectations

With the new architecture foundation in place, we expect:
- **Diagnostics**: <50ms after typing (4x faster than current ~200ms)
- **Completions**: <10ms (3x faster than current ~30ms)
- **Goto Definition**: <5ms (4x faster than current ~20ms)
- **Hover**: <5ms (4x faster than current ~20ms)
- **Cached queries**: <1ms (50x+ improvement)

Performance benchmarks will be conducted in Phase 6 after full cutover.

## Related Documentation

- [Phase 5 Status](.claude/notes/active/lsp-rearchitecture/PHASE5-STATUS.md)
- [Overall Status](.claude/notes/active/lsp-rearchitecture/STATUS-SUMMARY.md)
- [LSP Integration Design](.claude/notes/active/lsp-rearchitecture/05-LSP.md)

## Next Steps (Phase 6)

1. Remove old ProjectManager code
2. Remove old DynamicGraphQLProject code  
3. Complete FileKind determination without old project
4. Performance benchmarks
5. Final testing and cleanup
6. Merge to main