### PR TITLE
feat(vscode): add keybinding for restart server command

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -84,7 +84,14 @@
           "description": "Path to the graphql-lsp server executable. If empty, the extension will search for it in PATH or download it automatically."
         }
       }
-    }
+    },
+    "keybindings": [
+      {
+        "command": "graphql-lsp.restartServer",
+        "key": "ctrl+alt+g r",
+        "mac": "cmd+alt+g r"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
## Summary

- Adds keyboard shortcut for restarting the GraphQL language server

## Changes

New keybinding:
| Platform | Shortcut |
|----------|----------|
| Windows/Linux | `Ctrl+Alt+G R` |
| macOS | `Cmd+Alt+G R` |

## Test Plan

- [ ] Press the keybinding - server should restart
- [ ] Verify keybinding appears in Keyboard Shortcuts settings
- [ ] Test on macOS variant works

Addresses part of #356