### PR TITLE
chore: make graphql-cli the default workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+default-members = ["crates/graphql-cli"]
 members = [
     "crates/graphql-config",
     "crates/graphql-extract",


### PR DESCRIPTION
## Summary

- Adds `default-members = ["crates/graphql-cli"]` to workspace Cargo.toml
- This allows `cargo run` to run the CLI directly without needing `-p graphql-cli`

## Test plan

- [x] `cargo run -- --help` shows CLI help
- [x] `cargo build` succeeds
- [x] `cargo test` passes
- [x] `cargo clippy` passes