### PR TITLE
Fix duplicate fragment diagnostics on save

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -355,10 +355,20 @@ documents: "**/*.graphql"
                                                         &path_str, &content,
                                                     );
 
-                                                    let path_str = path_str.trim_start_matches('/');
-                                                    let uri = format!("file:///{path_str}");
+                                                    // Use Uri::from_file_path for proper URI construction
+                                                    // This ensures consistency with how VSCode formats URIs
+                                                    let uri_string = if let Some(uri) =
+                                                        Uri::from_file_path(&path)
+                                                    {
+                                                        uri.to_string()
+                                                    } else {
+                                                        // Fallback to manual construction
+                                                        let path_str =
+                                                            path_str.trim_start_matches('/');
+                                                        format!("file:///{path_str}")
+                                                    };
                                                     let file_path =
-                                                        graphql_ide::FilePath::new(uri.clone());
+                                                        graphql_ide::FilePath::new(uri_string);
 
                                                     collected_files
                                                         .push((file_path, content, file_kind));


### PR DESCRIPTION
## Summary

- Fixed duplicate fragment false positives that appeared on save in fragment files
- Changed glob discovery to use `Uri::from_file_path()` for consistent URI formatting with VSCode
- Added tests for project-wide lint duplicate detection scenarios

## Test plan

- [x] Added `test_project_lint_no_duplicates_same_file` - verifies single fragment files don't produce false duplicates
- [x] Added `test_project_lint_detects_actual_duplicates` - verifies actual duplicates ARE detected
- [x] Added `test_project_lint_file_update_no_duplicates` - verifies file updates don't cause false duplicates
- [x] Added `test_project_lint_different_uri_formats_same_file_no_duplicates` - verifies same file with same URI is correctly identified
- [x] All existing tests pass