### PR TITLE
feat(linter): Implement fragment resolution for require_id_field rule

### DIFF
--- a/crates/graphql-linter/src/rules/require_id_field.rs
+++ b/crates/graphql-linter/src/rules/require_id_field.rs
@@ -52,10 +52,21 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
             types_with_id.insert(type_name.to_string(), has_id);
         }
 
+        // Get all fragments from the project (for cross-file resolution)
+        let all_fragments = graphql_hir::all_fragments_with_project(db, project_files);
+
         // Get root operation types from schema
         let query_type = find_root_operation_type(&schema_types, "Query");
         let mutation_type = find_root_operation_type(&schema_types, "Mutation");
         let subscription_type = find_root_operation_type(&schema_types, "Subscription");
+
+        // Create context for fragment resolution
+        let check_context = CheckContext {
+            db,
+            schema_types: &schema_types,
+            types_with_id: &types_with_id,
+            all_fragments: &all_fragments,
+        };
 
         // Walk the CST for position info
         let doc_cst = parse.tree.document();
@@ -82,8 +93,7 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
                         check_selection_set(
                             &selection_set,
                             root_type_name,
-                            &schema_types,
-                            &types_with_id,
+                            &check_context,
                             &mut visited_fragments,
                             &mut diagnostics,
                         );
@@ -103,8 +113,7 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
                         check_selection_set(
                             &selection_set,
                             type_name,
-                            &schema_types,
-                            &types_with_id,
+                            &check_context,
                             &mut visited_fragments,
                             &mut diagnostics,
                         );
@@ -118,17 +127,25 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
     }
 }
 
