### PR TITLE
feat(lsp): Integrate linting into new architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "graphql-syntax",
  "salsa",
  "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/graphql-analysis/Cargo.toml
+++ b/crates/graphql-analysis/Cargo.toml
@@ -15,3 +15,4 @@ graphql-project = { path = "../graphql-project" }
 salsa = { workspace = true }
 apollo-compiler = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/crates/graphql-analysis/src/lint_integration.rs
+++ b/crates/graphql-analysis/src/lint_integration.rs
@@ -1,7 +1,7 @@
 // Integration with graphql-linter
 
-use crate::{Diagnostic, GraphQLAnalysisDatabase};
-use graphql_db::{FileContent, FileMetadata};
+use crate::{Diagnostic, DiagnosticRange, GraphQLAnalysisDatabase, Position, Severity};
+use graphql_db::{FileContent, FileKind, FileMetadata};
 use std::sync::Arc;
 
 /// Run lints on a file
@@ -9,17 +9,98 @@ use std::sync::Arc;
 #[salsa::tracked]
 pub fn lint_file(
     db: &dyn GraphQLAnalysisDatabase,
-    _content: FileContent,
-    _metadata: FileMetadata,
+    content: FileContent,
+    metadata: FileMetadata,
 ) -> Arc<Vec<Diagnostic>> {
-    let _lint_config = db.lint_config();
-    let diagnostics = Vec::new();
+    let lint_config = db.lint_config();
+    let mut diagnostics = Vec::new();
 
-    // TODO: Integrate with graphql_linter::Linter
-    // This will require:
-    // 1. Building SchemaIndex and DocumentIndex from HIR
-    // 2. Calling linter methods
-    // 3. Converting lint diagnostics to our Diagnostic type
+    // Get content text and file URI
+    let content_text = content.text(db);
+    let file_uri = metadata.uri(db);
+    let file_name = file_uri.as_str();
+    let file_kind = metadata.kind(db);
+
+    // Parse the file
+    let parse = graphql_syntax::parse(db, content, metadata);
+
+    // Skip linting if there are parse errors
+    if !parse.errors.is_empty() {
+        tracing::debug!("Skipping linting due to parse errors");
+        return Arc::new(diagnostics);
+    }
+
+    // Convert our LintConfig to graphql_linter::LintConfig
+    let mut rules = std::collections::HashMap::new();
+    for (rule_name, severity) in &lint_config.enabled_rules {
+        let lint_severity = match severity {
+            Severity::Error => graphql_linter::LintSeverity::Error,
+            Severity::Warning | Severity::Info => graphql_linter::LintSeverity::Warn,
+        };
+        rules.insert(
+            rule_name.clone(),
+            graphql_linter::LintRuleConfig::Severity(lint_severity),
+        );
+    }
+
+    let linter_config = graphql_linter::LintConfig::Rules { rules };
+    let linter = graphql_linter::Linter::new(linter_config);
+
+    // Run lints based on file kind
+    match file_kind {
+        FileKind::ExecutableGraphQL | FileKind::TypeScript | FileKind::JavaScript => {
+            // For executable GraphQL, run standalone document lints
+            // TODO: Also run document+schema lints when we have SchemaIndex available
+            let lint_diagnostics = linter.lint_standalone_document(
+                content_text.as_ref(),
+                file_name,
+                None, // TODO: Pass DocumentIndex for fragment resolution
+                Some(&parse.tree),
+            );
+
+            // Convert graphql_project::Diagnostic to our Diagnostic type
+            for lint_diag in lint_diagnostics {
+                diagnostics.push(convert_lint_diagnostic(&lint_diag));
+            }
+        }
+        FileKind::Schema => {
+            // TODO: Run schema lints when we have support for that
+            tracing::debug!("Schema linting not yet implemented");
+        }
+    }
+
+    tracing::debug!(
+        file = file_name,
+        diagnostics = diagnostics.len(),
+        "Linting complete"
+    );
 
     Arc::new(diagnostics)
+}
+
+/// Convert `graphql_project::Diagnostic` to our Diagnostic type
+#[allow(clippy::cast_possible_truncation)]
+fn convert_lint_diagnostic(lint_diag: &graphql_project::Diagnostic) -> Diagnostic {
+    let severity = match lint_diag.severity {
+        graphql_project::Severity::Error => Severity::Error,
+        graphql_project::Severity::Warning => Severity::Warning,
+        graphql_project::Severity::Information | graphql_project::Severity::Hint => Severity::Info,
+    };
+
+    Diagnostic {
+        severity,
+        message: lint_diag.message.clone().into(),
+        range: DiagnosticRange {
+            start: Position {
+                line: lint_diag.range.start.line as u32,
+                character: lint_diag.range.start.character as u32,
+            },
+            end: Position {
+                line: lint_diag.range.end.line as u32,
+                character: lint_diag.range.end.character as u32,
+            },
+        },
+        source: lint_diag.source.clone().into(),
+        code: lint_diag.code.as_ref().map(|c| c.clone().into()),
+    }
 }

--- a/test-workspace/src/mutations/battle-mutations.graphql
+++ b/test-workspace/src/mutations/battle-mutations.graphql
@@ -14,6 +14,7 @@ mutation PerformAttack($battleId: ID!, $trainerId: ID!, $moveId: ID!) {
     action: { type: ATTACK, moveId: $moveId }
   ) {
     ...BattleDetailed
+    endedAt
   }
 }
 


### PR DESCRIPTION
## Summary

Implement linting integration in the new query-based architecture:

- **Implement lint_file()**: Created query-based linting in graphql-analysis that calls graphql-linter
- **Enhanced redundant_fields rule**: Now detects duplicate fields in the same selection set, not just overlaps between fragments
- **Implement validate_document()**: LSP server now publishes diagnostics from IDE layer
- **Remove debouncing**: Removed all debouncing infrastructure - rely on Salsa's incremental computation for performance
- **Temporarily disable schema validation**: Schema validation requires project-wide schema aggregation which isn't implemented yet

## Updated Tests

- Added test for redundant_fields detecting duplicate fields in same selection set
- Updated test assertions to use `assert!` instead of `if panic!`

## Notes

Schema validation is disabled for now because it requires project-wide schema loading. It will be re-enabled once we implement the full project-wide schema aggregation in the new architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)