### PR TITLE
fix(vscode): don't auto-show output channel on activation

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -103,7 +103,6 @@ async function startLanguageServer(context: ExtensionContext): Promise<void> {
 
 export async function activate(context: ExtensionContext) {
   outputChannel = window.createOutputChannel("GraphQL LSP Debug");
-  outputChannel.show(true);
   outputChannel.appendLine("=== GraphQL LSP extension activating ===");
 
   try {
@@ -124,6 +123,7 @@ export async function activate(context: ExtensionContext) {
       } catch (error) {
         const errorMessage = `Failed to restart GraphQL LSP: ${error}`;
         outputChannel.appendLine(errorMessage);
+        outputChannel.show(true);
         window.showErrorMessage(errorMessage);
       }
     });
@@ -146,6 +146,7 @@ export async function activate(context: ExtensionContext) {
       } catch (error) {
         const errorMessage = `Failed to check status: ${error}`;
         outputChannel.appendLine(errorMessage);
+        outputChannel.show(true);
         window.showErrorMessage(errorMessage);
       }
     });
@@ -154,6 +155,7 @@ export async function activate(context: ExtensionContext) {
   } catch (error) {
     const errorMessage = `Failed to start GraphQL LSP: ${error}`;
     outputChannel.appendLine(errorMessage);
+    outputChannel.show(true);
     window.showErrorMessage(errorMessage);
     throw error;
   }


### PR DESCRIPTION
## Summary

- Removes automatic display of output channel on every extension activation
- Output channel now only shown when errors occur, providing debug info when needed

## Changes

- Remove `outputChannel.show(true)` from activation
- Add `outputChannel.show(true)` to all error handlers

## Test Plan

- [ ] Activate extension - output channel should NOT appear
- [ ] Trigger an error (e.g., bad server path) - output channel should appear
- [ ] Use "Check Status" command with error - output channel should appear

Addresses part of #356