### PR TITLE
feat: add complexity analysis for GraphQL operations

### DIFF
--- a/crates/graphql-cli/src/analysis.rs
+++ b/crates/graphql-cli/src/analysis.rs
@@ -394,6 +394,18 @@ impl CliAnalysisHost {
         let snapshot = self.host.snapshot();
         snapshot.field_coverage()
     }
+
+    /// Get complexity analysis for all operations in the project
+    ///
+    /// Analyzes each operation's selection set to calculate:
+    /// - Total complexity score (with list multipliers)
+    /// - Maximum depth
+    /// - Per-field complexity breakdown
+    /// - Warnings about potential issues (nested pagination, etc.)
+    pub fn complexity_analysis(&self) -> Vec<graphql_ide::ComplexityAnalysis> {
+        let snapshot = self.host.snapshot();
+        snapshot.complexity_analysis()
+    }
 }
 
 /// Count fragment spreads in a selection set

--- a/crates/graphql-cli/src/commands/complexity.rs
+++ b/crates/graphql-cli/src/commands/complexity.rs
@@ -1,0 +1,254 @@
+use crate::analysis::CliAnalysisHost;
+use crate::commands::common::CommandContext;
+use crate::OutputFormat;
+use anyhow::Result;
+use colored::Colorize;
+use std::path::PathBuf;
+
+/// Complexity analysis output for JSON format
+#[derive(serde::Serialize)]
+struct ComplexityOutput {
+    operation_name: String,
+    operation_type: String,
+    file: String,
+    total_complexity: u32,
+    depth: u32,
+    breakdown: Vec<FieldOutput>,
+    warnings: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct FieldOutput {
+    path: String,
+    complexity: u32,
+    multiplier: u32,
+    depth: u32,
+    is_connection: bool,
+    warning: Option<String>,
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn run(
+    config_path: Option<PathBuf>,
+    project_name: Option<&str>,
+    format: OutputFormat,
+    threshold: Option<u32>,
+    breakdown: bool,
+) -> Result<()> {
+    // Start timing
+    let start_time = std::time::Instant::now();
+
+    // Load config and validate project requirement
+    let ctx = CommandContext::load(config_path, project_name, "complexity")?;
+
+    // Get project config
+    let selected_name = CommandContext::get_project_name(project_name);
+    let project_config = ctx
+        .config
+        .projects()
+        .find(|(name, _)| *name == selected_name)
+        .map(|(_, cfg)| cfg.clone())
+        .ok_or_else(|| anyhow::anyhow!("Project '{selected_name}' not found"))?;
+
+    // Load and select project
+    let spinner = if matches!(format, OutputFormat::Human) {
+        Some(crate::progress::spinner("Loading schema and documents..."))
+    } else {
+        None
+    };
+
+    let load_start = std::time::Instant::now();
+    let host = CliAnalysisHost::from_project_config(&project_config, &ctx.base_dir)?;
+
+    if let Some(pb) = spinner {
+        pb.finish_and_clear();
+    }
+
+    let load_duration = load_start.elapsed();
+
+    // Report project loaded successfully
+    if matches!(format, OutputFormat::Human) {
+        println!("{}", "✓ Schema loaded successfully".green());
+        println!("{}", "✓ Documents loaded successfully".green());
+    }
+
+    // Run complexity analysis
+    let spinner = if matches!(format, OutputFormat::Human) {
+        Some(crate::progress::spinner(
+            "Analyzing operation complexity...",
+        ))
+    } else {
+        None
+    };
+
+    let analysis_start = std::time::Instant::now();
+    let results = host.complexity_analysis();
+
+    if let Some(pb) = spinner {
+        pb.finish_and_clear();
+    }
+
+    let analysis_duration = analysis_start.elapsed();
+
+    // Filter by threshold if specified
+    let threshold_value = threshold.unwrap_or(0);
+    let exceeds_threshold: Vec<_> = results
+        .iter()
+        .filter(|r| r.total_complexity >= threshold_value)
+        .collect();
+
+    // Display results
+    match format {
+        OutputFormat::Human => {
+            if results.is_empty() {
+                println!("\n{}", "No operations found to analyze".yellow());
+            } else {
+                println!("\n{}", "Complexity Analysis Results".bold().underline());
+                println!();
+
+                for result in &results {
+                    // Operation header
+                    let status =
+                        if threshold_value > 0 && result.total_complexity >= threshold_value {
+                            "⚠".yellow().to_string()
+                        } else {
+                            "✓".green().to_string()
+                        };
+
+                    println!(
+                        "{} {} {} ({})",
+                        status,
+                        result.operation_type.cyan(),
+                        result.operation_name.bold(),
+                        result.file.as_str().dimmed()
+                    );
+
+                    // Complexity metrics
+                    println!(
+                        "    {} {} | {} {}",
+                        "Complexity:".dimmed(),
+                        format_complexity(result.total_complexity, threshold_value),
+                        "Depth:".dimmed(),
+                        result.depth.to_string().cyan()
+                    );
+
+                    // Warnings
+                    for warning in &result.warnings {
+                        println!("    {} {}", "⚠ Warning:".yellow(), warning);
+                    }
+
+                    // Field breakdown (if requested)
+                    if breakdown && !result.breakdown.is_empty() {
+                        println!("    {}:", "Field Breakdown".dimmed());
+                        for field in &result.breakdown {
+                            let connection_tag = if field.is_connection {
+                                " [connection]".yellow().to_string()
+                            } else {
+                                String::new()
+                            };
+                            let warning_tag = if let Some(ref w) = field.warning {
+                                format!(" ⚠ {}", w.yellow())
+                            } else {
+                                String::new()
+                            };
+
+                            println!(
+                                "      {} {} (×{}){}{}",
+                                field.path.dimmed(),
+                                field.complexity.to_string().cyan(),
+                                field.multiplier,
+                                connection_tag,
+                                warning_tag
+                            );
+                        }
+                    }
+
+                    println!();
+                }
+            }
+        }
+        OutputFormat::Json => {
+            for result in &results {
+                let output = ComplexityOutput {
+                    operation_name: result.operation_name.clone(),
+                    operation_type: result.operation_type.clone(),
+                    file: result.file.as_str().to_string(),
+                    total_complexity: result.total_complexity,
+                    depth: result.depth,
+                    breakdown: result
+                        .breakdown
+                        .iter()
+                        .map(|f| FieldOutput {
+                            path: f.path.clone(),
+                            complexity: f.complexity,
+                            multiplier: f.multiplier,
+                            depth: f.depth,
+                            is_connection: f.is_connection,
+                            warning: f.warning.clone(),
+                        })
+                        .collect(),
+                    warnings: result.warnings.clone(),
+                };
+                println!("{}", serde_json::to_string(&output)?);
+            }
+        }
+    }
+
+    // Summary
+    let total_duration = start_time.elapsed();
+    if matches!(format, OutputFormat::Human) {
+        let total_ops = results.len();
+        let high_complexity = exceeds_threshold.len();
+
+        if threshold_value > 0 {
+            if high_complexity > 0 {
+                println!(
+                    "{}",
+                    format!(
+                        "⚠ {high_complexity} of {total_ops} operation(s) exceed complexity threshold ({threshold_value})"
+                    )
+                    .yellow()
+                    .bold()
+                );
+            } else {
+                println!(
+                    "{}",
+                    format!(
+                        "✓ All {total_ops} operation(s) are within complexity threshold ({threshold_value})"
+                    )
+                    .green()
+                    .bold()
+                );
+            }
+        } else {
+            println!("{}", format!("Analyzed {total_ops} operation(s)").bold());
+        }
+
+        println!(
+            "  {} load: {:.2}s, analysis: {:.2}s, total: {:.2}s",
+            "⏱".dimmed(),
+            load_duration.as_secs_f64(),
+            analysis_duration.as_secs_f64(),
+            total_duration.as_secs_f64()
+        );
+    }
+
+    // Exit with error code if threshold exceeded
+    if threshold_value > 0 && !exceeds_threshold.is_empty() {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Format complexity value with color based on threshold
+fn format_complexity(complexity: u32, threshold: u32) -> String {
+    let s = complexity.to_string();
+    if threshold > 0 && complexity >= threshold {
+        s.red().bold().to_string()
+    } else if complexity > 100 {
+        s.yellow().to_string()
+    } else {
+        s.green().to_string()
+    }
+}

--- a/crates/graphql-cli/src/commands/mod.rs
+++ b/crates/graphql-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod check;
 pub mod common;
+pub mod complexity;
 pub mod coverage;
 pub mod deprecations;
 pub mod fix;

--- a/crates/graphql-cli/src/main.rs
+++ b/crates/graphql-cli/src/main.rs
@@ -112,6 +112,21 @@ enum Commands {
         #[arg(long, value_name = "TYPE")]
         r#type: Option<String>,
     },
+
+    /// Analyze query complexity for GraphQL operations
+    Complexity {
+        /// Output format
+        #[arg(short, long, value_enum, default_value = "human")]
+        format: OutputFormat,
+
+        /// Complexity threshold - exit with error if any operation exceeds this value
+        #[arg(short, long)]
+        threshold: Option<u32>,
+
+        /// Show per-field complexity breakdown
+        #[arg(short, long)]
+        breakdown: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
@@ -160,6 +175,17 @@ async fn main() -> anyhow::Result<()> {
         Commands::Coverage { format, r#type } => {
             commands::coverage::run(cli.config, cli.project.as_deref(), format, r#type)
         }
+        Commands::Complexity {
+            format,
+            threshold,
+            breakdown,
+        } => commands::complexity::run(
+            cli.config,
+            cli.project.as_deref(),
+            format,
+            threshold,
+            breakdown,
+        ),
     };
 
     #[cfg(feature = "otel")]


### PR DESCRIPTION
## Summary

Implements query complexity analysis for GraphQL operations (#316). This feature analyzes each operation's selection set to calculate complexity metrics including total score, depth, and per-field breakdown with connection pattern detection.

## Changes

- Add `ComplexityAnalysis` and `FieldComplexity` POD types in `graphql-ide`
- Implement `complexity_analysis()` method on `Analysis` struct with recursive selection analysis
- Add connection pattern detection (Relay-style edges/nodes/pageInfo)
- Add list field multipliers with configurable default (10x)
- Add warnings for nested pagination patterns
- Create `graphql complexity` CLI command with:
  - Human-readable and JSON output formats
  - `--threshold` flag to fail on high complexity
  - `--breakdown` flag to show per-field details
- Add 3 unit tests for complexity analysis

## Consulted SME Agents

- **graphql-cli.md**: Followed CLI command patterns and output format conventions
- **rust.md**: Used idiomatic Rust patterns for the implementation
- **graphql.md**: Ensured correct understanding of GraphQL type system for complexity calculation
- **lsp.md**: Prepared groundwork for future code lens integration

## Manual Testing

- Run `cargo build` to build the CLI
- Run `target/debug/graphql complexity` on a project with operations
- Run `target/debug/graphql complexity --breakdown` to see per-field details
- Run `target/debug/graphql complexity --threshold 100` to test threshold enforcement
- Run `target/debug/graphql complexity --format json` for JSON output

## Related Issues

Closes #316