### PR TITLE
fix: use native HTTP transport for GitHub MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,11 @@
 {
   "mcpServers": {
     "github": {
-      "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-proxy@latest", "--header", "Authorization: Bearer ${GH_TOKEN}", "https://api.githubcopilot.com/mcp"]
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GH_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
The previous config used @anthropic-ai/mcp-proxy which doesn't exist
in npm. Claude Code supports native HTTP MCP connections, so we can
connect directly to api.githubcopilot.com/mcp without a proxy.