### PR TITLE
perf: add reverse index for O(1) workspace/project lookup

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -468,9 +468,7 @@ impl Default for IdeDatabase {
     fn default() -> Self {
         Self {
             storage: salsa::Storage::default(),
-            lint_config: Arc::new(RwLock::new(Arc::new(
-                graphql_linter::LintConfig::default(),
-            ))),
+            lint_config: Arc::new(RwLock::new(Arc::new(graphql_linter::LintConfig::default()))),
             extract_config: Arc::new(RwLock::new(Arc::new(
                 graphql_extract::ExtractConfig::default(),
             ))),

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -41,6 +41,9 @@ pub struct GraphQLLanguageServer {
     /// Document versions indexed by document URI string
     /// Used to detect out-of-order updates and avoid race conditions
     document_versions: Arc<DashMap<String, i32>>,
+    /// Reverse index: file URI → (`workspace_uri`, `project_name`)
+    /// Provides O(1) lookup instead of O(n) iteration over all hosts
+    file_to_project: Arc<DashMap<String, (String, String)>>,
 }
 
 impl GraphQLLanguageServer {
@@ -54,6 +57,7 @@ impl GraphQLLanguageServer {
             configs: Arc::new(DashMap::new()),
             hosts: Arc::new(DashMap::new()),
             document_versions: Arc::new(DashMap::new()),
+            file_to_project: Arc::new(DashMap::new()),
         }
     }
 
@@ -308,7 +312,11 @@ documents: "**/*.graphql"
 
                 // === PHASE 1: Collect all files without holding the lock ===
                 // This batching approach avoids lock contention during file I/O
-                let mut collected_files: Vec<(graphql_ide::FilePath, String, graphql_ide::FileKind)> = Vec::new();
+                let mut collected_files: Vec<(
+                    graphql_ide::FilePath,
+                    String,
+                    graphql_ide::FileKind,
+                )> = Vec::new();
                 let mut files_scanned = 0;
 
                 for pattern in patterns {
@@ -339,9 +347,7 @@ documents: "**/*.graphql"
 
                                             // Log progress every 100 files
                                             files_scanned += 1;
-                                            if files_scanned > 0
-                                                && files_scanned % 100 == 0
-                                            {
+                                            if files_scanned > 0 && files_scanned % 100 == 0 {
                                                 tracing::info!(
                                                     "Scanned {} files so far (pattern: {})",
                                                     files_scanned,
@@ -349,8 +355,7 @@ documents: "**/*.graphql"
                                                 );
 
                                                 // Show warning at threshold
-                                                if files_scanned == MAX_FILES_WARNING_THRESHOLD
-                                                {
+                                                if files_scanned == MAX_FILES_WARNING_THRESHOLD {
                                                     tracing::warn!(
                                                         "Loading large number of files ({}+), this may take a while...",
                                                         MAX_FILES_WARNING_THRESHOLD
@@ -382,7 +387,8 @@ documents: "**/*.graphql"
                                                         graphql_ide::FilePath::new(uri.clone());
 
                                                     // Collect file data for batch addition
-                                                    collected_files.push((file_path, content, file_kind));
+                                                    collected_files
+                                                        .push((file_path, content, file_kind));
                                                 }
                                                 Err(e) => {
                                                     tracing::warn!(
@@ -422,9 +428,17 @@ documents: "**/*.graphql"
                 // This significantly reduces lock contention compared to locking per-file
                 {
                     let mut host_guard = host.lock().await;
-                    for (file_path, content, file_kind) in collected_files {
-                        host_guard.add_file(&file_path, &content, file_kind, 0);
+                    for (file_path, content, file_kind) in &collected_files {
+                        host_guard.add_file(file_path, content, *file_kind, 0);
                     }
+                }
+
+                // === PHASE 2b: Populate file_to_project reverse index for O(1) lookup ===
+                for (file_path, _, _) in &collected_files {
+                    self.file_to_project.insert(
+                        file_path.as_str().to_string(),
+                        (workspace_uri.to_string(), project_name.to_string()),
+                    );
                 }
 
                 tracing::info!(
@@ -507,6 +521,23 @@ documents: "**/*.graphql"
             keys_to_remove.len()
         );
 
+        // Clear file_to_project entries for this workspace
+        let file_keys_to_remove: Vec<_> = self
+            .file_to_project
+            .iter()
+            .filter(|entry| entry.value().0 == workspace_uri)
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        for key in &file_keys_to_remove {
+            self.file_to_project.remove(key);
+        }
+
+        tracing::info!(
+            "Cleared {} file-to-project mappings for workspace",
+            file_keys_to_remove.len()
+        );
+
         // Clear the existing config
         self.configs.remove(workspace_uri);
 
@@ -530,27 +561,19 @@ documents: "**/*.graphql"
 
     /// Find the workspace and project for a given document URI
     ///
-    /// This first checks if the file was loaded during initialization by querying
-    /// each `AnalysisHost` directly. If not found, falls back to pattern matching
-    /// via the config (for files opened after init that match project patterns).
+    /// Uses a reverse index for O(1) lookup of previously seen files.
+    /// Falls back to config pattern matching for files opened after init
+    /// that haven't been indexed yet.
     fn find_workspace_and_project(&self, document_uri: &Uri) -> Option<(String, String)> {
-        let doc_path = document_uri.to_file_path()?;
-        let file_path = graphql_ide::FilePath::new(document_uri.to_string());
+        let uri_string = document_uri.to_string();
 
-        // First, check if file is already loaded in any host (fast path)
-        for host_entry in self.hosts.iter() {
-            let (workspace_uri, project_name) = host_entry.key();
-            let host_mutex = host_entry.value();
-
-            // Try to acquire lock without blocking - skip if locked
-            if let Ok(host) = host_mutex.try_lock() {
-                if host.contains_file(&file_path) {
-                    return Some((workspace_uri.clone(), project_name.clone()));
-                }
-            }
+        // Fast path: O(1) lookup in reverse index
+        if let Some(entry) = self.file_to_project.get(&uri_string) {
+            return Some(entry.value().clone());
         }
 
         // Fallback: use config pattern matching (for files opened after init)
+        let doc_path = document_uri.to_file_path()?;
         for workspace_entry in self.workspace_roots.iter() {
             let workspace_uri = workspace_entry.key();
             let workspace_path = workspace_entry.value();
@@ -870,6 +893,12 @@ impl LanguageServer for GraphQLLanguageServer {
             return;
         };
 
+        // Update file_to_project index for files opened after initialization
+        self.file_to_project.insert(
+            uri.to_string(),
+            (workspace_uri.clone(), project_name.clone()),
+        );
+
         // Get the host mutex
         let host = self.get_or_create_host(&workspace_uri, &project_name);
 
@@ -973,7 +1002,8 @@ impl LanguageServer for GraphQLLanguageServer {
         // removed from the analysis.
 
         // Remove version tracking for closed document
-        self.document_versions.remove(&params.text_document.uri.to_string());
+        self.document_versions
+            .remove(&params.text_document.uri.to_string());
 
         // Clear diagnostics for the closed file
         self.client


### PR DESCRIPTION
## Summary

- Added `file_to_project` reverse index (`DashMap<String, (String, String)>`) to `GraphQLLanguageServer`
- Changed `find_workspace_and_project()` from O(n) host iteration to O(1) hash map lookup
- Index is populated during file loading and `did_open`, and cleared on config reload

This addresses **Issue 4: Linear Workspace/Project Lookup** from `docs/PERF-ANALYSIS-SLOWEST-PATHS.md`.

### Before
Every LSP request (hover, completion, goto definition, etc.) required iterating over all hosts with `try_lock()`.

### After
O(1) lookup via reverse index.

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes  
- [x] `cargo test` passes
- [x] Pre-commit hooks pass