### PR TITLE
refactor: Remove self-explanatory comments from codebase

### DIFF
--- a/crates/graphql-analysis/src/schema_validation.rs
+++ b/crates/graphql-analysis/src/schema_validation.rs
@@ -29,17 +29,13 @@ pub fn validate_schema_file(
     let mut builder = apollo_compiler::schema::SchemaBuilder::new();
     let mut parser = Parser::new();
 
-    // Parse the schema SDL
     parser.parse_into_schema_builder(text.as_ref(), uri.as_str(), &mut builder);
 
-    // Build and validate the schema
     match builder.build() {
         Ok(_schema) => {
-            // Schema is valid - no diagnostics
             tracing::debug!(uri = ?uri, "Schema file validated successfully");
         }
         Err(with_errors) => {
-            // Convert apollo-compiler diagnostics to our Diagnostic type
             tracing::debug!(
                 uri = ?uri,
                 error_count = with_errors.errors.len(),
@@ -51,7 +47,6 @@ pub fn validate_schema_file(
 
             #[allow(clippy::cast_possible_truncation, clippy::option_if_let_else)]
             for apollo_diag in with_errors.errors.iter() {
-                // Get location information if available
                 let range = if let Some(loc_range) = apollo_diag.line_column_range() {
                     DiagnosticRange {
                         start: Position {
@@ -70,7 +65,6 @@ pub fn validate_schema_file(
                     DiagnosticRange::default()
                 };
 
-                // Get message - apollo_diag.error is a GraphQLError which can be converted to string
                 let message: Arc<str> = Arc::from(apollo_diag.error.to_string());
 
                 diagnostics.push(Diagnostic {

--- a/crates/graphql-config/src/loader.rs
+++ b/crates/graphql-config/src/loader.rs
@@ -31,7 +31,6 @@ pub fn find_config(start_dir: &Path) -> Result<Option<PathBuf>> {
         }
 
         checked_dirs += 1;
-        // Move to parent directory
         if !current_dir.pop() {
             // Reached root without finding config
             tracing::debug!(checked_dirs, "No config file found");

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -117,7 +117,6 @@ impl Default for RootDatabase {
     }
 }
 
-// Implement the Database trait
 #[salsa::db]
 impl salsa::Database for RootDatabase {}
 
@@ -200,7 +199,6 @@ mod tests {
     #[test]
     fn test_database_creation() {
         let _db = RootDatabase::new();
-        // Database should be created successfully
     }
 
     #[test]
@@ -225,7 +223,6 @@ mod tests {
             FileKind::JavaScript,
         ];
 
-        // All kinds should be distinct
         for (i, kind1) in kinds.iter().enumerate() {
             for (j, kind2) in kinds.iter().enumerate() {
                 if i == j {
@@ -243,7 +240,6 @@ mod tests {
         let content: Arc<str> = Arc::from("type Query { hello: String }");
         let file_content = FileContent::new(&db, content);
 
-        // File content should be stored and retrievable
         assert_eq!(
             file_content.text(&db).as_ref(),
             "type Query { hello: String }"
@@ -259,7 +255,6 @@ mod tests {
 
         let metadata = FileMetadata::new(&db, file_id, uri.clone(), kind);
 
-        // Metadata should be stored and retrievable
         assert_eq!(metadata.file_id(&db), file_id);
         assert_eq!(metadata.uri(&db), uri);
         assert_eq!(metadata.kind(&db), kind);
@@ -271,17 +266,14 @@ mod tests {
         let content1: Arc<str> = Arc::from("type Query { hello: String }");
         let file_content = FileContent::new(&db, content1);
 
-        // Initial content
         assert_eq!(
             file_content.text(&db).as_ref(),
             "type Query { hello: String }"
         );
 
-        // Update content
         let content2: Arc<str> = Arc::from("type Query { world: String }");
         file_content.set_text(&mut db).to(content2);
 
-        // Content should be updated
         assert_eq!(
             file_content.text(&db).as_ref(),
             "type Query { world: String }"
@@ -303,7 +295,6 @@ mod tests {
 
         db.apply_change(change);
 
-        // Change should be applied successfully
         // Detailed verification will come with FileRegistry implementation
     }
 }

--- a/crates/graphql-introspect/src/sdl.rs
+++ b/crates/graphql-introspect/src/sdl.rs
@@ -73,7 +73,6 @@ pub fn introspection_to_sdl(introspection: &IntrospectionResponse) -> String {
         sdl.push_str("}\n\n");
     }
 
-    // Generate directives
     for directive in &schema.directives {
         // Skip built-in directives
         if directive.name == "skip"
@@ -106,7 +105,6 @@ pub fn introspection_to_sdl(introspection: &IntrospectionResponse) -> String {
         sdl.push_str("\n\n");
     }
 
-    // Generate types
     let mut types_written = 0;
     for type_def in &schema.types {
         // Skip built-in types and introspection types

--- a/crates/graphql-project/src/document.rs
+++ b/crates/graphql-project/src/document.rs
@@ -307,11 +307,9 @@ impl DocumentLoader {
     fn load_file(&self, path: &Path, index: &mut DocumentIndex) -> Result<()> {
         use std::fs;
 
-        // Read the file content
         let content = fs::read_to_string(path)
             .map_err(|e| ProjectError::DocumentLoad(format!("Failed to read file: {e}")))?;
 
-        // Parse the full content once and cache it
         let parsed = Parser::new(&content).parse();
         let parsed_arc = std::sync::Arc::new(parsed);
 
@@ -369,7 +367,6 @@ impl DocumentLoader {
         let parser = Parser::new(source);
         let tree = parser.parse();
 
-        // Skip if there are syntax errors
         if tree.errors().len() > 0 {
             return; // Silently skip invalid documents
         }
@@ -538,7 +535,6 @@ mod tests {
         let loader = DocumentLoader::new(config);
         let index = loader.load().unwrap();
 
-        // Check operation
         let get_user = index.get_operation("GetUser");
         assert!(get_user.is_some());
         assert_eq!(get_user.unwrap().operation_type, OperationType::Query);
@@ -547,7 +543,6 @@ mod tests {
         assert!(update_user.is_some());
         assert_eq!(update_user.unwrap().operation_type, OperationType::Mutation);
 
-        // Check fragment
         let user_fields = index.get_fragment("UserFields");
         assert!(user_fields.is_some());
         assert_eq!(user_fields.unwrap().type_condition, "User");
@@ -589,11 +584,9 @@ mod tests {
         let loader = DocumentLoader::new(config);
         let index = loader.load().unwrap();
 
-        // Check operation
         let get_user = index.get_operation("GetUser");
         assert!(get_user.is_some());
 
-        // Check fragment
         let user_info = index.get_fragment("UserInfo");
         assert!(user_info.is_some());
     }

--- a/crates/graphql-project/src/index.rs
+++ b/crates/graphql-project/src/index.rs
@@ -22,7 +22,6 @@ impl Default for SchemaIndex {
 impl SchemaIndex {
     #[must_use]
     pub fn new() -> Self {
-        // Create an empty schema
         let schema = Schema::parse("", "schema.graphql").unwrap_or_else(|_| {
             Schema::parse("type Query { _: String }", "schema.graphql")
                 .expect("fallback schema should parse")
@@ -54,7 +53,6 @@ impl SchemaIndex {
             builder = builder.parse(content, path);
         }
 
-        // Build the schema
         match builder.build() {
             Ok(schema) => Self {
                 schema: Arc::new(schema),
@@ -196,17 +194,14 @@ impl SchemaIndex {
     ) -> Option<FieldDefinitionLocation> {
         use apollo_compiler::schema::ExtendedType;
 
-        // Get the type from the schema
         let extended_type = self.schema.types.get(type_name)?;
 
-        // Extract fields based on type kind
         let fields = match extended_type {
             ExtendedType::Object(obj) => &obj.fields,
             ExtendedType::Interface(iface) => &iface.fields,
             _ => return None,
         };
 
-        // Find the field
         let field_component = fields.get(field_name)?;
         let field_def = &field_component.node;
 
@@ -216,7 +211,6 @@ impl SchemaIndex {
         // Get the line/column range for the field name (not the whole field definition)
         let line_col_range = name.line_column_range(&self.schema.sources)?;
 
-        // Get the file path from the name's location
         let location = name.location()?;
         let file_id = location.file_id();
         let file_path = self
@@ -259,7 +253,6 @@ impl SchemaIndex {
     pub fn find_type_definition(&self, type_name: &str) -> Option<TypeDefinitionLocation> {
         use apollo_compiler::schema::ExtendedType;
 
-        // Get the type from the schema
         let extended_type = self.schema.types.get(type_name)?;
 
         // Get the name field from the type, which has its own location info
@@ -276,7 +269,6 @@ impl SchemaIndex {
         // Get the line/column range for the name (not the whole type definition)
         let line_col_range = name.line_column_range(&self.schema.sources)?;
 
-        // Get the file path from the name's location
         let location = name.location()?;
         let file_id = location.file_id();
         let file_path = self
@@ -1069,12 +1061,10 @@ mod tests {
 
         let index = SchemaIndex::from_schema(schema);
 
-        // Check type exists
         let user_type = index.get_type("User").expect("User type should exist");
         assert_eq!(user_type.name, "User");
         assert_eq!(user_type.kind, TypeKind::Object);
 
-        // Check fields
         let fields = index.get_fields("User").expect("User fields should exist");
         assert_eq!(fields.len(), 3);
 
@@ -1193,13 +1183,11 @@ mod tests {
             .expect("Query fields should exist");
         assert_eq!(fields.len(), 2);
 
-        // Test user field with single argument
         assert_eq!(fields[0].name, "user");
         assert_eq!(fields[0].arguments.len(), 1);
         assert_eq!(fields[0].arguments[0].name, "id");
         assert_eq!(fields[0].arguments[0].type_name, "ID!");
 
-        // Test users field with multiple arguments and default value
         assert_eq!(fields[1].name, "users");
         assert_eq!(fields[1].arguments.len(), 2);
         assert_eq!(fields[1].arguments[0].name, "limit");
@@ -1425,7 +1413,6 @@ mod tests {
 
         let index = SchemaIndex::from_schema(schema);
 
-        // Check that all types are indexed
         assert!(index.get_type("User").is_some());
         assert!(index.get_type("Node").is_some());
         assert!(index.get_type("Repository").is_some());
@@ -1433,11 +1420,9 @@ mod tests {
         assert!(index.get_type("RepositoryOrder").is_some());
         assert!(index.get_type("RepositoryOrderField").is_some());
 
-        // Check User fields
         let user_fields = index.get_fields("User").expect("User fields should exist");
         assert_eq!(user_fields.len(), 5);
 
-        // Check repositories field with arguments
         let repos_field = user_fields
             .iter()
             .find(|f| f.name == "repositories")
@@ -1445,7 +1430,6 @@ mod tests {
         assert_eq!(repos_field.arguments.len(), 3);
         assert_eq!(repos_field.type_name, "RepositoryConnection!");
 
-        // Verify input object fields
         let order_fields = index
             .get_fields("RepositoryOrder")
             .expect("RepositoryOrder fields should exist");
@@ -1501,7 +1485,6 @@ mod tests {
 
         let index = SchemaIndex::from_schema(schema);
 
-        // Check Product type
         let product = index.get_type("Product").expect("Product should exist");
         assert_eq!(product.kind, TypeKind::Object);
 
@@ -1510,7 +1493,6 @@ mod tests {
             .expect("Product fields should exist");
         assert_eq!(product_fields.len(), 6);
 
-        // Check variants field has arguments
         let variants_field = product_fields
             .iter()
             .find(|f| f.name == "variants")
@@ -1518,7 +1500,6 @@ mod tests {
         assert_eq!(variants_field.arguments.len(), 1);
         assert!(variants_field.arguments[0].default_value.is_some());
 
-        // Check Query type
         let query_fields = index
             .get_fields("Query")
             .expect("Query fields should exist");
@@ -1542,7 +1523,6 @@ mod tests {
 
         let index = SchemaIndex::from_schema(schema);
 
-        // Should return empty schema on syntax errors
         assert!(index.get_type("User").is_none());
     }
 
@@ -1552,7 +1532,6 @@ mod tests {
 
         let index = SchemaIndex::from_schema(schema);
 
-        // Empty schema won't have User type
         assert!(index.get_type("User").is_none());
     }
 
@@ -1567,7 +1546,6 @@ mod tests {
         let empty_type = index.get_type("Empty").expect("Empty type should exist");
         assert_eq!(empty_type.kind, TypeKind::Object);
 
-        // Should have no fields
         let fields = index.get_fields("Empty");
         assert!(fields.is_none() || fields.unwrap().is_empty());
     }


### PR DESCRIPTION
## Summary
- Removed self-explanatory comments that describe what code already clearly shows
- Preserved valuable comments explaining subtle behavior and architectural decisions  
- Kept important comments with IMPORTANT/NOTE prefixes about design rationale

## Files Modified
- `crates/graphql-db/src/lib.rs` - Removed test assertion comments
- `crates/graphql-project/src/document.rs` - Removed obvious operation comments
- `crates/graphql-project/src/index.rs` - Removed self-explanatory test comments
- `crates/graphql-analysis/src/schema_validation.rs` - Removed obvious parsing/validation comments
- `crates/graphql-introspect/src/sdl.rs` - Removed obvious loop comments
- `crates/graphql-config/src/loader.rs` - Removed obvious directory navigation comment

## Test Results
All tests pass (except one pre-existing failure in `test_line_offset_adjustment` which was already failing on `lsp-rearchitecture` before these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)