### PR TITLE
docs: add gh CLI --repo flag requirement for web instances

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -863,8 +863,11 @@ When running as a Claude web instance, the git remote uses a local proxy that `g
 ```bash
 # Correct - always specify the repo explicitly
 gh issue list --repo trevor-scheer/graphql-lsp
-gh pr create --repo trevor-scheer/graphql-lsp
+gh issue view 123 --repo trevor-scheer/graphql-lsp
 gh pr view 123 --repo trevor-scheer/graphql-lsp
+
+# For pr create, also include --head to specify the branch
+gh pr create --repo trevor-scheer/graphql-lsp --head your-branch-name
 
 # Incorrect - will fail with "none of the git remotes configured for this repository point to a known GitHub host"
 gh issue list


### PR DESCRIPTION
## Summary

- Documents the requirement to always use `--repo` flag with `gh` commands when running as a Claude web instance
- The git remote uses a local proxy that `gh` doesn't recognize as a GitHub host, causing commands without `--repo` to fail

## Test plan

- [x] Verify documentation is clear and includes examples