### PR TITLE
docs: update README with complete lint rules list

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,11 +399,19 @@ Linting is configured via top-level `lint` with optional tool-specific overrides
 
 **Available rules:**
 
-<!-- TODO(trevor): update rule list. List recommended rules. -->
+| Rule | Description | Recommended |
+|------|-------------|-------------|
+| `unique_names` | Ensures operation and fragment names are unique across the project | error |
+| `no_anonymous_operations` | Requires all operations to have explicit names for better monitoring and debugging | error |
+| `no_deprecated` | Warns when using deprecated fields, arguments, or enum values | warn |
+| `redundant_fields` | Detects fields that are redundant because they are already included in a sibling fragment spread | warn |
+| `require_id_field` | Warns when the `id` field is not requested on types that have it | warn |
+| `unused_fields` | Detects schema fields that are never used in any operation or fragment | - |
+| `unused_fragments` | Detects fragment definitions that are never used in any operation | - |
+| `unused_variables` | Detects variables declared in operations that are never used | - |
+| `operation_name_suffix` | Requires operation names to have type-specific suffixes (Query, Mutation, Subscription) | - |
 
-- `no_deprecated` - Warns when using fields marked with @deprecated (recommended: warn)
-- `unique_names` - Ensures operation and fragment names are unique (recommended: error)
-- `unused_fields` - Detects schema fields never used (recommended: warn)
+Rules marked with `-` in the Recommended column are not included in the `recommended` preset and must be explicitly enabled.
 
 **Severity levels:**
 


### PR DESCRIPTION
## Summary

Fixes #331

Replace the outdated 3-rule list with a comprehensive table of all 9 available lint rules.

## Changes

The new table includes:
- **Rule name** - The configuration key used in `.graphqlrc.yaml`
- **Description** - What the rule checks for (taken from each rule's `description()` method)
- **Recommended** - Whether the rule is in the `recommended` preset and at what severity

### Recommended Preset Rules

| Rule | Severity |
|------|----------|
| `unique_names` | error |
| `no_anonymous_operations` | error |
| `no_deprecated` | warn |
| `redundant_fields` | warn |
| `require_id_field` | warn |

### Non-Recommended Rules (must be explicitly enabled)

- `unused_fields`
- `unused_fragments`
- `unused_variables`
- `operation_name_suffix`

## Test plan

- [x] Documentation-only change, no code affected
- [x] Rule names and descriptions verified against source code