### PR TITLE
fix: switch to parking_lot::RwLock to prevent cascading panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "graphql-hir",
  "graphql-linter",
  "graphql-syntax",
+ "parking_lot",
  "salsa",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ swc_common = "18.0"
 # Utilities
 dashmap = "6.1"
 once_cell = "1.21"
+parking_lot = "0.12"
 
 # Logging and Tracing
 tracing = "0.1"

--- a/crates/graphql-ide/Cargo.toml
+++ b/crates/graphql-ide/Cargo.toml
@@ -27,6 +27,9 @@ glob = { workspace = true }
 # Error handling
 anyhow = { workspace = true }
 
+# Concurrency - parking_lot::RwLock never poisons, preventing cascading panics
+parking_lot = { workspace = true }
+
 # Internal crates (query-based layers)
 graphql-db = { path = "../graphql-db" }
 graphql-syntax = { path = "../graphql-syntax" }


### PR DESCRIPTION
## Summary
- Replace `std::sync::RwLock` with `parking_lot::RwLock` in graphql-ide
- Remove all `.unwrap()` calls from lock acquisitions (32 occurrences)
- Add `parking_lot = "0.12"` to workspace dependencies

## Motivation
`std::sync::RwLock` poisons when a thread panics while holding the lock. This causes cascading failures where all subsequent lock acquisition attempts panic, bringing down the entire LSP.

`parking_lot::RwLock` never poisons - if a thread panics while holding the lock, subsequent acquisitions succeed normally.

## Changes
- **Cargo.toml**: Add `parking_lot = "0.12"` to workspace dependencies  
- **graphql-ide/Cargo.toml**: Reference workspace parking_lot dependency
- **graphql-ide/src/lib.rs**: 
  - Replace `std::sync::RwLock` import with `parking_lot::RwLock`
  - Remove `.unwrap()` from all 32 lock acquisition sites

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --package graphql-ide` passes (66 tests)
- [x] `cargo clippy` passes with no warnings
- [x] Full test suite passes

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)