### PR TITLE
fix(lsp): Use project extract config instead of hardcoded defaults

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -334,6 +334,17 @@ impl AnalysisHost {
         ));
     }
 
+    /// Get the extract configuration for the project
+    ///
+    /// Returns the configured extract settings, or default if not set.
+    pub fn get_extract_config(&self) -> graphql_extract::ExtractConfig {
+        self.db
+            .extract_config_any()
+            .and_then(|any| any.downcast::<graphql_extract::ExtractConfig>().ok())
+            .map(|arc| (*arc).clone())
+            .unwrap_or_default()
+    }
+
     /// Get an immutable snapshot for analysis
     ///
     /// This snapshot can be used from multiple threads and provides all IDE features.


### PR DESCRIPTION
## Summary

Fixes the LSP server to use the project's extract configuration from `graphqlrc.yaml` instead of hardcoded `ExtractConfig::default()` when extracting GraphQL from TypeScript/JavaScript files.

## Problem

The LSP server was using `ExtractConfig::default()` when extracting GraphQL from TypeScript/JavaScript files, ignoring the user's extract configuration in `graphqlrc.yaml`. This caused operations to not be extracted from projects that require custom settings like `allowGlobalIdentifiers: true` for `graphql()` function calls.

For example, projects using:
```yaml
extensions:
  extractConfig:
    allowGlobalIdentifiers: true
```

Would have all their operations ignored because the LSP used the default config (which has `allowGlobalIdentifiers: false`).

## Root Cause

The `extract_graphql_from_source()` function in [server.rs:237](https://github.com/trevor-scheer/graphql-lsp/blob/lsp-rearchitecture/crates/graphql-lsp/src/server.rs#L237) used a hardcoded `ExtractConfig::default()` when extracting GraphQL. This meant that even if the project config specified custom extract settings, they were completely ignored by the LSP.

## Solution

1. Added `get_extract_config()` method to `AnalysisHost` to retrieve the configured extract settings
2. Modified `extract_graphql_from_source()` to accept an `&ExtractConfig` parameter instead of using hardcoded defaults
3. Updated workspace loading to parse extract config from project extensions and set it on the `AnalysisHost`
4. Updated `didOpen` and `didChange` handlers to retrieve extract config from the host and pass it to extraction
5. Updated all four call sites of `extract_graphql_from_source()` to pass the appropriate config

## Files Changed

- [crates/graphql-ide/src/lib.rs](crates/graphql-ide/src/lib.rs): Added `get_extract_config()` method to retrieve config from database
- [crates/graphql-lsp/src/server.rs](crates/graphql-lsp/src/server.rs): Parse extract config from project settings and use throughout LSP lifecycle

## Testing

- Verified with `cargo build` and `cargo clippy`
- Extract config is now properly loaded from `graphqlrc.yaml` and used throughout the LSP lifecycle
- All four extraction call sites (workspace loading for schema/documents, didOpen, didChange) now use project config

## Related

This complements PR #130 which fixed extract config for the CLI tool. Now both CLI and LSP properly respect the user's extract configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>