### PR TITLE
feat: add timeout for LSP request lock acquisition

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -5,6 +5,7 @@ use crate::conversions::{
 };
 use crate::workspace::WorkspaceManager;
 use graphql_config::find_config;
+use graphql_ide::AnalysisHost;
 use lsp_types::{
     ClientCapabilities, CodeAction, CodeActionKind, CodeActionOptions, CodeActionOrCommand,
     CodeActionParams, CodeActionResponse, CodeLens, CodeLensOptions, CodeLensParams,
@@ -25,9 +26,15 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use std::time::Duration;
+use tokio::sync::{Mutex, RwLock};
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::{Client, LanguageServer, UriExt};
+
+/// Default timeout for acquiring host locks during LSP requests.
+/// This prevents requests from blocking indefinitely when another request
+/// is holding the lock for too long.
+const LOCK_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub struct GraphQLLanguageServer {
     client: Client,
@@ -43,6 +50,22 @@ impl GraphQLLanguageServer {
             client,
             client_capabilities: Arc::new(RwLock::new(None)),
             workspace: Arc::new(WorkspaceManager::new()),
+        }
+    }
+
+    /// Try to acquire a snapshot from an `AnalysisHost` with a timeout.
+    ///
+    /// Returns `None` if the lock cannot be acquired within the timeout.
+    /// This prevents LSP requests from blocking indefinitely when another
+    /// request holds the lock.
+    async fn try_snapshot_with_timeout(
+        host: &Arc<Mutex<AnalysisHost>>,
+    ) -> Option<graphql_ide::Analysis> {
+        if let Ok(guard) = tokio::time::timeout(LOCK_TIMEOUT, host.lock()).await {
+            Some(guard.snapshot())
+        } else {
+            tracing::debug!("Timed out waiting for analysis host lock");
+            None
         }
     }
 
@@ -965,12 +988,11 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        let host = self
+let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
-        let analysis = {
-            let host_guard = host.lock().await;
-            host_guard.snapshot()
+        let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
+            return Ok(None);
         };
 
         let position = convert_lsp_position(lsp_position);
@@ -995,12 +1017,11 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        let host = self
+let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
-        let analysis = {
-            let host_guard = host.lock().await;
-            host_guard.snapshot()
+        let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
+            return Ok(None);
         };
 
         let position = convert_lsp_position(lsp_position);
@@ -1027,12 +1048,11 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        let host = self
+let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
-        let analysis = {
-            let host_guard = host.lock().await;
-            host_guard.snapshot()
+        let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
+            return Ok(None);
         };
 
         let position = convert_lsp_position(lsp_position);
@@ -1061,12 +1081,11 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        let host = self
+let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
-        let analysis = {
-            let host_guard = host.lock().await;
-            host_guard.snapshot()
+        let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
+            return Ok(None);
         };
 
         let position = convert_lsp_position(lsp_position);
@@ -1102,12 +1121,11 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-        let host = self
+let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
-        let analysis = {
-            let host_guard = host.lock().await;
-            host_guard.snapshot()
+        let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
+            return Ok(None);
         };
 
         let file_path = graphql_ide::FilePath::new(uri.to_string());
@@ -1138,9 +1156,9 @@ impl LanguageServer for GraphQLLanguageServer {
 
         for entry in &self.workspace.hosts {
             let host = entry.value();
-            let analysis = {
-                let host_guard = host.lock().await;
-                host_guard.snapshot()
+            let Some(analysis) = Self::try_snapshot_with_timeout(host).await else {
+                // Skip this host if we can't acquire the lock in time
+                continue;
             };
 
             let symbols = analysis.workspace_symbols(&params.query);


### PR DESCRIPTION
## Summary
- Add 500ms timeout when acquiring AnalysisHost lock for LSP requests
- Applies to: completion, hover, goto definition, references, document symbols, workspace symbols
- If lock cannot be acquired within timeout, request returns no results rather than blocking indefinitely
- Improves responsiveness when another request holds the lock for too long

## Implementation Notes
The `Analysis` type contains `RefCell` (via Salsa database) which is not `Send`/`Sync`, so we can't wrap the analysis operations themselves with timeouts. Instead, we timeout only on the lock acquisition, which is where blocking actually occurs.

## Test plan
- [x] Build passes
- [x] Clippy passes

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)