### PR TITLE
Make CLI project flag position flexible

### DIFF
--- a/crates/graphql-cli/src/main.rs
+++ b/crates/graphql-cli/src/main.rs
@@ -11,11 +11,11 @@ use std::path::PathBuf;
 #[command(version)]
 struct Cli {
     /// Path to GraphQL config file
-    #[arg(short, long, value_name = "FILE")]
+    #[arg(short, long, value_name = "FILE", global = true)]
     config: Option<PathBuf>,
 
     /// Project name (for multi-project configs)
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     project: Option<String>,
 
     #[command(subcommand)]


### PR DESCRIPTION
Add `global = true` to the `--project` and `--config` arguments, allowing them to be specified anywhere on the command line instead of requiring them before the subcommand.

Before: graphql --project foo validate
After:  graphql validate --project foo  (also works)

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- Bullet list of key changes -->

-

## Consulted SME Agents

<!--
List which SME agents from .claude/agents/ were consulted for this PR.
Format: **agent-name.md**: Key guidance received

Example:
- **lsp.md**: Confirmed response format for textDocument/definition
- **rust-analyzer.md**: Recommended query-based architecture
-->

-

## Manual Testing Plan

<!--
Steps for manually verifying these changes.

Examples:
- Run `cargo build` and open VSCode to verify hover works on type references
- Execute `graphql lint --project frontend` and confirm new rule triggers
- Open a .ts file with embedded GraphQL and verify diagnostics appear

Leave empty or write "N/A" if no manual testing is needed.

IMPORTANT: Do NOT mention automated test results, clippy results, or CI status
anywhere in the PR description. Statements like "all tests passing" or "clippy
clean" are unnecessary - CI enforces these automatically and they add no value.
This section is ONLY for manual verification steps that reviewers can follow.
-->

-

## Related Issues

<!-- Link to related issues if any (e.g., Fixes #123, Closes #456) -->
