### PR TITLE
test: Fix ignored and failing tests

### DIFF
--- a/crates/graphql-analysis/src/document_validation.rs
+++ b/crates/graphql-analysis/src/document_validation.rs
@@ -253,7 +253,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires multi-file HIR setup"]
     fn test_variable_invalid_input_type() {
         let db = TestDatabase::default();
 
@@ -268,9 +267,6 @@ mod tests {
             FileKind::Schema,
         );
 
-        // Parse schema to populate HIR
-        let _ = graphql_hir::file_structure(&db, schema_file_id, schema_fc, schema_metadata);
-
         // Now test document with invalid variable type
         let doc_file_id = graphql_db::FileId::new(1);
         let doc_content = "query GetUser($user: User!) { user }";
@@ -281,6 +277,14 @@ mod tests {
             FileUri::new("query.graphql"),
             FileKind::ExecutableGraphQL,
         );
+
+        // Set up project files with schema and document
+        let project_files = graphql_db::ProjectFiles::new(
+            &db,
+            Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+            Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
+        );
+        db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
 
@@ -327,7 +331,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires multi-file HIR setup"]
     fn test_fragment_invalid_type_condition() {
         let db = TestDatabase::default();
 
@@ -341,7 +344,6 @@ mod tests {
             FileUri::new("schema.graphql"),
             FileKind::Schema,
         );
-        let _ = graphql_hir::file_structure(&db, schema_file_id, schema_fc, schema_metadata);
 
         // Fragment on scalar (invalid)
         let doc_file_id = graphql_db::FileId::new(1);
@@ -353,6 +355,14 @@ mod tests {
             FileUri::new("fragment.graphql"),
             FileKind::ExecutableGraphQL,
         );
+
+        // Set up project files with schema and document
+        let project_files = graphql_db::ProjectFiles::new(
+            &db,
+            Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+            Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
+        );
+        db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
 
@@ -400,7 +410,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Requires multi-file HIR setup"]
     fn test_valid_document() {
         let db = TestDatabase::default();
 
@@ -418,7 +427,6 @@ mod tests {
             FileUri::new("schema.graphql"),
             FileKind::Schema,
         );
-        let _ = graphql_hir::file_structure(&db, schema_file_id, schema_fc, schema_metadata);
 
         // Valid query
         let doc_file_id = graphql_db::FileId::new(1);
@@ -435,6 +443,14 @@ mod tests {
             FileUri::new("query.graphql"),
             FileKind::ExecutableGraphQL,
         );
+
+        // Set up project files with schema and document
+        let project_files = graphql_db::ProjectFiles::new(
+            &db,
+            Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+            Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
+        );
+        db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
 


### PR DESCRIPTION
## Summary

Fixes 3 ignored tests in `document_validation.rs` by properly setting up multi-file test infrastructure with `ProjectFiles`.

## Changes Made

### Fixed Tests (3)
- `test_variable_invalid_input_type` - Now properly registers schema and document in ProjectFiles
- `test_fragment_invalid_type_condition` - Added ProjectFiles setup for schema+document validation
- `test_valid_document` - Enabled with proper multi-file setup

### Test Infrastructure
- Added `ProjectFiles` initialization to multi-file tests
- Tests now correctly set up both schema files and document files
- Database properly tracks project state for validation queries

## Test Results

**Before**: 30 passed, **9 ignored** in graphql-analysis
**After**: 33 passed, **6 ignored** in graphql-analysis

## Remaining Ignored Tests (Legitimate)

### Schema Validation (6 tests)
These tests are ignored because they document known limitations of apollo-compiler's SchemaBuilder:

- `test_unknown_field_type` - Single-file validation doesn't catch unknown types
- `test_interface_implementation_missing_field` - Requires merged schema validation
- `test_interface_implementation_wrong_type` - Requires merged schema validation  
- `test_union_non_object_member` - Apollo SchemaBuilder is lenient
- `test_union_unknown_member` - Apollo SchemaBuilder is lenient
- `test_input_object_invalid_field_type` - Apollo SchemaBuilder is lenient

These tests document expected behavior that would require changes to the validation strategy (switching away from apollo-compiler or adding additional validation layers).

### IDE Test (1 test)
- `test_diagnostics_after_file_update` - Known Salsa update hang when modifying files

This is a known issue that needs investigation separately.

## Test Plan

- [x] All 3 fixed tests now pass
- [x] No regressions in other tests
- [x] Total test count: 153 passed, 7 ignored (down from 10 ignored)
- [x] Remaining ignored tests have legitimate reasons documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>