### PR TITLE
refactor: Remove legacy query APIs

### DIFF
--- a/crates/graphql-analysis/src/project_lints.rs
+++ b/crates/graphql-analysis/src/project_lints.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 /// This is expensive and should only run when explicitly requested
 #[salsa::tracked]
 pub fn find_unused_fields(db: &dyn GraphQLAnalysisDatabase) -> Arc<Vec<(FieldId, Diagnostic)>> {
-    let _schema = graphql_hir::schema_types(db);
+    let project_files = db
+        .project_files()
+        .expect("project files must be set for project-wide analysis");
+    let _schema = graphql_hir::schema_types_with_project(db, project_files);
     let _operations = graphql_hir::all_operations(db);
 
     let unused = Vec::new();
@@ -32,7 +35,10 @@ pub fn find_unused_fields(db: &dyn GraphQLAnalysisDatabase) -> Arc<Vec<(FieldId,
 pub fn find_unused_fragments(
     db: &dyn GraphQLAnalysisDatabase,
 ) -> Arc<Vec<(FragmentId, Diagnostic)>> {
-    let all_fragments = graphql_hir::all_fragments(db);
+    let project_files = db
+        .project_files()
+        .expect("project files must be set for project-wide analysis");
+    let all_fragments = graphql_hir::all_fragments_with_project(db, project_files);
     let all_operations = graphql_hir::all_operations(db);
 
     // Collect all used fragments by walking operations

--- a/crates/graphql-linter/src/rules/redundant_fields.rs
+++ b/crates/graphql-linter/src/rules/redundant_fields.rs
@@ -72,7 +72,10 @@ impl StandaloneDocumentLintRule for RedundantFieldsRuleImpl {
         }
 
         // Get all fragments from the project (for cross-file resolution)
-        let all_fragments = graphql_hir::all_fragments(db);
+        let project_files = db
+            .project_files()
+            .expect("project files must be set for linting");
+        let all_fragments = graphql_hir::all_fragments_with_project(db, project_files);
 
         // Add cross-file fragments to the registry
         for (fragment_name, fragment_info) in all_fragments.iter() {

--- a/crates/graphql-linter/src/traits.rs
+++ b/crates/graphql-linter/src/traits.rs
@@ -22,7 +22,7 @@ pub trait LintRule: Send + Sync {
 ///
 /// These rules can access:
 /// - Parsed syntax tree via `graphql_syntax::parse(db, content, metadata)`
-/// - All fragments via `graphql_hir::all_fragments(db, project_files)`
+/// - All fragments via `graphql_hir::all_fragments_with_project(db, project_files)`
 ///
 /// Examples: `redundant_fields`, `operation_naming`, `no_anonymous_operations`
 pub trait StandaloneDocumentLintRule: LintRule {
@@ -41,7 +41,7 @@ pub trait StandaloneDocumentLintRule: LintRule {
 /// These rules can access:
 /// - Parsed syntax tree
 /// - All fragments
-/// - Schema types via `graphql_hir::schema_types(db, project_files)`
+/// - Schema types via `graphql_hir::schema_types_with_project(db, project_files)`
 ///
 /// Examples: `deprecated_field`, `require_id_field`
 pub trait DocumentSchemaLintRule: LintRule {


### PR DESCRIPTION
## Summary

Removes duplicate "legacy" query APIs and consolidates on a single consistent interface using explicit ProjectFiles parameters.

## Changes Made

### Removed Functions
- `schema_types(db)` - Replaced with `schema_types_with_project(db, project_files)`
- `all_fragments(db)` - Replaced with `all_fragments_with_project(db, project_files)`

### Updated Call Sites
- **crates/graphql-analysis/src/document_validation.rs**: Updated to use explicit ProjectFiles
- **crates/graphql-analysis/src/project_lints.rs**: Updated both `find_unused_fields` and `find_unused_fragments`
- **crates/graphql-linter/src/rules/redundant_fields.rs**: Updated fragment resolution
- **crates/graphql-linter/src/traits.rs**: Updated documentation examples
- **crates/graphql-hir/src/lib.rs**: Removed legacy functions and updated tests

### Test Improvements
- Enhanced `TestDatabase` in document_validation tests to properly support ProjectFiles
- All tests now properly initialize project files before validation

## Rationale

**Why explicit ProjectFiles is better:**
1. **Explicit is better than implicit** - No hidden trait method magic
2. **Easier to test** - Pass ProjectFiles directly instead of setting up database state
3. **More flexible** - Can query different projects without mutating database
4. **Aligns with Salsa best practices** - Explicit dependencies are tracked properly
5. **No "legacy" code at v0.1.1** - Clean architecture from the start

## Test Plan

- [x] All tests pass (`cargo test`)
- [x] No compiler errors
- [x] Confirmed no references to removed functions (`rg "schema_types\(" "all_fragments\("`)
- [x] All call sites updated to use explicit versions
- [x] Documentation updated

## Verification

```bash
# Verify no legacy function references remain
rg "schema_types\(" crates/ --type rust | grep -v "schema_types_with_project"
# (should return nothing)

rg "all_fragments\(" crates/ --type rust | grep -v "all_fragments_with_project"  
# (should return nothing)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>