### PR TITLE
refactor: Move content inspection logic from LSP layer (#134)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "graphql-extract",
  "graphql-ide",
  "graphql-linter",
+ "graphql-syntax",
  "lsp-types",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp 0.31.0",

--- a/crates/graphql-lsp/Cargo.toml
+++ b/crates/graphql-lsp/Cargo.toml
@@ -19,6 +19,7 @@ graphql-linter = { path = "../graphql-linter" }
 graphql-config = { path = "../graphql-config" }
 graphql-extract = { path = "../graphql-extract" }
 graphql-ide = { path = "../graphql-ide" }
+graphql-syntax = { path = "../graphql-syntax" }
 
 # GraphQL
 apollo-compiler = { workspace = true }


### PR DESCRIPTION
## Summary

Addresses issue #134 by moving content inspection logic from the LSP layer to appropriate lower-level crates.

- Moved `content_has_schema_definitions()` to **graphql-syntax** - parses GraphQL to detect schema definitions
- Moved `determine_file_kind_from_content()` to **graphql-syntax** - determines FileKind based on path and content inspection
- Removed duplicate implementations from LSP layer (server.rs)
- Added graphql-syntax as direct dependency to graphql-lsp

The `extract_graphql_from_source()` helper remains in the LSP layer as it handles LSP-specific concerns:
- Path-based language detection
- Aggregating extracted blocks into single string
- Line offset calculation for diagnostics
- Error handling with empty string fallback

## New and Updated Tests

- `test_content_has_schema_definitions_true` - Verifies detection of schema types, interfaces, enums
- `test_content_has_schema_definitions_false` - Verifies queries/mutations/fragments are not schema
- `test_content_has_schema_definitions_mixed` - Mixed content correctly identified as schema
- `test_determine_file_kind_typescript` - .ts/.tsx files return TypeScript FileKind
- `test_determine_file_kind_javascript` - .js/.jsx files return JavaScript FileKind
- `test_determine_file_kind_schema` - .graphql with schema defs returns Schema FileKind
- `test_determine_file_kind_executable` - .graphql with operations returns ExecutableGraphQL FileKind

## API Changes

`graphql-syntax` now exports:
- `content_has_schema_definitions(content: &str) -> bool`
- `determine_file_kind_from_content(path: &str, content: &str) -> FileKind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)