### PR TITLE
fix(analysis): Filter out false positive 'must be used in an operation' errors

### DIFF
--- a/crates/graphql-analysis/src/validation.rs
+++ b/crates/graphql-analysis/src/validation.rs
@@ -144,6 +144,12 @@ pub fn validate_document(
                 // Get message - apollo_diag.error is a GraphQLError which can be converted to string
                 let message: Arc<str> = Arc::from(apollo_diag.error.to_string());
 
+                // Filter out false positives: fragments are allowed to be standalone
+                // and don't need to be used in operations (they may be used in other files)
+                if message.contains("must be used in an operation") {
+                    continue;
+                }
+
                 diagnostics.push(Diagnostic {
                     severity: Severity::Error,
                     message,


### PR DESCRIPTION
Apollo-compiler reports an error when fragments are not used in operations within the same document. However, this is a false positive because:
- Fragments can be defined in separate files and used elsewhere
- Fragment-only documents are valid GraphQL
- Fragments have project-wide scope

This change filters out these errors to prevent spurious diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>