### PR TITLE
fix(analysis): add merged_schema_diagnostics to access schema merge errors

### DIFF
--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -13,7 +13,9 @@ mod schema_validation;
 pub mod validation;
 
 pub use diagnostics::*;
-pub use merged_schema::{merged_schema_with_diagnostics, MergedSchemaResult};
+pub use merged_schema::{
+    merged_schema_diagnostics, merged_schema_with_diagnostics, MergedSchemaResult,
+};
 pub use validation::validate_file;
 
 #[salsa::db]

--- a/crates/graphql-analysis/src/merged_schema.rs
+++ b/crates/graphql-analysis/src/merged_schema.rs
@@ -142,6 +142,9 @@ pub fn merged_schema_with_diagnostics(
 /// Merge all schema files into a single `apollo_compiler::Schema`
 /// This query depends ONLY on schema file IDs and their content, not `DocumentFiles`.
 /// Changing document files will not invalidate this query.
+///
+/// **Note**: This function discards validation diagnostics. If you need schema
+/// validation errors, use [`merged_schema_with_diagnostics`] instead.
 #[salsa::tracked]
 pub fn merged_schema_from_files(
     db: &dyn GraphQLAnalysisDatabase,
@@ -150,7 +153,27 @@ pub fn merged_schema_from_files(
     merged_schema_with_diagnostics(db, project_files).schema
 }
 
+/// Get diagnostics from merging schema files
+///
+/// This returns validation errors from the schema merge process, such as:
+/// - Duplicate type definitions
+/// - Interface implementation errors
+/// - Union member validation errors
+///
+/// This is a separate query so callers can get diagnostics without
+/// also needing the schema itself.
+#[salsa::tracked]
+pub fn merged_schema_diagnostics(
+    db: &dyn GraphQLAnalysisDatabase,
+    project_files: graphql_db::ProjectFiles,
+) -> Arc<Vec<crate::Diagnostic>> {
+    merged_schema_with_diagnostics(db, project_files).diagnostics
+}
+
 /// Convenience wrapper that extracts `SchemaFiles` from `ProjectFiles`
+///
+/// **Note**: This function discards validation diagnostics. If you need schema
+/// validation errors, use [`merged_schema_with_diagnostics`] instead.
 #[salsa::tracked]
 pub fn merged_schema(
     db: &dyn GraphQLAnalysisDatabase,


### PR DESCRIPTION
## Summary

- Adds `merged_schema_diagnostics` tracked query to access schema merge validation errors
- Documents that `merged_schema` and `merged_schema_from_files` discard diagnostics

## Details

The `merged_schema_from_files` and `merged_schema` functions call `merged_schema_with_diagnostics` but only return the `.schema` field, discarding the `.diagnostics`. This meant schema merge errors (like duplicate type definitions across files) were silently lost.

Added a new tracked query:

```rust
#[salsa::tracked]
pub fn merged_schema_diagnostics(
    db: &dyn GraphQLAnalysisDatabase,
    project_files: graphql_db::ProjectFiles,
) -> Arc<Vec<Diagnostic>> {
    merged_schema_with_diagnostics(db, project_files).diagnostics
}
```

Callers can now:
1. Use `merged_schema_with_diagnostics` to get both schema and diagnostics together
2. Use `merged_schema` + `merged_schema_diagnostics` separately if they only need one at a time

The convenience functions are documented to note they discard diagnostics.

## Test plan

- [x] `cargo build` compiles successfully  
- [x] `cargo test` - all tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

---

Addresses recommendation #5 from #347.