### PR TITLE
fix: Enable linting in CLI and add redundant_fields to recommended

### DIFF
--- a/crates/graphql-cli/src/analysis.rs
+++ b/crates/graphql-cli/src/analysis.rs
@@ -110,11 +110,13 @@ impl CliAnalysisHost {
                     &FilePath::new(path.to_string_lossy().to_string()),
                     &content,
                     kind,
-                    0, // No line offset for pure GraphQL files from disk
+                    0,
                 );
                 loaded_files.push(path);
             }
         }
+
+        host.rebuild_project_files();
 
         Ok(Self {
             host,

--- a/crates/graphql-linter/src/config.rs
+++ b/crates/graphql-linter/src/config.rs
@@ -134,6 +134,7 @@ impl LintConfig {
         match rule_name {
             "unique_names" | "no_anonymous_operations" => Some(LintSeverity::Error),
             "no_deprecated"
+            | "redundant_fields"
             | "field_names_should_be_camel_case"
             | "type_names_should_be_pascal_case"
             | "enum_values_should_be_screaming_snake_case" => Some(LintSeverity::Warn),

--- a/test-workspace/.graphqlrc.yaml
+++ b/test-workspace/.graphqlrc.yaml
@@ -5,7 +5,7 @@ projects:
     documents: "pokemon/src/**/*.{graphql,gql,ts,tsx,js,jsx}"
 
     lint:
-      recommended: error2
+      recommended: error
 
   starwars:
     schema: starwars/schema.graphql


### PR DESCRIPTION
## Summary

- Call `rebuild_project_files()` in `CliAnalysisHost` after loading files (was missing, causing `project_files` to be None and all lints to be skipped)
- Add `redundant_fields` rule to recommended preset as a warning
- Fix test-workspace config typo (`error2` -> `error`)

## Test plan

- [x] `graphql --project pokemon lint` now detects duplicate field selections
- [x] LSP shows lint diagnostics for redundant fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)