### PR TITLE
feat: add SessionStart hook to install gh CLI

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web remote environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Check if gh is already installed
+if command -v gh &> /dev/null; then
+  echo "✓ gh CLI already installed: $(gh --version | head -1)"
+  exit 0
+fi
+
+echo "Installing gh CLI..."
+
+# Install gh from default Ubuntu repositories
+# gh is available in Ubuntu 24.04 default repos
+sudo apt-get update && sudo apt-get install -y gh
+
+echo "✓ gh CLI installed successfully: $(gh --version | head -1)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash(git commit:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 !.claude/commands.json
 !.claude/settings.json
 !.claude/CLAUDE.md
+!.claude/hooks/


### PR DESCRIPTION
Add a session-start hook that automatically installs the GitHub CLI (gh) when running in Claude Code on the web remote environments.

Changes:
- Created .claude/hooks/session-start.sh script that:
  - Only runs in Claude Code remote environments (CLAUDE_CODE_REMOTE=true)
  - Checks if gh is already installed (idempotent)
  - Installs gh from Ubuntu default repositories
  - Provides clear status messages
- Registered SessionStart hook in .claude/settings.json
- Updated .gitignore to include .claude/hooks/ directory

The hook runs synchronously to ensure gh is available before the session starts, preventing race conditions where Claude might try to use gh before it's installed.

Once this is merged to the default branch, all future remote sessions will automatically have gh CLI available.