### PR TITLE
feat(vscode): activate extension for TS/JS files with embedded GraphQL

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -14,6 +14,10 @@
   ],
   "activationEvents": [
     "onLanguage:graphql",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "workspaceContains:**/graphql.config.{yaml,yml,json}",
     "workspaceContains:**/.graphqlrc{.yaml,.yml,.json,}"
   ],


### PR DESCRIPTION
## Summary

- Adds activation events for TypeScript and JavaScript files
- Enables LSP features for embedded GraphQL in template literals

## Changes

New activation events:
- `onLanguage:typescript`
- `onLanguage:typescriptreact`
- `onLanguage:javascript`
- `onLanguage:javascriptreact`

## Background

Previously, the extension only activated when:
- Opening `.graphql` files
- A GraphQL config file was present in the workspace

This meant users with embedded GraphQL in TS/JS files had to either:
1. Have a config file
2. Open a `.graphql` file first

## Test Plan

- [ ] Open a TS file with embedded GraphQL - extension should activate
- [ ] Verify diagnostics work for embedded GraphQL queries
- [ ] Verify goto definition works in embedded GraphQL

Addresses part of #356