### PR TITLE
fix: replace placeholder test assertion with proper assertion

### DIFF
--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -219,8 +219,11 @@ mod tests {
         // Get diagnostics (no project_files, so only syntax errors would be reported)
         let diagnostics = file_diagnostics(&db, content, metadata, None);
 
-        // Should have no diagnostics for valid schema
-        // Note: This will work once we implement the parse query properly
-        assert!(diagnostics.is_empty() || !diagnostics.is_empty()); // Placeholder assertion
+        // Valid schema should have no syntax errors
+        assert!(
+            diagnostics.is_empty(),
+            "Valid schema should have no diagnostics, got: {:?}",
+            diagnostics
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replace placeholder test assertion that always passes with a proper assertion.

## Problem

The test `test_file_diagnostics_empty` had a placeholder assertion:
```rust
assert!(diagnostics.is_empty() || !diagnostics.is_empty()); // ALWAYS TRUE!
```

This provides no test coverage and could mask regressions.

## Changes

Replaced with a proper assertion that validates the expected behavior:
```rust
assert!(
    diagnostics.is_empty(),
    "Valid schema should have no diagnostics, got: {:?}",
    diagnostics
);
```

## Test plan

- [x] `cargo test --package graphql-analysis test_file_diagnostics_empty` passes

Fixes #273