### PR TITLE
perf(hir): use returns(ref) for large Salsa query result types

### DIFF
--- a/crates/graphql-analysis/src/document_validation.rs
+++ b/crates/graphql-analysis/src/document_validation.rs
@@ -83,7 +83,7 @@ pub fn validate_document_file(
         let op_range =
             text_range_to_diagnostic_range(db, content, metadata, op_structure.operation_range);
         for var in &op_structure.variables {
-            validate_variable_type(&var.type_ref, &schema, op_range, &mut diagnostics);
+            validate_variable_type(&var.type_ref, schema, op_range, &mut diagnostics);
         }
 
         let root_type_name = match op_structure.operation_type {
@@ -131,7 +131,7 @@ pub fn validate_document_file(
         );
         validate_fragment_type_condition(
             frag_structure,
-            &schema,
+            schema,
             type_condition_range,
             &mut diagnostics,
         );

--- a/crates/graphql-analysis/src/project_lints.rs
+++ b/crates/graphql-analysis/src/project_lints.rs
@@ -17,7 +17,7 @@ pub fn find_unused_fields(db: &dyn GraphQLAnalysisDatabase) -> Arc<Vec<(FieldId,
 
     // Step 1: Collect all schema fields (type_name, field_name) -> (FileId, FieldSignature)
     let mut schema_fields: SchemaFieldsMap = HashMap::new();
-    for (type_name, type_def) in schema.iter() {
+    for (type_name, type_def) in schema {
         for field in &type_def.fields {
             schema_fields.insert(
                 (type_name.clone(), field.name.clone()),
@@ -58,8 +58,8 @@ pub fn find_unused_fields(db: &dyn GraphQLAnalysisDatabase) -> Arc<Vec<(FieldId,
             collect_used_fields_from_selections(
                 &body.selections,
                 &root_type,
-                &schema,
-                &all_fragments,
+                schema,
+                all_fragments,
                 db,
                 &document_files,
                 &mut used_fields,
@@ -126,7 +126,7 @@ pub fn find_unused_fragments(
     // follows them recursively.
 
     let mut unused = Vec::new();
-    for (fragment_name, _fragment_structure) in all_fragments.iter() {
+    for fragment_name in all_fragments.keys() {
         if !used_fragments.contains(fragment_name) {
             // Create a dummy FragmentId - in a real implementation,
             // we'd track the actual FragmentId in the HIR

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -1031,7 +1031,7 @@ impl Analysis {
                     let parent_ctx = find_parent_type_at_offset(block_context.tree, offset)?;
                     let parent_type_name = symbol::walk_type_stack_to_offset(
                         block_context.tree,
-                        &types,
+                        types,
                         offset,
                         &parent_ctx.root_type,
                     )?;
@@ -1174,7 +1174,7 @@ impl Analysis {
                 // which handles inline fragments correctly
                 let parent_type_name = symbol::walk_type_stack_to_offset(
                     &parse.tree,
-                    &types,
+                    types,
                     offset,
                     &parent_ctx.root_type,
                 )?;
@@ -1295,7 +1295,7 @@ impl Analysis {
                 // which handles inline fragments correctly
                 let parent_type_name = symbol::walk_type_stack_to_offset(
                     block_context.tree,
-                    &schema_types,
+                    schema_types,
                     offset,
                     &parent_context.root_type,
                 )?;
@@ -1487,7 +1487,7 @@ impl Analysis {
 
                 let parent_type_name = symbol::walk_type_stack_to_offset(
                     block_context.tree,
-                    &schema_types,
+                    schema_types,
                     offset,
                     &parent_context.root_type,
                 )?;
@@ -1834,7 +1834,7 @@ impl Analysis {
                 &parse,
                 type_name,
                 field_name,
-                &schema_types,
+                schema_types,
                 content,
                 &self.db,
                 line_offset,
@@ -1975,7 +1975,7 @@ impl Analysis {
 
         // Search types
         let types = graphql_hir::schema_types(&self.db, project_files);
-        for (name, type_def) in types.iter() {
+        for (name, type_def) in types {
             if name.to_lowercase().contains(&query_lower) {
                 if let Some(location) = self.get_type_location(type_def) {
                     let kind = match type_def.kind {
@@ -1994,7 +1994,7 @@ impl Analysis {
 
         // Search fragments
         let fragments = graphql_hir::all_fragments(&self.db, project_files);
-        for (name, fragment) in fragments.iter() {
+        for (name, fragment) in fragments {
             if name.to_lowercase().contains(&query_lower) {
                 if let Some(location) = self.get_fragment_location(fragment) {
                     symbols.push(

--- a/crates/graphql-linter/src/rules/no_deprecated.rs
+++ b/crates/graphql-linter/src/rules/no_deprecated.rs
@@ -54,14 +54,14 @@ impl DocumentSchemaLintRule for NoDeprecatedRuleImpl {
             || file_kind == graphql_db::FileKind::Schema
         {
             let doc_cst = parse.tree.document();
-            check_document_for_deprecated(&doc_cst, &schema_types, &mut diagnostics);
+            check_document_for_deprecated(&doc_cst, schema_types, &mut diagnostics);
         }
 
         // Check operations in extracted blocks (TypeScript/JavaScript)
         for block in &parse.blocks {
             let block_doc = block.tree.document();
             let mut block_diagnostics = Vec::new();
-            check_document_for_deprecated(&block_doc, &schema_types, &mut block_diagnostics);
+            check_document_for_deprecated(&block_doc, schema_types, &mut block_diagnostics);
             // Add block context to each diagnostic for proper position calculation
             for diag in block_diagnostics {
                 diagnostics.push(diag.with_block_context(block.line, block.source.clone()));

--- a/crates/graphql-linter/src/rules/redundant_fields.rs
+++ b/crates/graphql-linter/src/rules/redundant_fields.rs
@@ -76,7 +76,7 @@ impl StandaloneDocumentLintRule for RedundantFieldsRuleImpl {
         let all_fragments = graphql_hir::all_fragments(db, project_files);
 
         // Add cross-file fragments to the registry
-        for (fragment_name, fragment_info) in all_fragments.iter() {
+        for (fragment_name, fragment_info) in all_fragments {
             // Skip if we already have this fragment from the current document
             if fragments.get(fragment_name.as_ref()).is_some() {
                 continue;

--- a/crates/graphql-linter/src/rules/require_id_field.rs
+++ b/crates/graphql-linter/src/rules/require_id_field.rs
@@ -43,7 +43,7 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
 
         // Build a map of type names to whether they have an id field
         let mut types_with_id: HashMap<String, bool> = HashMap::new();
-        for (type_name, type_def) in schema_types.iter() {
+        for (type_name, type_def) in schema_types {
             let has_id = match type_def.kind {
                 graphql_hir::TypeDefKind::Object | graphql_hir::TypeDefKind::Interface => {
                     type_def.fields.iter().any(|f| f.name.as_ref() == "id")
@@ -57,7 +57,7 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
         let all_fragments = graphql_hir::all_fragments(db, project_files);
 
         // Get root operation types from schema definition or fall back to defaults
-        let root_types = extract_root_type_names(db, project_files, &schema_types);
+        let root_types = extract_root_type_names(db, project_files, schema_types);
         let query_type = root_types.query;
         let mutation_type = root_types.mutation;
         let subscription_type = root_types.subscription;
@@ -66,9 +66,9 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
         let check_context = CheckContext {
             db,
             project_files,
-            schema_types: &schema_types,
+            schema_types,
             types_with_id: &types_with_id,
-            all_fragments: &all_fragments,
+            all_fragments,
         };
 
         // Check the main document (for .graphql files only)

--- a/crates/graphql-linter/src/rules/unused_fields.rs
+++ b/crates/graphql-linter/src/rules/unused_fields.rs
@@ -35,7 +35,7 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
         let mut schema_fields: HashMap<String, HashSet<String>> = HashMap::new();
         let mut field_locations: HashMap<(String, String), FileId> = HashMap::new();
 
-        for (type_name, type_def) in schema_types.iter() {
+        for (type_name, type_def) in schema_types {
             // Skip introspection types
             if is_introspection_type(type_name) {
                 continue;
@@ -63,7 +63,7 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
         let doc_ids = project_files.document_file_ids(db).ids(db);
 
         // Determine root types for skipping (supports custom schema definitions)
-        let root_types = extract_root_type_names(db, project_files, &schema_types);
+        let root_types = extract_root_type_names(db, project_files, schema_types);
 
         for file_id in doc_ids.iter() {
             // Use per-file lookup for granular caching
@@ -128,7 +128,6 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
         diagnostics_by_file
     }
 }
-
 
 /// Check if a type is a built-in introspection type
 fn is_introspection_type(type_name: &str) -> bool {


### PR DESCRIPTION
## Summary

- Use Salsa's `returns(ref)` attribute on `file_type_defs`, `schema_types`, and `all_fragments` queries to return references instead of cloned Arc values
- This avoids Arc clone overhead on every query access by having Salsa manage the storage lifetime

## Details

Before this change, queries like `schema_types(db, project_files)` returned `Arc<HashMap<...>>`, requiring an Arc clone on every access even when the value is just being borrowed.

After this change, these queries return `&HashMap<...>` directly, with Salsa managing the storage lifetime. This eliminates atomic reference counting overhead.

### Affected Queries

| Query | Before | After |
|-------|--------|-------|
| `file_type_defs` | `Arc<Vec<TypeDef>>` | `&Vec<TypeDef>` |
| `schema_types` | `Arc<HashMap<...>>` | `&HashMap<...>` |
| `all_fragments` | `Arc<HashMap<...>>` | `&HashMap<...>` |

### Call Site Updates

Call sites were updated to work with references - mostly removing unnecessary `&` prefixes and `.iter()` calls since the returned reference already dereferences to the underlying type. No semantic changes to any call sites.

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Clippy passes (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)

Fixes #364