### PR TITLE
feat(vscode): add status bar item showing LSP state

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -7,12 +7,15 @@ import {
   OutputChannel,
   ProgressLocation,
   commands,
+  StatusBarItem,
+  StatusBarAlignment,
 } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   Executable,
+  State,
 } from "vscode-languageclient/node";
 import { findServerBinary } from "./binaryManager";
 
@@ -20,6 +23,27 @@ console.log(">>> GraphQL LSP extension imports complete <<<");
 
 let client: LanguageClient;
 let outputChannel: OutputChannel;
+let statusBarItem: StatusBarItem;
+
+function updateStatusBar(state: State): void {
+  switch (state) {
+    case State.Running:
+      statusBarItem.text = "$(check) GraphQL";
+      statusBarItem.tooltip = "GraphQL LSP is running";
+      statusBarItem.backgroundColor = undefined;
+      break;
+    case State.Starting:
+      statusBarItem.text = "$(sync~spin) GraphQL";
+      statusBarItem.tooltip = "GraphQL LSP is starting...";
+      statusBarItem.backgroundColor = undefined;
+      break;
+    case State.Stopped:
+      statusBarItem.text = "$(warning) GraphQL";
+      statusBarItem.tooltip = "GraphQL LSP is stopped";
+      statusBarItem.backgroundColor = undefined;
+      break;
+  }
+}
 
 async function startLanguageServer(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration("graphql-lsp");
@@ -67,6 +91,10 @@ async function startLanguageServer(context: ExtensionContext): Promise<void> {
     clientOptions
   );
 
+  client.onDidChangeState((event) => {
+    updateStatusBar(event.newState);
+  });
+
   outputChannel.appendLine("Starting language client...");
 
   await window.withProgress(
@@ -105,6 +133,13 @@ export async function activate(context: ExtensionContext) {
   outputChannel = window.createOutputChannel("GraphQL LSP Debug");
   outputChannel.show(true);
   outputChannel.appendLine("=== GraphQL LSP extension activating ===");
+
+  statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  statusBarItem.command = "graphql-lsp.checkStatus";
+  statusBarItem.text = "$(sync~spin) GraphQL";
+  statusBarItem.tooltip = "GraphQL LSP is starting...";
+  statusBarItem.show();
+  context.subscriptions.push(statusBarItem);
 
   try {
     await startLanguageServer(context);
@@ -155,6 +190,8 @@ export async function activate(context: ExtensionContext) {
     const errorMessage = `Failed to start GraphQL LSP: ${error}`;
     outputChannel.appendLine(errorMessage);
     window.showErrorMessage(errorMessage);
+    statusBarItem.text = "$(error) GraphQL";
+    statusBarItem.tooltip = `GraphQL LSP failed to start: ${error}`;
     throw error;
   }
 


### PR DESCRIPTION
## Summary

- Adds a status bar item showing the current GraphQL LSP connection state
- Provides visual feedback on server status without needing to check output

## Changes

Status bar states:
| State | Icon | Tooltip |
|-------|------|---------|
| Starting | $(sync~spin) | "GraphQL LSP is starting..." |
| Running | $(check) | "GraphQL LSP is running" |
| Stopped | $(warning) | "GraphQL LSP is stopped" |
| Error | $(error) | Error details |

Clicking the status bar item runs the "Check Status" command.

## Test Plan

- [ ] Start extension - status bar shows spinning icon then checkmark
- [ ] Stop server - status bar shows warning icon
- [ ] Trigger startup error - status bar shows error icon with tooltip details

Addresses part of #356