+/// Context for checking selection sets with fragment resolution
+struct CheckContext<'a> {
+    db: &'a dyn graphql_hir::GraphQLHirDatabase,
+    schema_types: &'a HashMap<Arc<str>, graphql_hir::TypeDef>,
+    types_with_id: &'a HashMap<String, bool>,
+    all_fragments: &'a HashMap<Arc<str>, graphql_hir::FragmentStructure>,
+}
+
 #[allow(clippy::only_used_in_recursion)]
 fn check_selection_set(
     selection_set: &cst::SelectionSet,
     parent_type_name: &str,
-    schema_types: &HashMap<Arc<str>, graphql_hir::TypeDef>,
-    types_with_id: &HashMap<String, bool>,
+    context: &CheckContext,
     visited_fragments: &mut HashSet<String>,
     diagnostics: &mut Vec<LintDiagnostic>,
 ) {
     // Check if this type has an id field
-    let has_id_field = types_with_id
+    let has_id_field = context
+        .types_with_id
         .get(parent_type_name)
         .copied()
         .unwrap_or(false);
@@ -154,13 +171,12 @@ fn check_selection_set(
                     if let Some(nested_selection_set) = field.selection_set() {
                         // Get the field's return type from schema
                         if let Some(field_type) =
-                            get_field_type(parent_type_name, &field_name_str, schema_types)
+                            get_field_type(parent_type_name, &field_name_str, context.schema_types)
                         {
                             check_selection_set(
                                 &nested_selection_set,
                                 &field_type,
-                                schema_types,
-                                types_with_id,
+                                context,
                                 visited_fragments,
                                 diagnostics,
                             );
@@ -168,11 +184,21 @@ fn check_selection_set(
                     }
                 }
             }
-            cst::Selection::FragmentSpread(_fragment_spread) => {
-                // TODO: Implement fragment resolution using HIR
-                // For now, we conservatively assume fragments might contain id
-                // This prevents false positives but may miss some cases
-                has_id_in_selection = true;
+            cst::Selection::FragmentSpread(fragment_spread) => {
+                // Check if the fragment contains the id field
+                if let Some(fragment_name) = fragment_spread.fragment_name() {
+                    if let Some(name) = fragment_name.name() {
+                        let name_str = name.text().to_string();
+                        if fragment_contains_id(
+                            &name_str,
+                            parent_type_name,
+                            context,
+                            visited_fragments,
+                        ) {
+                            has_id_in_selection = true;
+                        }
+                    }
+                }
             }
             cst::Selection::InlineFragment(inline_fragment) => {
                 // For inline fragments, check nested selections
@@ -197,13 +223,12 @@ fn check_selection_set(
                                     if let Some(field_type) = get_field_type(
                                         &inline_type,
                                         &field_name.text(),
-                                        schema_types,
+                                        context.schema_types,
                                     ) {
                                         check_selection_set(
                                             &field_selection_set,
                                             &field_type,
-                                            schema_types,
-                                            types_with_id,
+                                            context,
                                             visited_fragments,
                                             diagnostics,
                                         );
@@ -270,4 +295,151 @@ fn get_field_type(
 
     // The TypeRef name is already unwrapped from List/NonNull wrappers
     Some(field.type_ref.name.to_string())
+}
+
+/// Check if a fragment (or its nested fragments) contains the `id` field
+fn fragment_contains_id(
+    fragment_name: &str,
+    parent_type_name: &str,
+    context: &CheckContext,
+    visited_fragments: &mut HashSet<String>,
+) -> bool {
+    // Prevent infinite recursion with circular fragment references
+    if visited_fragments.contains(fragment_name) {
+        return false;
+    }
+    visited_fragments.insert(fragment_name.to_string());
+
+    // Look up the fragment in HIR
+    let Some(fragment_info) = context.all_fragments.get(fragment_name) else {
+        // Fragment not found - might be undefined
+        return false;
+    };
+
+    // Get the fragment's file and parse it (cached by Salsa)
+    let file_id = fragment_info.file_id;
+
+    // We need to get the file content and metadata to parse it
+    // Use the document_files from project_files to find this file
+    let document_files = context.db.document_files();
+
+    let Some((file_content, file_metadata)) = document_files
+        .iter()
+        .find(|(fid, _, _)| *fid == file_id)
+        .map(|(_, c, m)| (*c, *m))
+    else {
+        return false;
+    };
+
+    // Parse the file (cached by Salsa)
+    let parse = graphql_syntax::parse(context.db, file_content, file_metadata);
+    if !parse.errors.is_empty() {
+        return false;
+    }
+
+    // Find the fragment definition in the CST
+    let doc_cst = parse.tree.document();
+    for definition in doc_cst.definitions() {
+        if let cst::Definition::FragmentDefinition(frag) = definition {
+            // Check if this is the fragment we're looking for
+            let is_target_fragment = frag
+                .fragment_name()
+                .and_then(|name| name.name())
+                .is_some_and(|name| name.text() == fragment_name);
+
+            if !is_target_fragment {
+                continue;
+            }
+
+            // Found the fragment, check its selection set for id
+            if let Some(selection_set) = frag.selection_set() {
+                return check_fragment_selection_for_id(
+                    &selection_set,
+                    parent_type_name,
+                    context,
+                    visited_fragments,
+                );
+            }
+        }
+    }
+
+    false
+}
+
+/// Check if a selection set within a fragment contains the `id` field
+/// This is similar to `check_selection_set` but only checks for presence of id,
+/// doesn't emit diagnostics
+fn check_fragment_selection_for_id(
+    selection_set: &cst::SelectionSet,
+    parent_type_name: &str,
+    context: &CheckContext,
+    visited_fragments: &mut HashSet<String>,
+) -> bool {
+    for selection in selection_set.selections() {
+        match selection {
+            cst::Selection::Field(field) => {
+                if let Some(field_name) = field.name() {
+                    // Check if this is the id field
+                    if field_name.text() == "id" {
+                        return true;
+                    }
+
+                    // Recurse into nested selection sets
+                    if let Some(nested_selection_set) = field.selection_set() {
+                        if let Some(field_type) = get_field_type(
+                            parent_type_name,
+                            &field_name.text(),
+                            context.schema_types,
+                        ) {
+                            if check_fragment_selection_for_id(
+                                &nested_selection_set,
+                                &field_type,
+                                context,
+                                visited_fragments,
+                            ) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            cst::Selection::FragmentSpread(fragment_spread) => {
+                // Recursively check nested fragment spreads
+                if let Some(fragment_name) = fragment_spread.fragment_name() {
+                    if let Some(name) = fragment_name.name() {
+                        let name_str = name.text().to_string();
+                        if fragment_contains_id(
+                            &name_str,
+                            parent_type_name,
+                            context,
+                            visited_fragments,
+                        ) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            cst::Selection::InlineFragment(inline_fragment) => {
+                // Check inline fragments
+                if let Some(nested_selection_set) = inline_fragment.selection_set() {
+                    let inline_type = inline_fragment
+                        .type_condition()
+                        .and_then(|tc| tc.named_type())
+                        .and_then(|nt| nt.name())
+                        .map_or_else(|| parent_type_name.to_string(), |n| n.text().to_string());
+
+                    if check_fragment_selection_for_id(
+                        &nested_selection_set,
+                        &inline_type,
+                        context,
+                        visited_fragments,
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
## Summary

Resolves the workaround in the `require_id_field` rule by implementing proper fragment resolution using HIR queries. Previously, the rule conservatively assumed all fragment spreads might contain the `id` field to avoid false positives.

## Changes

### Fragment Resolution Implementation
- Added `CheckContext` struct to carry HIR database, schema types, and fragment registry
- Implemented `fragment_contains_id()` to resolve fragments across files using HIR
- Implemented `check_fragment_selection_for_id()` to recursively check fragment selection sets
- Handles circular fragment references with visited set tracking
- Uses Salsa-cached parsing for efficient cross-file fragment lookups

### How It Works
1. Uses HIR's `all_fragments_with_project` query to get fragment metadata
2. Looks up fragment files by `file_id` from fragment structure
3. Parses fragment files (automatically cached by Salsa)
4. Walks CST to find fragment definitions
5. Recursively checks selection sets for `id` field
6. Handles nested fragment spreads and inline fragments

### Benefits
- **Accurate diagnostics**: No longer assumes fragments contain `id`
- **Cross-file resolution**: Properly resolves fragments defined in other files
- **Efficient**: Leverages Salsa caching for fragment file parsing
- **Circular reference safe**: Tracks visited fragments to prevent infinite recursion

## Testing

- ✅ All existing tests pass (95/95)
- ✅ Cargo clippy clean
- ✅ Cargo fmt clean
- ✅ Pre-commit hooks pass

## Example

Before (conservative):
```graphql
fragment UserInfo on User {
  name
  email
}

query GetUser {
  user {
    ...UserInfo  # Assumed to contain id (false negative)
  }
}
```

After (accurate):
```graphql
fragment UserInfo on User {
  name
  email
}

query GetUser {
  user {
    ...UserInfo  # Now correctly detected as missing id
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)