### PR TITLE
fix(ide): resolve Salsa deadlock in analysis host isolation test

### DIFF
--- a/crates/graphql-ide/src/analysis_host_isolation.rs
+++ b/crates/graphql-ide/src/analysis_host_isolation.rs
@@ -1,11 +1,16 @@
 //! Integration test for per-project `AnalysisHost` isolation in the LSP
 //!
 //! This test simulates two projects with different schemas and ensures their analysis is isolated.
+//!
+//! # Snapshot Lifecycle
+//!
+//! Salsa uses a single-writer, multi-reader model. Snapshots (via `Analysis`) hold read locks
+//! on the database. All snapshots MUST be dropped before any mutating operation (`add_file`,
+//! `rebuild_project_files`, etc.) or the mutation will hang waiting for the read locks.
 
 use super::{AnalysisHost, DiagnosticSeverity, FileKind, FilePath};
 
 #[test]
-#[ignore = "hangs due to Salsa deadlock when rebuilding project files"]
 #[allow(clippy::similar_names)]
 fn test_analysis_host_isolation_between_projects() {
     // Project 1: StarWars
@@ -13,11 +18,16 @@ fn test_analysis_host_isolation_between_projects() {
     let path1 = FilePath::new("file:///starwars/schema.graphql");
     host1.add_file(&path1, "type Query { hero: String }", FileKind::Schema, 0);
     host1.rebuild_project_files();
-    let snapshot1 = host1.snapshot();
-    let diagnostics1 = snapshot1.diagnostics(&path1);
-    assert!(diagnostics1
-        .iter()
-        .all(|d| d.severity != DiagnosticSeverity::Error));
+
+    // Scope the snapshot so it's dropped before the next mutation
+    {
+        let snapshot1 = host1.snapshot();
+        let diagnostics1 = snapshot1.diagnostics(&path1);
+        assert!(diagnostics1
+            .iter()
+            .all(|d| d.severity != DiagnosticSeverity::Error));
+    }
+
     // Project 2: Pokemon
     let mut host2 = AnalysisHost::new();
     let path2 = FilePath::new("file:///pokemon/schema.graphql");
@@ -28,29 +38,41 @@ fn test_analysis_host_isolation_between_projects() {
         0,
     );
     host2.rebuild_project_files();
-    let snapshot2 = host2.snapshot();
-    let diagnostics2 = snapshot2.diagnostics(&path2);
-    assert!(diagnostics2
-        .iter()
-        .all(|d| d.severity != DiagnosticSeverity::Error));
+
+    {
+        let snapshot2 = host2.snapshot();
+        let diagnostics2 = snapshot2.diagnostics(&path2);
+        assert!(diagnostics2
+            .iter()
+            .all(|d| d.severity != DiagnosticSeverity::Error));
+    }
+
     // Add a file to project 1 that would be invalid in project 2
     let file1 = FilePath::new("file:///starwars/query.graphql");
     host1.add_file(&file1, "query { hero }", FileKind::ExecutableGraphQL, 0);
     host1.rebuild_project_files();
-    let snapshot1b = host1.snapshot();
-    let diagnostics1b = snapshot1b.diagnostics(&file1);
-    assert!(diagnostics1b
-        .iter()
-        .all(|d| d.severity != DiagnosticSeverity::Error));
+
+    {
+        let snapshot1b = host1.snapshot();
+        let diagnostics1b = snapshot1b.diagnostics(&file1);
+        assert!(diagnostics1b
+            .iter()
+            .all(|d| d.severity != DiagnosticSeverity::Error));
+    }
+
     // Add a file to project 2 that would be invalid in project 1
     let file2 = FilePath::new("file:///pokemon/query.graphql");
     host2.add_file(&file2, "query { pokemon }", FileKind::ExecutableGraphQL, 0);
     host2.rebuild_project_files();
-    let snapshot2b = host2.snapshot();
-    let diagnostics2b = snapshot2b.diagnostics(&file2);
-    assert!(diagnostics2b
-        .iter()
-        .all(|d| d.severity != DiagnosticSeverity::Error));
+
+    {
+        let snapshot2b = host2.snapshot();
+        let diagnostics2b = snapshot2b.diagnostics(&file2);
+        assert!(diagnostics2b
+            .iter()
+            .all(|d| d.severity != DiagnosticSeverity::Error));
+    }
+
     // Cross-check: project 1 should not recognize 'pokemon', project 2 should not recognize 'hero'
     let file1_invalid = FilePath::new("file:///starwars/query_pokemon.graphql");
     host1.add_file(
@@ -60,11 +82,15 @@ fn test_analysis_host_isolation_between_projects() {
         0,
     );
     host1.rebuild_project_files();
-    let snapshot1c = host1.snapshot();
-    let diagnostics1c = snapshot1c.diagnostics(&file1_invalid);
-    assert!(diagnostics1c
-        .iter()
-        .any(|d| d.severity == DiagnosticSeverity::Error));
+
+    {
+        let snapshot1c = host1.snapshot();
+        let diagnostics1c = snapshot1c.diagnostics(&file1_invalid);
+        assert!(diagnostics1c
+            .iter()
+            .any(|d| d.severity == DiagnosticSeverity::Error));
+    }
+
     let file2_invalid = FilePath::new("file:///pokemon/query_hero.graphql");
     host2.add_file(
         &file2_invalid,
@@ -73,9 +99,12 @@ fn test_analysis_host_isolation_between_projects() {
         0,
     );
     host2.rebuild_project_files();
-    let snapshot2c = host2.snapshot();
-    let diagnostics2c = snapshot2c.diagnostics(&file2_invalid);
-    assert!(diagnostics2c
-        .iter()
-        .any(|d| d.severity == DiagnosticSeverity::Error));
+
+    {
+        let snapshot2c = host2.snapshot();
+        let diagnostics2c = snapshot2c.diagnostics(&file2_invalid);
+        assert!(diagnostics2c
+            .iter()
+            .any(|d| d.severity == DiagnosticSeverity::Error));
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes the hanging test in `analysis_host_isolation.rs` by properly scoping snapshots
- Snapshots must be dropped before mutating the `AnalysisHost` (Salsa's single-writer, multi-reader model)
- Added module documentation explaining the snapshot lifecycle requirements

## Details

The test was marked with `#[ignore = "hangs due to Salsa deadlock when rebuilding project files"]` because snapshots (`Analysis`) were being kept alive while calling mutating methods like `add_file()` and `rebuild_project_files()`. 

Salsa uses a single-writer, multi-reader model where:
- Snapshots hold read locks on the database
- Mutations require exclusive write access
- Mutations will hang indefinitely waiting for all snapshots to be dropped

The fix scopes each snapshot usage in a block so it's dropped before the next mutation.

## Test plan

- [x] Run `cargo test --package graphql-ide test_analysis_host_isolation_between_projects` - now passes (was hanging)
- [x] Run full test suite with `cargo test`
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

---

Addresses recommendation #7 from #347.