### PR TITLE
docs: require SME agent consultation for features and bug fixes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,6 +24,7 @@ This document provides context and guidance for working with the GraphQL LSP cod
 - [Instructions for Claude](#instructions-for-claude)
   - [Operating Guidelines](#operating-guidelines)
 - [Expert Agents](#expert-agents)
+  - [SME Consultation Requirements](#sme-consultation-requirements)
 
 ---
 
@@ -250,6 +251,7 @@ npm run lint             # Lint TypeScript
 - Explain what changed and why
 - Call out new and updated tests
 - Reference related issues
+- Document which SME agents were consulted (see [SME Consultation Requirements](#sme-consultation-requirements))
 
 **Don't:**
 
@@ -801,7 +803,7 @@ Overhead: ~1-2% CPU when enabled, zero when disabled.
 
 1. **Read before acting**: Always check relevant README.md files and this document before starting work
 2. **Understand the architecture**: Know which layer you're working in (db → syntax → hir → analysis → ide → lsp)
-3. **Consult expert agents**: Use the SME agents in `.claude/agents/` for domain-specific guidance
+3. **Consult expert agents (REQUIRED)**: You MUST consult the relevant SME agents in `.claude/agents/` before implementing features, fixing bugs, or making significant changes. See [SME Consultation Requirements](#sme-consultation-requirements) for details.
 4. **Follow the patterns**: Study existing code in the same layer before adding new features
 5. **Test incrementally**: Write tests as you go, don't batch at the end
 6. **Keep it simple**: Don't over-engineer or add unnecessary abstractions
@@ -927,6 +929,8 @@ This preserves notes and local settings.
 ### Things to Always Do
 
 - ✅ Read this file and relevant READMEs before starting
+- ✅ Consult relevant SME agents before implementing features or fixes
+- ✅ Document consulted agents in PR descriptions and issue comments
 - ✅ Write tests for new functionality
 - ✅ Update documentation when changing behavior
 - ✅ Follow the existing code style and patterns
@@ -1000,6 +1004,53 @@ All agents share these traits:
 - **Thorough**: They provide comprehensive analysis, not quick answers
 - **Tradeoff-aware**: They present multiple solutions with clear pros/cons
 - **Challenging**: They respectfully correct misconceptions and anti-patterns
+
+### SME Consultation Requirements
+
+**Consultation is MANDATORY** for the following work types:
+
+| Work Type | Required Agents |
+|-----------|-----------------|
+| **New LSP features** | `lsp.md`, `rust-analyzer.md`, `rust.md` |
+| **GraphQL validation/linting** | `graphql.md`, `apollo-rs.md` |
+| **VSCode extension changes** | `vscode-extension.md` |
+| **CLI tool changes** | `graphql-cli.md` |
+| **Salsa/incremental computation** | `rust-analyzer.md` |
+| **IDE UX features** | `graphiql.md`, `lsp.md` |
+| **Apollo-specific patterns** | `apollo-client.md`, `apollo-rs.md` |
+| **Rust API design** | `rust.md` |
+
+#### Documentation Requirements
+
+When consulting SME agents, Claude MUST document:
+
+1. **In user communications**: Mention which agents were consulted when proposing or explaining a solution
+2. **In PR descriptions**: Include a "Consulted SME Agents" section listing agents and key guidance received
+3. **In issue comments**: Note agent consultations when providing analysis or recommendations
+
+#### Example Documentation Format
+
+**In user messages:**
+> "I consulted the `lsp.md` and `rust-analyzer.md` agents for guidance on this feature. The LSP agent confirmed this follows the specification, and the rust-analyzer agent recommended using a Salsa query for incremental computation."
+
+**In PR descriptions:**
+```markdown
+## Consulted SME Agents
+
+- **lsp.md**: Confirmed `textDocument/definition` response format
+- **rust-analyzer.md**: Recommended query-based architecture for goto definition
+- **rust.md**: Advised on error handling patterns using `Result<Option<T>>`
+```
+
+**In issue comments:**
+> "After consulting the `graphql.md` agent, I can confirm this is expected behavior per section 5.8.3 of the GraphQL specification regarding fragment spread validation."
+
+#### Why Documentation Matters
+
+- **Traceability**: Users can understand the reasoning behind decisions
+- **Review Quality**: Reviewers know which domain expertise was applied
+- **Knowledge Transfer**: Future sessions can see what guidance was relevant
+- **Accountability**: Ensures agents are actually being consulted, not skipped
 
 ### Example Usage
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,19 @@
 
 -
 
+## Consulted SME Agents
+
+<!--
+List which SME agents from .claude/agents/ were consulted for this PR.
+Format: **agent-name.md**: Key guidance received
+
+Example:
+- **lsp.md**: Confirmed response format for textDocument/definition
+- **rust-analyzer.md**: Recommended query-based architecture
+-->
+
+-
+
 ## Test Plan
 
 <!-- How were these changes tested? What should the reviewer test manually? -->


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to make SME (Subject Matter Expert) agent consultation mandatory when implementing features, fixing bugs, or making significant changes. Also requires documenting which agents were consulted in all communications.

## Changes

- Updated "General Approach" to mark SME consultation as REQUIRED with link to new section
- Added comprehensive "SME Consultation Requirements" section under Expert Agents including:
  - Table mapping work types to required agents (LSP features, validation, VSCode, CLI, etc.)
  - Documentation requirements for user communications, PR descriptions, and issue comments
  - Example formats showing how to document consultations
  - Rationale explaining why documentation matters (traceability, review quality, knowledge transfer)
- Updated PR Guidelines to require documenting consulted agents
- Updated "Things to Always Do" checklist with two new items
- Updated Table of Contents
- Added "Consulted SME Agents" section to PR template with examples

## Consulted SME Agents

- N/A - This is a documentation-only change to project guidelines

## Test Plan

- Reviewed markdown formatting and anchor links
- Verified Table of Contents link works correctly

## Related Issues

None