### PR TITLE
fix: goto definition and hover for field selections including inline fragments

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -49,8 +49,7 @@ use symbol::{
     extract_all_definitions, find_field_definition_full_range, find_fragment_definition_full_range,
     find_fragment_definition_range, find_fragment_spreads, find_operation_definition_ranges,
     find_parent_type_at_offset, find_symbol_at_offset, find_type_definition_full_range,
-    find_type_definition_range, find_type_references_in_tree, get_parent_field_path,
-    is_in_selection_set, Symbol,
+    find_type_definition_range, find_type_references_in_tree, is_in_selection_set, Symbol,
 };
 
 // Re-export database types that IDE layer needs
@@ -900,23 +899,6 @@ impl Analysis {
         results
     }
 
-    /// Resolve a field name in a parent type to get its return type name.
-    /// Handles unwrapping List and `NonNull` types to get the base type.
-    fn resolve_field_type(
-        parent_type_name: &str,
-        field_name: &str,
-        types: &std::collections::HashMap<std::sync::Arc<str>, graphql_hir::TypeDef>,
-    ) -> Option<String> {
-        let parent_type = types.get(parent_type_name)?;
-        let field = parent_type
-            .fields
-            .iter()
-            .find(|f| f.name.as_ref() == field_name)?;
-
-        // Unwrap the type to get the base type name
-        Some(unwrap_type_to_name(&field.type_ref))
-    }
-
     /// Get completions at a position
     ///
     /// Returns a list of completion items appropriate for the context.
@@ -1134,37 +1116,20 @@ impl Analysis {
                 let types = graphql_hir::schema_types_with_project(&self.db, project_files);
                 let parent_ctx = find_parent_type_at_offset(&parse.tree, offset)?;
 
-                // Get the full field path to properly resolve nested fields
-                let field_path = get_parent_field_path(&parse.tree, offset);
-
-                // Resolve the parent type by walking the field path
-                let parent_type_name = if let Some(path) = field_path {
-                    let mut current_type = parent_ctx.root_type;
-                    for field_name in path.iter().take(path.len().saturating_sub(1)) {
-                        current_type = Self::resolve_field_type(&current_type, field_name, &types)?;
-                    }
-                    current_type
-                } else {
-                    // No field path, check if immediate_parent is a type or field
-                    if let Some(first_char) = parent_ctx.immediate_parent.chars().next() {
-                        if first_char.is_lowercase() {
-                            Self::resolve_field_type(
-                                &parent_ctx.root_type,
-                                &parent_ctx.immediate_parent,
-                                &types,
-                            )?
-                        } else {
-                            parent_ctx.immediate_parent
-                        }
-                    } else {
-                        parent_ctx.root_type
-                    }
-                };
+                // Use walk_type_stack_to_offset to properly resolve the parent type,
+                // which handles inline fragments correctly
+                let parent_type_name = symbol::walk_type_stack_to_offset(
+                    &parse.tree,
+                    &types,
+                    offset,
+                    &parent_ctx.root_type,
+                )?;
 
                 tracing::debug!(
-                    "Hover: resolved parent type '{}' for field '{}'",
+                    "Hover: resolved parent type '{}' for field '{}' (root: {})",
                     parent_type_name,
-                    name
+                    name,
+                    parent_ctx.root_type
                 );
 
                 // Look up the field in the parent type
@@ -2588,6 +2553,37 @@ fragment AttackActionInfo on AttackAction {
         let hover = hover.unwrap();
         assert!(hover.contents.contains("Query"));
         assert!(hover.contents.contains("Type"));
+    }
+
+    #[test]
+    fn test_hover_field_in_inline_fragment() {
+        let mut host = AnalysisHost::new();
+
+        let schema_file = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_file,
+            "type Query { battleParticipant(id: ID!): BattleParticipant }\ninterface BattleParticipant { id: ID! name: String! displayName: String! }\ntype BattlePokemon implements BattleParticipant { id: ID! name: String! displayName: String! currentHP: Int! }",
+            FileKind::Schema,
+            0,
+        );
+
+        let query_file = FilePath::new("file:///query.graphql");
+        let (query_text, cursor_pos) = extract_cursor(
+            "query { battleParticipant(id: \"1\") { id name ... on BattlePokemon { current*HP } } }",
+        );
+        host.add_file(&query_file, &query_text, FileKind::ExecutableGraphQL, 0);
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let hover = snapshot.hover(&query_file, cursor_pos);
+
+        assert!(
+            hover.is_some(),
+            "Should show hover info for field in inline fragment type"
+        );
+        let hover = hover.unwrap();
+        assert!(hover.contents.contains("currentHP"));
+        assert!(hover.contents.contains("Int!"));
     }
 
     #[test]

