### PR TITLE
fix(vscode): align config setting names with README documentation

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -68,7 +68,7 @@
       "type": "object",
       "title": "GraphQL LSP",
       "properties": {
-        "graphql-lsp.trace.server": {
+        "graphql.trace.server": {
           "type": "string",
           "enum": [
             "off",
@@ -78,10 +78,18 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "graphql-lsp.serverPath": {
+        "graphql.server.path": {
           "type": "string",
           "default": "",
           "description": "Path to the graphql-lsp server executable. If empty, the extension will search for it in PATH or download it automatically."
+        },
+        "graphql.server.env": {
+          "type": "object",
+          "default": {},
+          "description": "Environment variables to pass to the LSP server process.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -22,11 +22,13 @@ let client: LanguageClient;
 let outputChannel: OutputChannel;
 
 async function startLanguageServer(context: ExtensionContext): Promise<void> {
-  const config = workspace.getConfiguration("graphql-lsp");
-  const customPath = config.get<string>("serverPath");
+  const config = workspace.getConfiguration("graphql");
+  const customPath = config.get<string>("server.path");
 
   const serverCommand = await findServerBinary(context, outputChannel, customPath);
   outputChannel.appendLine(`Using LSP server at: ${serverCommand}`);
+
+  const serverEnv = config.get<Record<string, string>>("server.env") || {};
 
   const run: Executable = {
     command: serverCommand,
@@ -34,6 +36,7 @@ async function startLanguageServer(context: ExtensionContext): Promise<void> {
       env: {
         ...process.env,
         RUST_LOG: process.env.RUST_LOG || "debug",
+        ...serverEnv,
       },
     },
   };


### PR DESCRIPTION
## Summary

- Aligns VSCode extension configuration names with what the README documents
- Changes `graphql-lsp.*` prefix to `graphql.*` for consistency
- Adds missing `graphql.server.env` setting for custom environment variables

## Changes

| Before | After |
|--------|-------|
| `graphql-lsp.trace.server` | `graphql.trace.server` |
| `graphql-lsp.serverPath` | `graphql.server.path` |
| (missing) | `graphql.server.env` |

## Test Plan

- [ ] Verify settings appear correctly in VSCode settings UI under "GraphQL LSP"
- [ ] Test that `graphql.server.path` works for custom server binary
- [ ] Test that `graphql.server.env` passes env vars to LSP server

Addresses part of #356