### PR TITLE
Implement targeted auto-revalidation for fragment changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "apollo-compiler",
+ "apollo-parser 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap",
  "glob",
  "graphql-config",

--- a/crates/graphql-lsp/Cargo.toml
+++ b/crates/graphql-lsp/Cargo.toml
@@ -23,6 +23,7 @@ graphql-ide = { path = "../graphql-ide" }
 
 # GraphQL
 apollo-compiler = { workspace = true }
+apollo-parser = { workspace = true }
 
 # LSP
 tower-lsp-server = { workspace = true }


### PR DESCRIPTION
## Summary

Implements smart revalidation of documents when fragment files change, only re-validating documents that actually reference the changed fragments.

## Changes

- **Fragment resolution**: Uses apollo-compiler builder pattern with proper source tracking across files
- **Targeted auto-revalidation**: When a file with fragments changes, only documents that reference those fragments are re-validated
- **Helper methods**: Extract fragment names from content and check if documents reference specific fragments
- **Unit tests**: Verify fragment extraction and reference checking behavior

## Implementation Details

The targeted revalidation approach:

1. Extracts which fragments are defined in the changed file
2. Checks which open documents reference those specific fragments
3. Only re-validates documents that have a dependency on the changed fragments

This ensures efficient incremental updates while maintaining correctness. Files that don't use the changed fragments are not unnecessarily re-validated.

## Testing

New unit tests verify:
- Fragment name extraction from GraphQL content
- Document fragment reference detection (both direct and nested)
- Correct handling of documents that don't reference changed fragments

Log messages at INFO level show which documents are being re-validated and which are being skipped, making it easy to verify the targeted behavior.