### PR TITLE
fix: track document versions in LSP server

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -38,6 +38,9 @@ pub struct GraphQLLanguageServer {
     /// `AnalysisHost` per (workspace URI, project name) tuple
     #[allow(clippy::type_complexity)]
     hosts: Arc<DashMap<(String, String), Arc<Mutex<AnalysisHost>>>>,
+    /// Document versions indexed by document URI string
+    /// Used to detect out-of-order updates and avoid race conditions
+    document_versions: Arc<DashMap<String, i32>>,
 }
 
 impl GraphQLLanguageServer {
@@ -50,6 +53,7 @@ impl GraphQLLanguageServer {
             config_paths: Arc::new(DashMap::new()),
             configs: Arc::new(DashMap::new()),
             hosts: Arc::new(DashMap::new()),
+            document_versions: Arc::new(DashMap::new()),
         }
     }
 
@@ -849,6 +853,10 @@ impl LanguageServer for GraphQLLanguageServer {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri;
         let content = params.text_document.text;
+        let version = params.text_document.version;
+
+        // Track the initial document version
+        self.document_versions.insert(uri.to_string(), version);
 
         // Add to AnalysisHost
         let Some((workspace_uri, project_name)) = self.find_workspace_and_project(&uri) else {
@@ -889,6 +897,22 @@ impl LanguageServer for GraphQLLanguageServer {
     #[tracing::instrument(skip(self, params), fields(path = ?params.text_document.uri.to_file_path().unwrap()))]
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
+        let version = params.text_document.version;
+
+        // Check document version to detect out-of-order updates
+        let uri_string = uri.to_string();
+        if let Some(current_version) = self.document_versions.get(&uri_string) {
+            if version <= *current_version {
+                tracing::warn!(
+                    "Ignoring stale document update: version {} <= current {}",
+                    version,
+                    *current_version
+                );
+                return;
+            }
+        }
+        // Update tracked version
+        self.document_versions.insert(uri_string, version);
 
         // Get the latest content from changes (full sync mode)
         for change in params.content_changes {
@@ -941,6 +965,9 @@ impl LanguageServer for GraphQLLanguageServer {
         // The file is still part of the project on disk, and other files may reference
         // fragments/types defined in it. Only files that are deleted from disk should be
         // removed from the analysis.
+
+        // Remove version tracking for closed document
+        self.document_versions.remove(&params.text_document.uri.to_string());
 
         // Clear diagnostics for the closed file
         self.client


### PR DESCRIPTION
## Summary

Add document version tracking to detect and ignore out-of-order updates in the LSP server.

## Problem

The LSP server receives document versions in `DidChangeTextDocumentParams` but doesn't track them, which can lead to:
- Out-of-order updates being processed incorrectly
- Diagnostics published for stale document states
- Race conditions between didChange and diagnostic publishing

## Changes

- Add `document_versions: Arc<DashMap<String, i32>>` to `GraphQLLanguageServer`
- Record initial version in `did_open`
- Check and update version in `did_change`, rejecting stale updates with a warning log
- Remove version tracking in `did_close`

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo clippy -- -D warnings` passes

Fixes #272