--- a/crates/graphql-ide/src/symbol.rs
+++ b/crates/graphql-ide/src/symbol.rs
@@ -358,44 +358,6 @@ fn find_parent_field_type(selection_set: &cst::SelectionSet, byte_offset: usize)
     find_parent_field_path(selection_set, byte_offset).and_then(|path| path.last().cloned())
 }
 
-/// Public wrapper to get the full field path for a position
-/// Returns a vector of field names from outermost to innermost
-pub fn get_parent_field_path(
-    tree: &apollo_parser::SyntaxTree,
-    byte_offset: usize,
-) -> Option<Vec<String>> {
-    let doc = tree.document();
-
-    // Check all definitions
-    for definition in doc.definitions() {
-        match definition {
-            cst::Definition::OperationDefinition(op) => {
-                if let Some(selection_set) = op.selection_set() {
-                    let start: usize = selection_set.syntax().text_range().start().into();
-                    let end: usize = selection_set.syntax().text_range().end().into();
-
-                    if byte_offset >= start && byte_offset <= end {
-                        return find_parent_field_path(&selection_set, byte_offset);
-                    }
-                }
-            }
-            cst::Definition::FragmentDefinition(frag) => {
-                if let Some(selection_set) = frag.selection_set() {
-                    let start: usize = selection_set.syntax().text_range().start().into();
-                    let end: usize = selection_set.syntax().text_range().end().into();
-
-                    if byte_offset >= start && byte_offset <= end {
-                        return find_parent_field_path(&selection_set, byte_offset);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    None
-}
-
 /// Check if the byte offset is within a selection set (for field completions)
 pub fn is_in_selection_set(tree: &apollo_parser::SyntaxTree, byte_offset: usize) -> bool {
     let doc = tree.document();


### PR DESCRIPTION
## Summary

Restores goto definition and hover functionality for field selections in GraphQL queries, including support for fields inside inline fragments.

## What Changed

### Goto Definition (commits 1-2)
Added support for `Symbol::FieldName` in the `goto_definition()` method:

1. Uses `find_parent_type_at_offset()` to determine the parent type context
2. Uses `walk_type_stack_to_offset()` to properly resolve the parent type (handles inline fragments)
3. Searches through schema files for the field definition
4. Returns the location of the field definition

### Hover (commit 3)
Applied the same fix to `hover()` - replaced manual field path resolution with `walk_type_stack_to_offset()` to properly handle inline fragments.

## Examples

### Top-level fields
```graphql
query GetBattleParticipant($id: ID!) {
  battleParticipant(id: $id) {
    name           # ← goto definition and hover now work
    displayName    # ← goto definition and hover now work
  }
}
```

### Nested fields in inline fragments
```graphql
query GetBattleParticipant($id: ID!) {
  battleParticipant(id: $id) {
    id
    ... on BattlePokemon {
      currentHP    # ← goto definition and hover now work here too!
    }
  }
}
```

Both features now correctly resolve the type from the inline fragment's type condition (`BattlePokemon`) rather than the outer type (`BattleParticipant`).

## Testing

- ✅ Builds successfully
- ✅ All existing tests pass
- ✅ New test: `test_goto_definition_field_in_inline_fragment`
- ✅ New test: `test_hover_field_in_inline_fragment`
- ✅ Clippy clean
- ✅ Pre-commit hooks pass

## Technical Details

**Files modified**:
- `crates/graphql-ide/src/lib.rs` - Updated goto_definition and hover implementations
- `crates/graphql-ide/src/symbol.rs` - Removed unused helper functions

The key insight: `walk_type_stack_to_offset()` already existed and properly handles inline fragments by walking the type stack. This is the same approach used for completions, so now goto definition, hover, and completions all use the same type resolution logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)