### PR TITLE
fix(vscode): remove fragile config-loaded detection

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -80,23 +80,6 @@ async function startLanguageServer(context: ExtensionContext): Promise<void> {
 
       await client.start();
       outputChannel.appendLine("Language client started successfully!");
-
-      progress.report({ message: "Loading GraphQL configuration..." });
-
-      await new Promise<void>((resolve) => {
-        const disposable = client.onNotification("window/logMessage", (params) => {
-          if (params.message === "GraphQL config loaded successfully") {
-            window.showInformationMessage("GraphQL LSP: Configuration loaded successfully");
-            disposable.dispose();
-            resolve();
-          }
-        });
-
-        setTimeout(() => {
-          disposable.dispose();
-          resolve();
-        }, 5000);
-      });
     }
   );
 }


### PR DESCRIPTION
## Summary

- Removes fragile notification listener that waited for specific log message
- Simplifies startup by resolving after `client.start()` completes

## Problem

The previous implementation:
1. Listened for `"GraphQL config loaded successfully"` message
2. Had a 5 second timeout fallback
3. Would always wait 5s if message format changed

## Solution

Simply resolve the progress notification after `client.start()` completes,
which is sufficient for indicating server readiness.

## Test Plan

- [ ] Start extension - should complete quickly without 5s delay
- [ ] Verify LSP features work after startup
- [ ] Check that progress notification dismisses promptly

Addresses part of #356