### PR TITLE
Remove redundant CI checks from PR test plan

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -249,14 +249,16 @@ npm run lint             # Lint TypeScript
 
 - Write clear, descriptive PR titles
 - Explain what changed and why
-- Call out new and updated tests
+- Call out new and updated tests in the Changes section
 - Reference related issues
 - Document which SME agents were consulted (see [SME Consultation Requirements](#sme-consultation-requirements))
+- Use "Manual Testing" section for steps reviewers can follow to verify changes
 
 **Don't:**
 
 - Use excessive emoji in titles or descriptions
-- Mention that tests or linting passed (expected baseline)
+- Mention that tests or linting passed (expected baseline, CI enforces this)
+- Put automated test/lint results in "Manual Testing" section (that's for manual verification steps only)
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,18 @@ Example:
 
 -
 
-## Test Plan
+## Manual Testing
 
-<!-- How were these changes tested? What should the reviewer test manually? -->
+<!--
+Steps for manually verifying these changes. CI handles automated tests and linting.
+
+Examples:
+- Run `cargo build` and open VSCode to verify hover works on type references
+- Execute `graphql lint --project frontend` and confirm new rule triggers
+- Open a .ts file with embedded GraphQL and verify diagnostics appear
+
+Leave empty or write "N/A" if no manual testing is needed.
+-->
 
 -
 


### PR DESCRIPTION
Clarify that the Manual Testing section is for manual verification steps only, not automated test/lint results (which CI enforces). Updated both the PR template with examples and CLAUDE.md PR guidelines.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- Bullet list of key changes -->

-

## Consulted SME Agents

<!--
List which SME agents from .claude/agents/ were consulted for this PR.
Format: **agent-name.md**: Key guidance received

Example:
- **lsp.md**: Confirmed response format for textDocument/definition
- **rust-analyzer.md**: Recommended query-based architecture
-->

-

## Test Plan

<!-- How were these changes tested? What should the reviewer test manually? -->

-

## Related Issues

<!-- Link to related issues if any (e.g., Fixes #123, Closes #456) -->
