### PR TITLE
fix(lsp): Correct line offset calculation for extracted GraphQL diagnostics

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -242,9 +242,9 @@ impl GraphQLLanguageServer {
                 let combined_graphql: Vec<String> =
                     extracted.iter().map(|e| e.source.clone()).collect();
 
-                // Use the line offset from the first block
+                // Use the line offset from the first block (already 0-indexed)
                 #[allow(clippy::cast_possible_truncation)]
-                let line_offset = extracted[0].location.range.start.line.saturating_sub(1) as u32;
+                let line_offset = extracted[0].location.range.start.line as u32;
 
                 let result = combined_graphql.join("\n\n");
                 tracing::info!(


### PR DESCRIPTION
## Summary

Fixes validation diagnostics for GraphQL extracted from TypeScript/JavaScript files appearing one line too early.

## Problem

When GraphQL code is embedded in TypeScript/JavaScript files (e.g., in `gql` template literals), validation errors were showing up on the wrong line - always one line too early.

## Root Cause

The line offset calculation was double-counting the conversion from 1-indexed to 0-indexed line numbers:
1. `graphql-extract` returns 0-indexed line numbers
2. We were subtracting 1 from these already-0-indexed numbers
3. Then in validation, apollo-compiler's 1-indexed errors were converted to 0-indexed and the offset was added
4. This resulted in diagnostics appearing one line too early

## Solution

Removed the unnecessary `.saturating_sub(1)` from the line offset calculation in [server.rs:247](https://github.com/trevor-scheer/graphql-lsp/blob/fix/diagnostic-line-offset/crates/graphql-lsp/src/server.rs#L247). The extraction already provides 0-indexed line numbers which can be used directly as the offset.

## Testing

Before: Diagnostic appears on line N-1
After: Diagnostic appears on line N (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)