### PR TITLE
docs: document apollo-rs fork dependency in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ anyhow = "1.0"
 
 # GraphQL
 apollo-parser = "0.8"
+# FORK DEPENDENCY: Uses trevor-scheer/apollo-rs fork with `parse_with_offset` branch
+# Required for: ExecutableDocument::builder() API for incremental document construction
+# Tracking issue: https://github.com/trevor-scheer/graphql-lsp/issues/274
+# TODO: Upstream these changes to apollographql/apollo-rs and switch to official release
 apollo-compiler = { git = "https://github.com/trevor-scheer/apollo-rs.git", branch = "parse_with_offset" }
 
 # Async


### PR DESCRIPTION
## Summary

Add documentation explaining the apollo-rs fork dependency and how to track upstream contribution efforts.

## Problem

The project depends on a fork of apollo-rs (`trevor-scheer/apollo-rs` branch `parse_with_offset`) which provides `ExecutableDocument::builder()` API. This creates maintenance burden and wasn't documented.

## Changes

Added comments in Cargo.toml explaining:
- Why the fork is needed (ExecutableDocument::builder() API)
- Link to the tracking issue (#274)
- Goal of upstreaming changes to apollographql/apollo-rs

## Test plan

- [x] Documentation is clear and actionable

Addresses #274