### PR TITLE
fix(ide): consolidate remove_file into single lock acquisition

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -619,17 +619,9 @@ impl AnalysisHost {
 
     /// Remove a file from the host
     pub fn remove_file(&mut self, path: &FilePath) {
-        let file_id = {
-            let registry = self.registry.read();
-            registry.get_file_id(path)
-        };
-
-        if let Some(file_id) = file_id {
-            {
-                let mut registry = self.registry.write();
-                registry.remove_file(file_id);
-            } // Drop lock before rebuilding ProjectFiles
-            let mut registry = self.registry.write();
+        let mut registry = self.registry.write();
+        if let Some(file_id) = registry.get_file_id(path) {
+            registry.remove_file(file_id);
             registry.rebuild_project_files(&mut self.db);
         }
     }


### PR DESCRIPTION
## Summary

- Consolidates `remove_file` to use a single write lock instead of multiple lock acquisitions
- Eliminates race condition where registry could be modified between lock releases

## Details

The previous implementation had a race condition:

```rust
// OLD CODE - Race condition between lock acquisitions
let file_id = {
    let registry = self.registry.read();  // Lock 1
    registry.get_file_id(path)
};  // Lock 1 released - RACE WINDOW

if let Some(file_id) = file_id {
    {
        let mut registry = self.registry.write();  // Lock 2
        registry.remove_file(file_id);
    }  // Lock 2 released - RACE WINDOW
    let mut registry = self.registry.write();  // Lock 3
    registry.rebuild_project_files(&mut self.db);
}
```

Another thread could modify the registry during either race window, potentially:
- Removing the file before we do (leading to incorrect state)
- Adding a file that gets missed during rebuild

The fix consolidates to a single write lock:

```rust
// NEW CODE - Single lock acquisition
let mut registry = self.registry.write();
if let Some(file_id) = registry.get_file_id(path) {
    registry.remove_file(file_id);
    registry.rebuild_project_files(&mut self.db);
}
```

## Test plan

- [x] `cargo test` - all tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

---

Addresses recommendation #4 from #347.