### PR TITLE
perf: separate schema and document file tracking

### DIFF
--- a/benches/benches/incremental_computation.rs
+++ b/benches/benches/incremental_computation.rs
@@ -84,11 +84,11 @@ fn create_project_files(db: &RootDatabase) -> ProjectFiles {
         FileKind::ExecutableGraphQL,
     );
 
-    ProjectFiles::new(
-        db,
-        Arc::new(vec![(schema_id, schema_content, schema_meta)]),
-        Arc::new(vec![(doc_id, doc_content, doc_meta)]),
-    )
+    let schema_files =
+        graphql_db::SchemaFiles::new(db, Arc::new(vec![(schema_id, schema_content, schema_meta)]));
+    let document_files =
+        graphql_db::DocumentFiles::new(db, Arc::new(vec![(doc_id, doc_content, doc_meta)]));
+    ProjectFiles::new(db, schema_files, document_files)
 }
 
 /// Parse benchmarks
@@ -198,11 +198,15 @@ fn bench_golden_invariant(c: &mut Criterion) {
                     FileKind::ExecutableGraphQL,
                 );
 
-                let project_files = ProjectFiles::new(
+                let schema_files = graphql_db::SchemaFiles::new(
                     &db,
                     Arc::new(vec![(schema_id, schema_content, schema_meta)]),
+                );
+                let document_files = graphql_db::DocumentFiles::new(
+                    &db,
                     Arc::new(vec![(doc_id, doc_content, doc_meta)]),
                 );
+                let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
                 // Cache schema types
                 let _ = graphql_hir::schema_types_with_project(&db, project_files);
@@ -261,11 +265,15 @@ fn bench_fragment_resolution_cold(c: &mut Criterion) {
                     FileKind::ExecutableGraphQL,
                 );
 
-                let project_files = ProjectFiles::new(
+                let schema_files = graphql_db::SchemaFiles::new(
                     &db,
                     Arc::new(vec![(schema_id, schema_content, schema_meta)]),
+                );
+                let document_files = graphql_db::DocumentFiles::new(
+                    &db,
                     Arc::new(vec![(doc_id, doc_content, doc_meta)]),
                 );
+                let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
                 (db, project_files)
             },
@@ -301,11 +309,13 @@ fn bench_fragment_resolution_warm(c: &mut Criterion) {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_meta)]),
-            Arc::new(vec![(doc_id, doc_content, doc_meta)]),
         );
+        let document_files =
+            graphql_db::DocumentFiles::new(&db, Arc::new(vec![(doc_id, doc_content, doc_meta)]));
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let _ = graphql_hir::all_fragments_with_project(&db, project_files);
 

--- a/crates/graphql-analysis/src/document_validation.rs
+++ b/crates/graphql-analysis/src/document_validation.rs
@@ -234,11 +234,10 @@ mod tests {
         );
 
         // Set up project files
-        let project_files = graphql_db::ProjectFiles::new(
-            &db,
-            Arc::new(Vec::new()), // No schema files
-            Arc::new(vec![(file_id, content, metadata)]),
-        );
+        let schema_files = graphql_db::SchemaFiles::new(&db, Arc::new(Vec::new()));
+        let document_files =
+            graphql_db::DocumentFiles::new(&db, Arc::new(vec![(file_id, content, metadata)]));
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, content, metadata);
@@ -279,11 +278,15 @@ mod tests {
         );
 
         // Set up project files with schema and document
-        let project_files = graphql_db::ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
         );
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
@@ -312,11 +315,10 @@ mod tests {
         );
 
         // Set up project files
-        let project_files = graphql_db::ProjectFiles::new(
-            &db,
-            Arc::new(Vec::new()), // No schema files
-            Arc::new(vec![(file_id, content, metadata)]),
-        );
+        let schema_files = graphql_db::SchemaFiles::new(&db, Arc::new(Vec::new()));
+        let document_files =
+            graphql_db::DocumentFiles::new(&db, Arc::new(vec![(file_id, content, metadata)]));
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, content, metadata);
@@ -357,11 +359,15 @@ mod tests {
         );
 
         // Set up project files with schema and document
-        let project_files = graphql_db::ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
         );
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
@@ -391,11 +397,10 @@ mod tests {
         );
 
         // Set up project files
-        let project_files = graphql_db::ProjectFiles::new(
-            &db,
-            Arc::new(Vec::new()), // No schema files
-            Arc::new(vec![(file_id, content, metadata)]),
-        );
+        let schema_files = graphql_db::SchemaFiles::new(&db, Arc::new(Vec::new()));
+        let document_files =
+            graphql_db::DocumentFiles::new(&db, Arc::new(vec![(file_id, content, metadata)]));
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, content, metadata);
@@ -445,11 +450,15 @@ mod tests {
         );
 
         // Set up project files with schema and document
