### PR TITLE
Claude web use gh cli instead of mcp

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -904,7 +904,9 @@ Claude must follow these guidelines when working on this project:
 
 ### GitHub CLI (gh) Usage
 
-When running as a Claude web instance, the git remote uses a local proxy that `gh` doesn't recognize as a GitHub host. **Always use the `--repo` flag** with all `gh` commands:
+**When running as a Claude web instance, always use the `gh` CLI instead of MCP GitHub tools.** MCP tools require permission approval dialogs that cannot be accepted in the web client, causing them to timeout.
+
+The git remote also uses a local proxy that `gh` doesn't recognize as a GitHub host. **Always use the `--repo` flag** with all `gh` commands:
 
 ```bash
 # Correct - always specify the repo explicitly


### PR DESCRIPTION
MCP GitHub tools require permission approval dialogs that cannot be accepted in the web client, causing them to timeout. Document that the gh CLI should be used instead.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- Bullet list of key changes -->

-

## Consulted SME Agents

<!--
List which SME agents from .claude/agents/ were consulted for this PR.
Format: **agent-name.md**: Key guidance received

Example:
- **lsp.md**: Confirmed response format for textDocument/definition
- **rust-analyzer.md**: Recommended query-based architecture
-->

-

## Manual Testing Plan

<!--
Steps for manually verifying these changes.

Examples:
- Run `cargo build` and open VSCode to verify hover works on type references
- Execute `graphql lint --project frontend` and confirm new rule triggers
- Open a .ts file with embedded GraphQL and verify diagnostics appear

Leave empty or write "N/A" if no manual testing is needed.

IMPORTANT: Do NOT mention automated test results, clippy results, or CI status
anywhere in the PR description. Statements like "all tests passing" or "clippy
clean" are unnecessary - CI enforces these automatically and they add no value.
This section is ONLY for manual verification steps that reviewers can follow.
-->

-

## Related Issues

<!-- Link to related issues if any (e.g., Fixes #123, Closes #456) -->
