### PR TITLE
fix: resolve clippy and formatting CI failures

### DIFF
--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -178,6 +178,7 @@ pub fn file_diagnostics(
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
 mod tests {
     use super::*;
     use graphql_db::{FileContent, FileId, FileKind, FileMetadata, FileUri};
@@ -222,8 +223,7 @@ mod tests {
         // Valid schema should have no syntax errors
         assert!(
             diagnostics.is_empty(),
-            "Valid schema should have no diagnostics, got: {:?}",
-            diagnostics
+            "Valid schema should have no diagnostics, got: {diagnostics:?}"
         );
     }
 }

--- a/crates/graphql-analysis/src/merged_schema.rs
+++ b/crates/graphql-analysis/src/merged_schema.rs
@@ -160,6 +160,7 @@ pub fn merged_schema(
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
 mod tests {
     use super::*;
     use graphql_db::{FileContent, FileId, FileKind, FileMetadata, FileUri};

--- a/crates/graphql-hir/src/lib.rs
+++ b/crates/graphql-hir/src/lib.rs
@@ -769,8 +769,8 @@ mod tests {
 
         // UserFields should be unchanged (same Arc)
         assert_eq!(
-            user_source_1.as_ref().map(|s| s.as_ref()),
-            user_source_2.as_ref().map(|s| s.as_ref()),
+            user_source_1.as_ref().map(AsRef::as_ref),
+            user_source_2.as_ref().map(AsRef::as_ref),
             "UserFields source should be unchanged"
         );
 

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -33,7 +33,6 @@
 /// - [`Analysis`] - Immutable snapshot for querying IDE features
 /// - POD types: [`Position`], [`Range`], [`Location`], [`FilePath`]
 /// - Feature types: [`CompletionItem`], [`HoverResult`], [`Diagnostic`]
-
 #[cfg(test)]
 mod analysis_host_isolation;
 
@@ -112,9 +111,7 @@ fn extract_cursor(input: &str) -> (String, Position) {
         result.push(ch);
     }
 
-    if !found {
-        panic!("No cursor marker '*' found in input");
-    }
+    assert!(found, "No cursor marker '*' found in input");
 
     (result, Position::new(line, character))
 }
@@ -468,9 +465,7 @@ impl Default for IdeDatabase {
     fn default() -> Self {
         Self {
             storage: salsa::Storage::default(),
-            lint_config: Arc::new(RwLock::new(Arc::new(
-                graphql_linter::LintConfig::default(),
-            ))),
+            lint_config: Arc::new(RwLock::new(Arc::new(graphql_linter::LintConfig::default()))),
             extract_config: Arc::new(RwLock::new(Arc::new(
                 graphql_extract::ExtractConfig::default(),
             ))),
@@ -2885,6 +2880,7 @@ fn format_type_ref(type_ref: &graphql_hir::TypeRef) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_raw_string_hashes)]
 mod tests {
     use super::*;
 
@@ -4247,6 +4243,7 @@ type Move {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_typescript_off_by_one_parent_completions() {
         let schema = r#"
 type Query { allPokemon(region: Region!, limit: Int): PokemonConnection }
@@ -4374,6 +4371,7 @@ enum Region { KANTO JOHTO }
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_typescript_deeply_nested_completions() {
         let schema = r#"
 type Query { allPokemon(region: Region!, limit: Int): PokemonConnection }
@@ -4607,6 +4605,7 @@ query TestEvolution {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_completions_for_interface_type_suggest_fields_and_inline_fragments() {
         let schema = r#"
 type Query { evolution: EvolutionEdge }

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -308,7 +308,11 @@ documents: "**/*.graphql"
 
                 // === PHASE 1: Collect all files without holding the lock ===
                 // This batching approach avoids lock contention during file I/O
-                let mut collected_files: Vec<(graphql_ide::FilePath, String, graphql_ide::FileKind)> = Vec::new();
+                let mut collected_files: Vec<(
+                    graphql_ide::FilePath,
+                    String,
+                    graphql_ide::FileKind,
+                )> = Vec::new();
                 let mut files_scanned = 0;
 
                 for pattern in patterns {
@@ -339,9 +343,7 @@ documents: "**/*.graphql"
 
                                             // Log progress every 100 files
                                             files_scanned += 1;
-                                            if files_scanned > 0
-                                                && files_scanned % 100 == 0
-                                            {
+                                            if files_scanned > 0 && files_scanned % 100 == 0 {
                                                 tracing::info!(
                                                     "Scanned {} files so far (pattern: {})",
                                                     files_scanned,
@@ -349,8 +351,7 @@ documents: "**/*.graphql"
                                                 );
 
                                                 // Show warning at threshold
-                                                if files_scanned == MAX_FILES_WARNING_THRESHOLD
-                                                {
+                                                if files_scanned == MAX_FILES_WARNING_THRESHOLD {
                                                     tracing::warn!(
                                                         "Loading large number of files ({}+), this may take a while...",
                                                         MAX_FILES_WARNING_THRESHOLD
@@ -382,7 +383,8 @@ documents: "**/*.graphql"
                                                         graphql_ide::FilePath::new(uri.clone());
 
                                                     // Collect file data for batch addition
-                                                    collected_files.push((file_path, content, file_kind));
+                                                    collected_files
+                                                        .push((file_path, content, file_kind));
                                                 }
                                                 Err(e) => {
                                                     tracing::warn!(
@@ -973,7 +975,8 @@ impl LanguageServer for GraphQLLanguageServer {
         // removed from the analysis.
 
         // Remove version tracking for closed document
-        self.document_versions.remove(&params.text_document.uri.to_string());
+        self.document_versions
+            .remove(&params.text_document.uri.to_string());
 
         // Clear diagnostics for the closed file
         self.client


### PR DESCRIPTION
## Summary
- Fix rustfmt formatting issues in graphql-ide and graphql-lsp
- Replace redundant closures with method references in graphql-hir
- Convert manual panic to assert! macro in graphql-ide
- Allow too_many_lines for test functions in graphql-ide
- Allow needless_raw_string_hashes in test modules
- Use inline format arguments in assert! macro

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test` passes