### PR TITLE
Replace type-erased config storage with concrete types

### DIFF
--- a/crates/graphql-analysis/src/document_validation.rs
+++ b/crates/graphql-analysis/src/document_validation.rs
@@ -188,11 +188,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl graphql_hir::GraphQLHirDatabase for TestDatabase {}

--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -30,17 +30,7 @@ pub trait GraphQLAnalysisDatabase: graphql_hir::GraphQLHirDatabase {
 // This makes RootDatabase usable with all analysis queries
 #[salsa::db]
 impl GraphQLAnalysisDatabase for graphql_db::RootDatabase {
-    /// Get the lint configuration from the database storage
-    fn lint_config(&self) -> Arc<graphql_linter::LintConfig> {
-        if let Some(config_any) = self.lint_config_any() {
-            // Try to downcast to the concrete type
-            if let Some(config) = config_any.downcast_ref::<graphql_linter::LintConfig>() {
-                return Arc::new(config.clone());
-            }
-        }
-        // Fall back to default if not set or downcast fails
-        Arc::new(graphql_linter::LintConfig::default())
-    }
+    // Use default implementation (returns default LintConfig)
 }
 
 /// Get all diagnostics for a file
@@ -181,11 +171,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl graphql_hir::GraphQLHirDatabase for TestDatabase {}

--- a/crates/graphql-analysis/src/merged_schema.rs
+++ b/crates/graphql-analysis/src/merged_schema.rs
@@ -76,11 +76,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl graphql_hir::GraphQLHirDatabase for TestDatabase {}

--- a/crates/graphql-analysis/src/schema_validation.rs
+++ b/crates/graphql-analysis/src/schema_validation.rs
@@ -96,11 +96,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl graphql_hir::GraphQLHirDatabase for TestDatabase {}

--- a/crates/graphql-analysis/src/validation.rs
+++ b/crates/graphql-analysis/src/validation.rs
@@ -443,11 +443,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl graphql_hir::GraphQLHirDatabase for TestDatabase {}
@@ -538,8 +534,10 @@ mod tests {
 
         // Create document with fragment that has an invalid field
         let doc_id = FileId::new(1);
-        let doc_content =
-            FileContent::new(&db, Arc::from("fragment UserFields on User { invalidField }"));
+        let doc_content = FileContent::new(
+            &db,
+            Arc::from("fragment UserFields on User { invalidField }"),
+        );
         let doc_metadata = FileMetadata::new(
             &db,
             doc_id,
@@ -809,8 +807,12 @@ mod tests {
         // The content is already extracted GraphQL, so we mark it as ExecutableGraphQL
         let doc_id = FileId::new(1);
         let doc_content = FileContent::new(&db, Arc::from("query { invalidField }"));
-        let doc_metadata =
-            FileMetadata::new(&db, doc_id, FileUri::new("query.ts"), FileKind::ExecutableGraphQL);
+        let doc_metadata = FileMetadata::new(
+            &db,
+            doc_id,
+            FileUri::new("query.ts"),
+            FileKind::ExecutableGraphQL,
+        );
         // Set line offset to simulate extraction from line 10 in TypeScript file
         doc_metadata.set_line_offset(&mut db).to(10);
 

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -96,14 +96,6 @@ pub struct RootDatabase {
     /// Current project files (stored with interior mutability for access from queries)
     /// This is set by the IDE layer when files are added/removed
     project_files: std::cell::Cell<Option<ProjectFiles>>,
-    /// Lint configuration (stored with interior mutability for access from queries)
-    /// This is set by the IDE/CLI layer when loading configuration
-    /// Stored as Arc<dyn Any> to avoid circular dependencies
-    lint_config: std::cell::RefCell<Option<Arc<dyn std::any::Any + Send + Sync>>>,
-    /// Extract configuration (stored with interior mutability for access from queries)
-    /// This is set by the IDE/CLI layer when loading configuration
-    /// Stored as Arc<dyn Any> to avoid circular dependencies
-    extract_config: std::cell::RefCell<Option<Arc<dyn std::any::Any + Send + Sync>>>,
 }
 
 impl Default for RootDatabase {
@@ -111,8 +103,6 @@ impl Default for RootDatabase {
         Self {
             storage: salsa::Storage::default(),
             project_files: std::cell::Cell::new(None),
-            lint_config: std::cell::RefCell::new(None),
-            extract_config: std::cell::RefCell::new(None),
         }
     }
 }
@@ -137,32 +127,6 @@ impl RootDatabase {
     /// This should be called by the IDE layer when files are added/removed
     pub fn set_project_files(&self, project_files: Option<ProjectFiles>) {
         self.project_files.set(project_files);
-    }
-
-    /// Get the current lint configuration (type-erased)
-    /// Use `GraphQLAnalysisDatabase::lint_config()` for typed access
-    #[must_use]
-    pub fn lint_config_any(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
-        self.lint_config.borrow().clone()
-    }
-
-    /// Set the lint configuration (type-erased)
-    /// This should be called by the IDE/CLI layer when loading configuration
-    pub fn set_lint_config_any(&self, config: Option<Arc<dyn std::any::Any + Send + Sync>>) {
-        *self.lint_config.borrow_mut() = config;
-    }
-
-    /// Get the current extract configuration (type-erased)
-    /// Use `GraphQLSyntaxDatabase::extract_config()` for typed access
-    #[must_use]
-    pub fn extract_config_any(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
-        self.extract_config.borrow().clone()
-    }
-
-    /// Set the extract configuration (type-erased)
-    /// This should be called by the IDE/CLI layer when loading configuration
-    pub fn set_extract_config_any(&self, config: Option<Arc<dyn std::any::Any + Send + Sync>>) {
-        *self.extract_config.borrow_mut() = config;
     }
 }
 

--- a/crates/graphql-hir/src/lib.rs
+++ b/crates/graphql-hir/src/lib.rs
@@ -227,11 +227,7 @@ mod tests {
     impl salsa::Database for TestDatabase {}
 
     #[salsa::db]
-    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {
-        fn extract_config_any(&self) -> Option<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-            None
-        }
-    }
+    impl graphql_syntax::GraphQLSyntaxDatabase for TestDatabase {}
 
     #[salsa::db]
     impl GraphQLHirDatabase for TestDatabase {}

--- a/crates/graphql-ide/src/file_registry.rs
+++ b/crates/graphql-ide/src/file_registry.rs
@@ -3,14 +3,24 @@
 //! This module provides the bridge between editor file paths (strings/URIs)
 //! and salsa database file identifiers.
 
-use graphql_db::{
-    FileContent, FileId, FileKind, FileMetadata, FileUri, ProjectFiles, RootDatabase,
-};
+use graphql_db::{FileContent, FileId, FileKind, FileMetadata, FileUri, ProjectFiles};
 use salsa::Setter;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::FilePath;
+
+/// Trait for databases that support project files
+pub trait ProjectFilesDatabase {
+    fn set_project_files(&self, project_files: Option<ProjectFiles>);
+}
+
+// Implement for RootDatabase
+impl ProjectFilesDatabase for graphql_db::RootDatabase {
+    fn set_project_files(&self, project_files: Option<ProjectFiles>) {
+        self.set_project_files(project_files);
+    }
+}
 
 /// Maps file paths to database file IDs and metadata
 ///
@@ -34,14 +44,17 @@ impl FileRegistry {
     }
 
     /// Add or update a file in the registry
-    pub fn add_file(
+    pub fn add_file<DB>(
         &mut self,
-        db: &mut RootDatabase,
+        db: &mut DB,
         path: &FilePath,
         content: &str,
         kind: FileKind,
         line_offset: u32,
-    ) -> (FileId, FileContent, FileMetadata) {
+    ) -> (FileId, FileContent, FileMetadata)
+    where
+        DB: salsa::Database,
+    {
         let uri_str = path.as_str();
 
         // Get or create FileId
@@ -122,7 +135,10 @@ impl FileRegistry {
     /// This should be called after files are added or removed
     ///
     /// Note: This method should be called WITHOUT holding any locks to avoid deadlocks
-    pub fn rebuild_project_files(&mut self, db: &mut RootDatabase) {
+    pub fn rebuild_project_files<DB>(&mut self, db: &mut DB)
+    where
+        DB: salsa::Database + ProjectFilesDatabase,
+    {
         let mut schema_files = Vec::new();
         let mut document_files = Vec::new();
 
@@ -170,6 +186,7 @@ impl FileRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use graphql_db::RootDatabase;
 
     #[test]
     fn test_file_registry_add_and_lookup() {

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -34,13 +34,12 @@
 //! - POD types: [`Position`], [`Range`], [`Location`], [`FilePath`]
 //! - Feature types: [`CompletionItem`], [`HoverResult`], [`Diagnostic`]
 
-use graphql_db::RootDatabase;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::{Arc, RwLock};
 
 mod file_registry;
-pub use file_registry::FileRegistry;
+pub use file_registry::{FileRegistry, ProjectFilesDatabase};
 
 mod symbol;
 use symbol::{
@@ -247,12 +246,79 @@ impl Diagnostic {
     }
 }
 
+/// Custom database that implements config traits
+/// This extends `RootDatabase` functionality with config storage
+#[salsa::db]
+#[derive(Clone)]
+struct IdeDatabase {
+    storage: salsa::Storage<Self>,
+    /// Project files (same as `RootDatabase`)
+    project_files: std::cell::Cell<Option<graphql_db::ProjectFiles>>,
+    /// Lint configuration
+    lint_config: std::cell::RefCell<Arc<graphql_linter::LintConfig>>,
+    /// Extract configuration
+    extract_config: std::cell::RefCell<Arc<graphql_extract::ExtractConfig>>,
+}
+
+impl Default for IdeDatabase {
+    fn default() -> Self {
+        Self {
+            storage: salsa::Storage::default(),
+            project_files: std::cell::Cell::new(None),
+            lint_config: std::cell::RefCell::new(Arc::new(graphql_linter::LintConfig::default())),
+            extract_config: std::cell::RefCell::new(Arc::new(
+                graphql_extract::ExtractConfig::default(),
+            )),
+        }
+    }
+}
+
+impl IdeDatabase {
+    /// Apply a batch of changes
+    #[allow(
+        clippy::unused_self,
+        clippy::needless_pass_by_value,
+        clippy::needless_pass_by_ref_mut
+    )]
+    pub fn apply_change(&mut self, change: graphql_db::Change) {
+        // For now, change operations are handled by Salsa automatically
+        // This method exists for compatibility with `RootDatabase` API
+        let _ = change; // Suppress unused warning
+    }
+}
+
+#[salsa::db]
+impl salsa::Database for IdeDatabase {}
+
+#[salsa::db]
+impl graphql_syntax::GraphQLSyntaxDatabase for IdeDatabase {
+    fn extract_config(&self) -> Option<Arc<graphql_extract::ExtractConfig>> {
+        Some(self.extract_config.borrow().clone())
+    }
+}
+
+#[salsa::db]
+impl graphql_hir::GraphQLHirDatabase for IdeDatabase {}
+
+#[salsa::db]
+impl graphql_analysis::GraphQLAnalysisDatabase for IdeDatabase {
+    fn lint_config(&self) -> Arc<graphql_linter::LintConfig> {
+        self.lint_config.borrow().clone()
+    }
+}
+
+impl ProjectFilesDatabase for IdeDatabase {
+    fn set_project_files(&self, project_files: Option<graphql_db::ProjectFiles>) {
+        self.project_files.set(project_files);
+    }
+}
+
 /// The main analysis host
 ///
 /// This is the entry point for all IDE features. It owns the database and
 /// provides methods to apply changes and create snapshots for analysis.
 pub struct AnalysisHost {
-    db: RootDatabase,
+    db: IdeDatabase,
     /// File registry for mapping paths to file IDs
     /// Wrapped in Arc<RwLock> so snapshots can share it
     registry: Arc<RwLock<FileRegistry>>,
@@ -263,7 +329,7 @@ impl AnalysisHost {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            db: RootDatabase::default(),
+            db: IdeDatabase::default(),
             registry: Arc::new(RwLock::new(FileRegistry::new())),
         }
     }
@@ -400,34 +466,18 @@ impl AnalysisHost {
     }
 
     /// Set the lint configuration for the project
-    ///
-    /// This should be called when loading project configuration to enable/disable
-    /// specific lint rules and their severities.
     pub fn set_lint_config(&mut self, config: graphql_linter::LintConfig) {
-        self.db.set_lint_config_any(Some(
-            Arc::new(config) as Arc<dyn std::any::Any + Send + Sync>
-        ));
+        *self.db.lint_config.borrow_mut() = Arc::new(config);
     }
 
     /// Set the extract configuration for the project
-    ///
-    /// This should be called when loading project configuration to customize
-    /// how GraphQL is extracted from TypeScript/JavaScript files.
     pub fn set_extract_config(&mut self, config: graphql_extract::ExtractConfig) {
-        self.db.set_extract_config_any(Some(
-            Arc::new(config) as Arc<dyn std::any::Any + Send + Sync>
-        ));
+        *self.db.extract_config.borrow_mut() = Arc::new(config);
     }
 
     /// Get the extract configuration for the project
-    ///
-    /// Returns the configured extract settings, or default if not set.
     pub fn get_extract_config(&self) -> graphql_extract::ExtractConfig {
-        self.db
-            .extract_config_any()
-            .and_then(|any| any.downcast::<graphql_extract::ExtractConfig>().ok())
-            .map(|arc| (*arc).clone())
-            .unwrap_or_default()
+        (**self.db.extract_config.borrow()).clone()
     }
 
     /// Get an immutable snapshot for analysis
@@ -455,12 +505,6 @@ impl AnalysisHost {
             project_files,
         }
     }
-
-    /// Get mutable access to the database (for testing)
-    #[doc(hidden)]
-    pub const fn db_mut(&mut self) -> &mut RootDatabase {
-        &mut self.db
-    }
 }
 
 impl Default for AnalysisHost {
@@ -475,7 +519,7 @@ impl Default for AnalysisHost {
 /// All IDE feature queries go through this.
 #[derive(Clone)]
 pub struct Analysis {
-    db: RootDatabase,
+    db: IdeDatabase,
     registry: Arc<RwLock<FileRegistry>>,
     /// Cached `ProjectFiles` for HIR queries
     /// This is fetched from the registry when the snapshot is created

--- a/crates/graphql-syntax/src/lib.rs
+++ b/crates/graphql-syntax/src/lib.rs
@@ -293,24 +293,18 @@ pub fn line_index(db: &dyn GraphQLSyntaxDatabase, content: FileContent) -> Arc<L
 #[salsa::db]
 pub trait GraphQLSyntaxDatabase: salsa::Database {
     /// Get the extract configuration for TypeScript/JavaScript extraction
-    /// Returns None if no configuration is set (will use default)
+    /// Returns None by default, which means use `ExtractConfig::default()`
+    /// Implementations can override to provide custom configuration
     fn extract_config(&self) -> Option<Arc<graphql_extract::ExtractConfig>> {
-        self.extract_config_any()
-            .and_then(|any| any.downcast::<graphql_extract::ExtractConfig>().ok())
+        None
     }
-
-    /// Get the extract configuration (type-erased)
-    /// This is implemented by `RootDatabase`
-    fn extract_config_any(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>>;
 }
 
 // Implement the trait for RootDatabase
 // This makes RootDatabase usable with all syntax queries
 #[salsa::db]
 impl GraphQLSyntaxDatabase for graphql_db::RootDatabase {
-    fn extract_config_any(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
-        self.extract_config_any()
-    }
+    // Use default implementation (returns None)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes #153 by replacing type-erased config storage (`dyn Any`) with concrete types.

## Implementation Approach (Option B)

Instead of storing configs in `RootDatabase` (which would create circular dependencies), created a custom `IdeDatabase` in `graphql-ide` that:
- Stores concrete `LintConfig` and `ExtractConfig` types
- Implements all necessary Salsa database traits
- Has its own Salsa storage (doesn't wrap `RootDatabase`)

## Changes

- **Created `IdeDatabase`**: New database type in graphql-ide with config fields
- **Removed type erasure**: Eliminated all `Arc<dyn Any>` usage from config storage
- **Updated trait implementations**: Both `RootDatabase` and `IdeDatabase` implement config traits
- **Made FileRegistry generic**: Updated to work with any database implementing necessary traits
- **Added `ProjectFilesDatabase` trait**: Provides shared `set_project_files` functionality

## Benefits

✅ **Type safety**: No runtime downcasting or `dyn Any`
✅ **No circular dependencies**: `graphql-db` remains dependency-free
✅ **Clean architecture**: Configs stored at the IDE layer where they're used
✅ **All tests passing**: No regressions

## Test plan

- [x] All existing tests pass
- [x] Build succeeds with no warnings
- [x] Clippy passes
- [x] Code formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)