### PR TITLE
fix(lsp): Don't remove files from AnalysisHost when closed in editor

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -339,10 +339,19 @@ impl AnalysisHost {
     /// This snapshot can be used from multiple threads and provides all IDE features.
     /// It's cheap to create and clone (`RootDatabase` implements Clone via salsa).
     pub fn snapshot(&self) -> Analysis {
-        let project_files = {
-            let registry = self.registry.read().unwrap();
-            registry.project_files()
-        };
+        let project_files = self.registry.read().unwrap().project_files();
+
+        if let Some(ref project_files) = project_files {
+            let doc_count = project_files.document_files(&self.db).len();
+            let schema_count = project_files.schema_files(&self.db).len();
+            tracing::debug!(
+                "Snapshot project_files: {} schema files, {} document files",
+                schema_count,
+                doc_count
+            );
+        } else {
+            tracing::warn!("Snapshot project_files is None!");
+        }
 
         Analysis {
             db: self.db.clone(),
@@ -886,6 +895,12 @@ impl Analysis {
             Symbol::FragmentSpread { name } => {
                 // Query HIR for all fragments
                 let fragments = graphql_hir::all_fragments_with_project(&self.db, project_files);
+
+                tracing::debug!(
+                    "Looking for fragment '{}', available fragments: {:?}",
+                    name,
+                    fragments.keys().collect::<Vec<_>>()
+                );
 
                 // Find the fragment by name
                 let fragment = fragments.get(name.as_str())?;

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -1162,14 +1162,12 @@ impl LanguageServer for GraphQLLanguageServer {
         self.document_cache
             .remove(&params.text_document.uri.to_string());
 
-        // Remove from AnalysisHost (new architecture)
-        if let Some((workspace_uri, _)) = self.find_workspace_and_project(&params.text_document.uri)
-        {
-            self.remove_file_from_host(&workspace_uri, &params.text_document.uri)
-                .await;
-        }
+        // NOTE: We intentionally do NOT remove the file from AnalysisHost when it's closed.
+        // The file is still part of the project on disk, and other files may reference
+        // fragments/types defined in it. Only files that are deleted from disk should be
+        // removed from the analysis.
 
-        // Clear diagnostics
+        // Clear diagnostics for the closed file
         self.client
             .publish_diagnostics(params.text_document.uri, vec![], None)
             .await;


### PR DESCRIPTION
## Summary

Fixes a critical bug where closing a file in the editor would break goto definition for any fragments/types defined in that file.

## Problem

When a file is closed in the editor, the `did_close` handler was calling `remove_file_from_host`, which removed the file from the `AnalysisHost`. This caused:
- Goto definition to fail for fragment spreads referencing fragments in closed files
- Type references to break when the defining file is closed
- General IDE features to stop working for cross-file references

## Root Cause

The `did_close` LSP notification indicates that a file is closed *in the editor*, not that it's been deleted from the project. The file is still:
- Part of the project on disk
- Listed in the GraphQL config's document patterns
- Referenced by other files in the project

## Solution

Don't remove files from `AnalysisHost` when they're closed in the editor. Files should only be removed when:
- They are actually deleted from disk (handled by file watchers)
- The project configuration changes to exclude them

## Changes

- Removed `remove_file_from_host` call from `did_close` handler
- Added explanatory comment about why files aren't removed
- Added debug logging to help diagnose similar issues in the future

## Testing

Verified that:
1. Files are loaded on LSP startup ✅
2. Goto definition works for cross-file references ✅
3. Closing a file doesn't break goto definition ✅
4. Reopening a file still works ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)