### PR TITLE
docs: add guideline to update PR titles/descriptions after changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -249,6 +249,7 @@ npm run lint             # Lint TypeScript
 
 - Write clear, descriptive PR titles
 - Explain what changed and why
+- **Update PR titles and descriptions after pushing additional commits** - keep them accurate and reflective of current changes
 - Call out new and updated tests in the Changes section
 - Reference related issues
 - Document which SME agents were consulted (see [SME Consultation Requirements](#sme-consultation-requirements))


### PR DESCRIPTION
## Summary

- Adds explicit guidance in CLAUDE.md to update PR titles and descriptions after pushing additional commits
- Ensures PR metadata stays accurate and reflective of the current state of changes

## Changes

Updated the PR Guidelines "Do:" section in `.claude/CLAUDE.md` to include:

> **Update PR titles and descriptions after pushing additional commits** - keep them accurate and reflective of current changes

## Test Plan

- [ ] Review the updated guideline in CLAUDE.md
- [ ] Verify the guideline is clear and actionable