-        let project_files = graphql_db::ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_file_id, schema_fc, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_file_id, doc_fc, doc_metadata)]),
         );
+        let project_files = graphql_db::ProjectFiles::new(&db, schema_files, document_files);
         db.set_project_files(Some(project_files));
 
         let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);

--- a/crates/graphql-analysis/src/lint_integration.rs
+++ b/crates/graphql-analysis/src/lint_integration.rs
@@ -326,14 +326,16 @@ fn find_file_content_and_metadata(
     file_id: FileId,
 ) -> Option<(FileContent, FileMetadata)> {
     // Search in document files
-    for (fid, content, metadata) in project_files.document_files(db).iter() {
+    let document_files = project_files.document_files(db).files(db);
+    for (fid, content, metadata) in document_files.iter() {
         if *fid == file_id {
             return Some((*content, *metadata));
         }
     }
 
     // Search in schema files
-    for (fid, content, metadata) in project_files.schema_files(db).iter() {
+    let schema_files = project_files.schema_files(db).files(db);
+    for (fid, content, metadata) in schema_files.iter() {
         if *fid == file_id {
             return Some((*content, *metadata));
         }

--- a/crates/graphql-analysis/src/project_lints.rs
+++ b/crates/graphql-analysis/src/project_lints.rs
@@ -36,7 +36,8 @@ pub fn find_unused_fragments(
         .project_files()
         .expect("project files must be set for project-wide analysis");
     let all_fragments = graphql_hir::all_fragments_with_project(db, project_files);
-    let document_files = project_files.document_files(db);
+    let document_files_input = project_files.document_files(db);
+    let document_files = document_files_input.files(db);
 
     let mut used_fragments = HashSet::new();
 

--- a/crates/graphql-analysis/src/validation.rs
+++ b/crates/graphql-analysis/src/validation.rs
@@ -349,7 +349,9 @@ mod tests {
         );
 
         // Empty project files (no schema)
-        let project_files = ProjectFiles::new(&db, Arc::new(vec![]), Arc::new(vec![]));
+        let schema_files = graphql_db::SchemaFiles::new(&db, Arc::new(vec![]));
+        let document_files = graphql_db::DocumentFiles::new(&db, Arc::new(vec![]));
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, content, metadata, project_files);
         assert_eq!(
@@ -387,11 +389,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert_eq!(
@@ -429,11 +435,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert!(
@@ -472,11 +482,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert!(
@@ -515,11 +529,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert_eq!(
@@ -554,11 +572,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert!(
@@ -597,11 +619,15 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert!(
@@ -654,14 +680,18 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![
                 (frag_id, frag_content, frag_metadata),
                 (query_id, query_content, query_metadata),
             ]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         // Validate the query - it should find the fragment from the other file
         let diagnostics = validate_document(&db, query_content, query_metadata, project_files);
@@ -700,11 +730,15 @@ mod tests {
         // Set line offset to simulate extraction from line 10 in TypeScript file
         doc_metadata.set_line_offset(&mut db).to(10);
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             &db,
             Arc::new(vec![(schema_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            &db,
             Arc::new(vec![(doc_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let diagnostics = validate_document(&db, doc_content, doc_metadata, project_files);
         assert!(!diagnostics.is_empty(), "Expected validation errors");

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -76,15 +76,38 @@ pub struct FileMetadata {
     pub line_offset: u32,
 }
 
+/// Input: Schema file list
+/// Tracks which schema files are in the project
+/// This is a separate input from DocumentFiles to enable fine-grained invalidation:
+/// changing document files won't invalidate queries that only depend on schema files
+#[salsa::input]
+pub struct SchemaFiles {
+    /// List of schema files with their content and metadata
+    pub files: Arc<Vec<(FileId, FileContent, FileMetadata)>>,
+}
+
+/// Input: Document file list
+/// Tracks which document files (operations/fragments) are in the project
+/// This is a separate input from SchemaFiles to enable fine-grained invalidation:
+/// changing schema files won't invalidate queries that only depend on document files
+#[salsa::input]
+pub struct DocumentFiles {
+    /// List of document files with their content and metadata
+    pub files: Arc<Vec<(FileId, FileContent, FileMetadata)>>,
+}
+
 /// Input: Project file lists
 /// Tracks which files are in the project, categorized by kind
 /// This is updated by the IDE layer when files are added/removed
+///
+/// Note: This struct now just holds references to the separate SchemaFiles and DocumentFiles
+/// inputs. Queries should prefer using the specific input they need to minimize invalidation scope.
 #[salsa::input]
 pub struct ProjectFiles {
-    /// List of schema files with their content and metadata
-    pub schema_files: Arc<Vec<(FileId, FileContent, FileMetadata)>>,
-    /// List of document files with their content and metadata
-    pub document_files: Arc<Vec<(FileId, FileContent, FileMetadata)>>,
+    /// Schema files input
+    pub schema_files: SchemaFiles,
+    /// Document files input
+    pub document_files: DocumentFiles,
 }
 
 /// The root salsa database

--- a/crates/graphql-hir/src/body.rs
+++ b/crates/graphql-hir/src/body.rs
@@ -176,7 +176,8 @@ pub fn operation_transitive_fragments(
         // Look up the fragment and get its body
         if all_fragments.contains_key(&frag_name) {
             // Find the fragment's file content and metadata
-            let document_files = project_files.document_files(db);
+            let document_files_input = project_files.document_files(db);
+            let document_files = document_files_input.files(db);
             for (_, content, metadata) in document_files.iter() {
                 let frag_body = fragment_body(db, *content, *metadata, frag_name.clone());
 
@@ -528,11 +529,10 @@ mod tests {
             FileKind::ExecutableGraphQL,
         );
 
-        let project_files = ProjectFiles::new(
-            &db,
-            Arc::new(Vec::new()),
-            Arc::new(vec![(file_id, content, metadata)]),
-        );
+        let schema_files = graphql_db::SchemaFiles::new(&db, Arc::new(Vec::new()));
+        let document_files =
+            graphql_db::DocumentFiles::new(&db, Arc::new(vec![(file_id, content, metadata)]));
+        let project_files = ProjectFiles::new(&db, schema_files, document_files);
 
         let transitive = operation_transitive_fragments(&db, content, metadata, 0, project_files);
 

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -605,8 +605,8 @@ impl AnalysisHost {
         let project_files = self.registry.read().unwrap().project_files();
 
         if let Some(ref project_files) = project_files {
-            let doc_count = project_files.document_files(&self.db).len();
-            let schema_count = project_files.schema_files(&self.db).len();
+            let doc_count = project_files.document_files(&self.db).files(&self.db).len();
+            let schema_count = project_files.schema_files(&self.db).files(&self.db).len();
             tracing::debug!(
                 "Snapshot project_files: {} schema files, {} document files",
                 schema_count,
@@ -1441,7 +1441,8 @@ impl Analysis {
         }
 
         // Search through all document files for fragment spreads
-        let document_files = project_files.document_files(&self.db);
+        let document_files_input = project_files.document_files(&self.db);
+        let document_files = document_files_input.files(&self.db);
 
         for (file_id, content, metadata) in document_files.iter() {
             // Parse the document
@@ -1526,7 +1527,8 @@ impl Analysis {
         }
 
         // Search through all schema files for type references
-        let schema_files = project_files.schema_files(&self.db);
+        let schema_files_input = project_files.schema_files(&self.db);
+        let schema_files = schema_files_input.files(&self.db);
 
         for (file_id, content, metadata) in schema_files.iter() {
             // Parse the schema file
@@ -1777,7 +1779,8 @@ impl Analysis {
         }
 
         // Search operations from document files
-        let document_files = project_files.document_files(&self.db);
+        let document_files_input = project_files.document_files(&self.db);
+        let document_files = document_files_input.files(&self.db);
         for (file_id, content, metadata) in document_files.iter() {
             let structure = graphql_hir::file_structure(&self.db, *file_id, *content, *metadata);
             for operation in &structure.operations {

--- a/crates/graphql-linter/src/rules/no_anonymous_operations.rs
+++ b/crates/graphql-linter/src/rules/no_anonymous_operations.rs
@@ -153,7 +153,9 @@ mod tests {
     use std::sync::Arc;
 
     fn create_test_project_files(db: &RootDatabase) -> ProjectFiles {
-        ProjectFiles::new(db, Arc::new(vec![]), Arc::new(vec![]))
+        let schema_files = graphql_db::SchemaFiles::new(db, Arc::new(vec![]));
+        let document_files = graphql_db::DocumentFiles::new(db, Arc::new(vec![]));
+        ProjectFiles::new(db, schema_files, document_files)
     }
 
     #[test]

--- a/crates/graphql-linter/src/rules/redundant_fields.rs
+++ b/crates/graphql-linter/src/rules/redundant_fields.rs
@@ -86,7 +86,8 @@ impl StandaloneDocumentLintRule for RedundantFieldsRuleImpl {
             let fragment_file_id = fragment_info.file_id;
 
             // Get the file from document_files (use project_files directly, not db.document_files())
-            let document_files = project_files.document_files(db);
+            let document_files_input = project_files.document_files(db);
+            let document_files = document_files_input.files(db);
             if let Some((_, file_content, file_metadata)) = document_files
                 .iter()
                 .find(|(fid, _, _)| *fid == fragment_file_id)

--- a/crates/graphql-linter/src/rules/require_id_field.rs
+++ b/crates/graphql-linter/src/rules/require_id_field.rs
@@ -349,7 +349,8 @@ fn fragment_contains_id(
 
     // We need to get the file content and metadata to parse it
     // Use project_files directly (not db.document_files() which uses db.project_files())
-    let document_files = context.project_files.document_files(context.db);
+    let document_files_input = context.project_files.document_files(context.db);
+    let document_files = document_files_input.files(context.db);
 
     let Some((file_content, file_metadata)) = document_files
         .iter()
@@ -494,11 +495,15 @@ mod tests {
             document_kind,
         );
 
-        let project_files = ProjectFiles::new(
+        let schema_files = graphql_db::SchemaFiles::new(
             db,
             Arc::new(vec![(schema_file_id, schema_content, schema_metadata)]),
+        );
+        let document_files = graphql_db::DocumentFiles::new(
+            db,
             Arc::new(vec![(doc_file_id, doc_content, doc_metadata)]),
         );
+        let project_files = ProjectFiles::new(db, schema_files, document_files);
 
         (doc_file_id, doc_content, doc_metadata, project_files)
     }

--- a/crates/graphql-linter/src/rules/unique_names.rs
+++ b/crates/graphql-linter/src/rules/unique_names.rs
@@ -29,7 +29,8 @@ impl ProjectLintRule for UniqueNamesRuleImpl {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
 
         // Collect all operations with their locations
-        let document_files = project_files.document_files(db);
+        let document_files_input = project_files.document_files(db);
+        let document_files = document_files_input.files(db);
         let mut operations_by_name: HashMap<String, Vec<(FileId, usize)>> = HashMap::new();
 
         for (file_id, content, metadata) in document_files.iter() {

--- a/crates/graphql-linter/src/rules/unused_fields.rs
+++ b/crates/graphql-linter/src/rules/unused_fields.rs
@@ -59,7 +59,8 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
 
         // Step 2: Collect all used fields from operations and fragments
         let mut used_fields: HashMap<String, HashSet<String>> = HashMap::new();
-        let document_files = project_files.document_files(db);
+        let document_files_input = project_files.document_files(db);
+        let document_files = document_files_input.files(db);
 
         // Determine root types for skipping
         let root_types = get_root_type_names(db, &schema_types);

--- a/crates/graphql-linter/src/rules/unused_fragments.rs
+++ b/crates/graphql-linter/src/rules/unused_fragments.rs
@@ -29,7 +29,8 @@ impl ProjectLintRule for UnusedFragmentsRuleImpl {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
 
         // Step 1: Collect all fragment definitions
-        let document_files = project_files.document_files(db);
+        let document_files_input = project_files.document_files(db);
+        let document_files = document_files_input.files(db);
         let mut all_fragments: HashMap<String, Vec<FileId>> = HashMap::new();
 
         for (file_id, content, metadata) in document_files.iter() {

--- a/crates/graphql-linter/src/rules/unused_variables.rs
+++ b/crates/graphql-linter/src/rules/unused_variables.rs
@@ -227,7 +227,9 @@ mod tests {
     use std::sync::Arc;
 
     fn create_test_project_files(db: &RootDatabase) -> ProjectFiles {
-        ProjectFiles::new(db, Arc::new(vec![]), Arc::new(vec![]))
+        let schema_files = graphql_db::SchemaFiles::new(db, Arc::new(vec![]));
+        let document_files = graphql_db::DocumentFiles::new(db, Arc::new(vec![]));
+        ProjectFiles::new(db, schema_files, document_files)
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Split `ProjectFiles` into separate `SchemaFiles` and `DocumentFiles` Salsa inputs
- Enables fine-grained invalidation: changing documents won't invalidate schema queries and vice versa
- Add direct query versions (`schema_types`, `all_fragments`, etc.) that take specific input types

## Details
This PR addresses the core architectural issue where `ProjectFiles` was a single Salsa input containing both schema and document files. When Salsa tracked dependencies, it would see the entire `ProjectFiles` as a dependency even when a query only needed schema files.

Now:
- `SchemaFiles` and `DocumentFiles` are separate `#[salsa::input]` types
- `ProjectFiles` holds references to these inputs (not the data)
- Critical queries have new versions that take the specific input they need:
  - `schema_types(db, SchemaFiles)` - only invalidates on schema changes
  - `all_fragments(db, DocumentFiles)` - only invalidates on document changes
  - `merged_schema_from_files(db, SchemaFiles)` - only invalidates on schema changes
- Wrapper functions with `_with_project` suffix maintain compatibility

## Test plan
- [x] All existing tests pass
- [x] Benchmarks compile and work with new API
- [ ] Manual testing in real codebase to verify cache behavior

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)