### PR TITLE
feat(linter): add configurable lint options for rules

### DIFF
--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -21,6 +21,7 @@ projects:
       extends: recommended
       rules:
         no_deprecated: warn
+        require_id_field: [warn, { fields: ["id", "databaseId"] }]
 
   github-admin:
     schema:
@@ -31,6 +32,10 @@ projects:
       extends: recommended
       rules:
         no_deprecated: error
+        require_id_field:
+          severity: error
+          options:
+            fields: ["id"]
 
   countries:
     schema:

--- a/crates/graphql-analysis/src/lint_integration.rs
+++ b/crates/graphql-analysis/src/lint_integration.rs
@@ -122,7 +122,8 @@ fn standalone_document_lints(
             continue;
         }
 
-        let lint_diags = rule.check(db, file_id, content, metadata, project_files);
+        let options = lint_config.get_options(rule.name());
+        let lint_diags = rule.check(db, file_id, content, metadata, project_files, options);
 
         if !lint_diags.is_empty() {
             tracing::debug!(
@@ -170,7 +171,8 @@ fn document_schema_lints(
             continue;
         }
 
-        let lint_diags = rule.check(db, file_id, content, metadata, project_files);
+        let options = lint_config.get_options(rule.name());
+        let lint_diags = rule.check(db, file_id, content, metadata, project_files, options);
 
         if !lint_diags.is_empty() {
             tracing::debug!(
@@ -254,7 +256,8 @@ fn project_lint_diagnostics_impl(
             continue;
         }
 
-        let lint_diags = rule.check(db, project_files);
+        let options = lint_config.get_options(rule.name());
+        let lint_diags = rule.check(db, project_files, options);
 
         tracing::info!(
             rule = rule.name(),
@@ -328,14 +331,30 @@ pub fn lint_file_with_fixes(
         // Standalone document lints
         for rule in graphql_linter::standalone_document_rules() {
             if lint_config.is_enabled(rule.name()) {
-                all_diagnostics.extend(rule.check(db, file_id, content, metadata, project_files));
+                let options = lint_config.get_options(rule.name());
+                all_diagnostics.extend(rule.check(
+                    db,
+                    file_id,
+                    content,
+                    metadata,
+                    project_files,
+                    options,
+                ));
             }
         }
 
         // Document+schema lints
         for rule in graphql_linter::document_schema_rules() {
             if lint_config.is_enabled(rule.name()) {
-                all_diagnostics.extend(rule.check(db, file_id, content, metadata, project_files));
+                let options = lint_config.get_options(rule.name());
+                all_diagnostics.extend(rule.check(
+                    db,
+                    file_id,
+                    content,
+                    metadata,
+                    project_files,
+                    options,
+                ));
             }
         }
     }
@@ -364,7 +383,8 @@ pub fn project_lint_diagnostics_with_fixes(
         }
 
         // Run the project-wide rule
-        let lint_diags = rule.check(db, project_files);
+        let options = lint_config.get_options(rule.name());
+        let lint_diags = rule.check(db, project_files, options);
 
         // Merge into result
         for (file_id, file_lint_diags) in lint_diags {

--- a/crates/graphql-linter/README.md
+++ b/crates/graphql-linter/README.md
@@ -226,6 +226,27 @@ extensions:
 - `warn` - Show as warning
 - `error` - Show as error
 
+### Rule Options
+
+Some rules support additional configuration options. Options can be specified using either ESLint-style array syntax or object syntax:
+
+```yaml
+# ESLint-style array: [severity, options]
+lint:
+  rules:
+    require_id_field: [warn, { fields: ["id", "uuid"] }]
+
+# Object style
+lint:
+  rules:
+    require_id_field:
+      severity: warn
+      options:
+        fields: ["id", "uuid"]
+```
+
+See individual rule documentation for available options.
+
 ## Built-in Rules
 
 ### redundant_fields
@@ -264,6 +285,72 @@ The rule handles:
 - Transitive redundancy (field in fragment that includes other fragments)
 - Circular fragment references (prevents infinite loops)
 - Aliased fields (only same alias is considered redundant)
+
+### require_id_field
+
+**Type**: DocumentSchemaRule
+**Default**: `warn`
+**Performance**: Fast
+
+Warns when selection sets on types that have an `id` field don't include it. This is useful for ensuring cache normalization works correctly with tools like Apollo Client.
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fields` | `string[]` | `["id"]` | Field names to require if they exist on the type |
+
+**Configuration examples:**
+
+```yaml
+# Default: require 'id' field
+lint:
+  rules:
+    require_id_field: warn
+
+# Require a different field (e.g., for Relay-style nodeId)
+lint:
+  rules:
+    require_id_field: [warn, { fields: ["nodeId"] }]
+
+# Require multiple fields (if they exist on the type)
+lint:
+  rules:
+    require_id_field:
+      severity: warn
+      options:
+        fields: ["id", "uuid"]
+
+# Disable the rule
+lint:
+  rules:
+    require_id_field: off
+```
+
+**Example:**
+
+```graphql
+# Schema
+type User {
+  id: ID!
+  name: String!
+}
+
+# Query
+query GetUser {
+  user {
+    name  # ⚠️ Warning: Selection set on type 'User' should include the 'id' field
+  }
+}
+
+# Fixed
+query GetUser {
+  user {
+    id    # ✅ OK
+    name
+  }
+}
+```
 
 ### no_deprecated
 

--- a/crates/graphql-linter/src/rules/no_anonymous_operations.rs
+++ b/crates/graphql-linter/src/rules/no_anonymous_operations.rs
@@ -54,6 +54,7 @@ impl StandaloneDocumentLintRule for NoAnonymousOperationsRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         _project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
         let mut diagnostics = Vec::new();
 
@@ -184,7 +185,7 @@ query {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("Anonymous query operation"));
@@ -215,7 +216,7 @@ query {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("Anonymous query operation"));
@@ -246,7 +247,7 @@ mutation {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0]
@@ -279,7 +280,7 @@ subscription {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0]
@@ -312,7 +313,7 @@ query GetUser {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -341,7 +342,7 @@ mutation UpdateUser {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -370,7 +371,7 @@ subscription OnMessageAdded {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -410,7 +411,7 @@ query {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should have 2 diagnostics - one for the anonymous mutation, one for the anonymous query
         assert_eq!(diagnostics.len(), 2);
@@ -451,7 +452,7 @@ query GetUser {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Fragment definitions should be ignored, query is named
         assert_eq!(diagnostics.len(), 0);
@@ -481,7 +482,7 @@ query {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Even a single anonymous operation should fail (per user's request)
         assert_eq!(diagnostics.len(), 1);
@@ -512,7 +513,7 @@ query GetUserById($id: ID!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -541,7 +542,7 @@ query($id: ID!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("Anonymous query operation"));
@@ -569,7 +570,7 @@ subscription { onUserUpdate { id } }
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         let messages: Vec<&str> = diagnostics.iter().map(|d| d.message.as_str()).collect();
         insta::assert_yaml_snapshot!(messages);

--- a/crates/graphql-linter/src/rules/no_deprecated.rs
+++ b/crates/graphql-linter/src/rules/no_deprecated.rs
@@ -35,6 +35,7 @@ impl DocumentSchemaLintRule for NoDeprecatedRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
         let mut diagnostics = Vec::new();
 

--- a/crates/graphql-linter/src/rules/operation_name_suffix.rs
+++ b/crates/graphql-linter/src/rules/operation_name_suffix.rs
@@ -31,6 +31,7 @@ impl StandaloneDocumentLintRule for OperationNameSuffixRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         _project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
         let mut diagnostics = Vec::new();
 

--- a/crates/graphql-linter/src/rules/redundant_fields.rs
+++ b/crates/graphql-linter/src/rules/redundant_fields.rs
@@ -51,6 +51,7 @@ impl StandaloneDocumentLintRule for RedundantFieldsRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
         let mut diagnostics = Vec::new();
 

--- a/crates/graphql-linter/src/rules/require_id_field.rs
+++ b/crates/graphql-linter/src/rules/require_id_field.rs
@@ -3,8 +3,52 @@ use crate::schema_utils::extract_root_type_names;
 use crate::traits::{DocumentSchemaLintRule, LintRule};
 use apollo_parser::cst::{self, CstNode};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
+use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+/// Options for the `require_id_field` rule
+///
+/// Example configuration:
+/// ```yaml
+/// lint:
+///   rules:
+///     # Default: requires 'id' field
+///     require_id_field: warn
+///
+///     # Custom fields to require (if they exist on the type)
+///     require_id_field: [warn, { fields: ["id", "nodeId", "uuid"] }]
+///
+///     # Object style
+///     require_id_field:
+///       severity: warn
+///       options:
+///         fields: ["id"]
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct RequireIdFieldOptions {
+    /// Field names to require if they exist on the type.
+    /// Defaults to `["id"]`.
+    pub fields: Vec<String>,
+}
+
+impl Default for RequireIdFieldOptions {
+    fn default() -> Self {
+        Self {
+            fields: vec!["id".to_string()],
+        }
+    }
+}
+
+impl RequireIdFieldOptions {
+    /// Parse options from a JSON value, falling back to defaults on error
+    fn from_json(value: Option<&serde_json::Value>) -> Self {
+        value
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
 
 /// Trait implementation for `require_id_field` rule
 pub struct RequireIdFieldRuleImpl;
@@ -31,7 +75,9 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
+        let opts = RequireIdFieldOptions::from_json(options);
         let mut diagnostics = Vec::new();
         let parse = graphql_syntax::parse(db, content, metadata);
         if parse.has_errors() {
@@ -41,16 +87,19 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
         // Get schema types from HIR
         let schema_types = graphql_hir::schema_types(db, project_files);
 
-        // Build a map of type names to whether they have an id field
-        let mut types_with_id: HashMap<String, bool> = HashMap::new();
+        // Build a map of type names to their required fields (from options) that exist
+        let mut types_with_required_fields: HashMap<String, Vec<String>> = HashMap::new();
         for (type_name, type_def) in schema_types {
-            let has_id = match type_def.kind {
-                graphql_hir::TypeDefKind::Object | graphql_hir::TypeDefKind::Interface => {
-                    type_def.fields.iter().any(|f| f.name.as_ref() == "id")
-                }
-                _ => false,
+            let required_fields: Vec<String> = match type_def.kind {
+                graphql_hir::TypeDefKind::Object | graphql_hir::TypeDefKind::Interface => opts
+                    .fields
+                    .iter()
+                    .filter(|field| type_def.fields.iter().any(|f| f.name.as_ref() == *field))
+                    .cloned()
+                    .collect(),
+                _ => Vec::new(),
             };
-            types_with_id.insert(type_name.to_string(), has_id);
+            types_with_required_fields.insert(type_name.to_string(), required_fields);
         }
 
         // Get all fragments from the project (for cross-file resolution)
@@ -67,7 +116,7 @@ impl DocumentSchemaLintRule for RequireIdFieldRuleImpl {
             db,
             project_files,
             schema_types,
-            types_with_id: &types_with_id,
+            types_with_required_fields: &types_with_required_fields,
             all_fragments,
         };
 
@@ -200,7 +249,8 @@ struct CheckContext<'a> {
     db: &'a dyn graphql_hir::GraphQLHirDatabase,
     project_files: graphql_base_db::ProjectFiles,
     schema_types: &'a HashMap<Arc<str>, graphql_hir::TypeDef>,
-    types_with_id: &'a HashMap<String, bool>,
+    /// Map of type names to their required fields (only includes fields that exist on the type)
+    types_with_required_fields: &'a HashMap<String, Vec<String>>,
     all_fragments: &'a HashMap<Arc<str>, graphql_hir::FragmentStructure>,
 }
 
@@ -220,17 +270,18 @@ fn check_selection_set(
     visited_fragments: &mut HashSet<String>,
     diagnostics: &mut Vec<LintDiagnostic>,
 ) {
-    // Check if this type has an id field
-    let has_id_field = context
-        .types_with_id
+    // Get required fields for this type (only those that exist on the type)
+    let required_fields = context
+        .types_with_required_fields
         .get(parent_type_name)
-        .copied()
-        .unwrap_or(false);
+        .cloned()
+        .unwrap_or_default();
 
-    let mut has_id_in_selection = false;
+    // Track which required fields are present in the selection
+    let mut found_fields: HashSet<String> = HashSet::new();
 
     // ALWAYS iterate through selections to recurse into nested selection sets,
-    // even if the current type doesn't have an id field. This ensures we check
+    // even if the current type has no required fields. This ensures we check
     // nested types like Query.allPokemon.nodes which returns Pokemon (has id).
     for selection in selection_set.selections() {
         match selection {
@@ -238,9 +289,9 @@ fn check_selection_set(
                 if let Some(field_name) = field.name() {
                     let field_name_str = field_name.text();
 
-                    // Check if this is the id field (only relevant if type has id)
-                    if has_id_field && field_name_str == "id" {
-                        has_id_in_selection = true;
+                    // Check if this is one of the required fields
+                    if required_fields.contains(&field_name_str.to_string()) {
+                        found_fields.insert(field_name_str.to_string());
                     }
 
                     // ALWAYS recurse into nested selection sets
@@ -266,21 +317,24 @@ fn check_selection_set(
                 }
             }
             cst::Selection::FragmentSpread(fragment_spread) => {
-                // Check if the fragment contains the id field (only relevant if type has id)
-                if has_id_field {
+                // Check if the fragment contains any required fields
+                if !required_fields.is_empty() {
                     if let Some(fragment_name) = fragment_spread.fragment_name() {
                         if let Some(name) = fragment_name.name() {
                             let name_str = name.text().to_string();
-                            // Clone visited_fragments so sibling checks don't interfere
-                            // (each fragment_contains_id call chain has its own cycle detection)
-                            let mut visited_clone = visited_fragments.clone();
-                            if fragment_contains_id(
-                                &name_str,
-                                parent_type_name,
-                                context,
-                                &mut visited_clone,
-                            ) {
-                                has_id_in_selection = true;
+                            // Check each required field in the fragment
+                            for required_field in &required_fields {
+                                // Clone visited_fragments so sibling checks don't interfere
+                                let mut visited_clone = visited_fragments.clone();
+                                if fragment_contains_field(
+                                    &name_str,
+                                    parent_type_name,
+                                    required_field,
+                                    context,
+                                    &mut visited_clone,
+                                ) {
+                                    found_fields.insert(required_field.clone());
+                                }
                             }
                         }
                     }
@@ -296,13 +350,14 @@ fn check_selection_set(
                         .and_then(|nt| nt.name())
                         .map_or_else(|| parent_type_name.to_string(), |n| n.text().to_string());
 
-                    // Check for id in inline fragment's selections (only if type has id)
+                    // Check for required fields in inline fragment's selections
                     for nested_selection in nested_selection_set.selections() {
                         match nested_selection {
                             cst::Selection::Field(nested_field) => {
                                 if let Some(field_name) = nested_field.name() {
-                                    if has_id_field && field_name.text() == "id" {
-                                        has_id_in_selection = true;
+                                    let field_name_str = field_name.text();
+                                    if required_fields.contains(&field_name_str.to_string()) {
+                                        found_fields.insert(field_name_str.to_string());
                                     }
 
                                     // ALWAYS recurse into nested object selections
@@ -334,20 +389,23 @@ fn check_selection_set(
                                 }
                             }
                             cst::Selection::FragmentSpread(fragment_spread) => {
-                                // Check if the fragment contains the id field (only relevant if type has id)
-                                if has_id_field {
+                                // Check if the fragment contains any required fields
+                                if !required_fields.is_empty() {
                                     if let Some(fragment_name) = fragment_spread.fragment_name() {
                                         if let Some(name) = fragment_name.name() {
                                             let name_str = name.text().to_string();
-                                            // Clone visited_fragments so sibling checks don't interfere
-                                            let mut visited_clone = visited_fragments.clone();
-                                            if fragment_contains_id(
-                                                &name_str,
-                                                parent_type_name,
-                                                context,
-                                                &mut visited_clone,
-                                            ) {
-                                                has_id_in_selection = true;
+                                            for required_field in &required_fields {
+                                                // Clone visited_fragments so sibling checks don't interfere
+                                                let mut visited_clone = visited_fragments.clone();
+                                                if fragment_contains_field(
+                                                    &name_str,
+                                                    parent_type_name,
+                                                    required_field,
+                                                    context,
+                                                    &mut visited_clone,
+                                                ) {
+                                                    found_fields.insert(required_field.clone());
+                                                }
                                             }
                                         }
                                     }
@@ -364,40 +422,47 @@ fn check_selection_set(
         }
     }
 
-    // Only emit diagnostic if type has id field and it's not in the selection
-    if has_id_field && !has_id_in_selection {
-        // Calculate insertion position and indentation for the fix
-        let selection_set_start: usize = selection_set.syntax().text_range().start().into();
-        let selection_set_source = selection_set.syntax().to_string();
+    // Emit diagnostics for each missing required field
+    for required_field in &required_fields {
+        if !found_fields.contains(required_field) {
+            // Calculate insertion position and indentation for the fix
+            let selection_set_start: usize = selection_set.syntax().text_range().start().into();
+            let selection_set_source = selection_set.syntax().to_string();
 
-        let (insert_pos, indent) = selection_set.selections().next().map_or_else(
-            || {
-                // Empty selection set - insert after the opening brace with default indent
-                (selection_set_start + 1, "  ".to_string())
-            },
-            |first| {
-                let pos: usize = first.syntax().text_range().start().into();
-                // Calculate position relative to selection set start
-                let relative_pos = pos - selection_set_start;
-                let indent = extract_indentation(&selection_set_source, relative_pos);
-                (pos, indent)
-            },
-        );
+            let (insert_pos, indent) = selection_set.selections().next().map_or_else(
+                || {
+                    // Empty selection set - insert after the opening brace with default indent
+                    (selection_set_start + 1, "  ".to_string())
+                },
+                |first| {
+                    let pos: usize = first.syntax().text_range().start().into();
+                    // Calculate position relative to selection set start
+                    let relative_pos = pos - selection_set_start;
+                    let indent = extract_indentation(&selection_set_source, relative_pos);
+                    (pos, indent)
+                },
+            );
 
-        let fix = CodeFix::new(
-            format!("Add 'id' field to {parent_type_name}"),
-            vec![TextEdit::insert(insert_pos, format!("id\n{indent}"))],
-        );
+            let fix = CodeFix::new(
+                format!("Add '{required_field}' field to {parent_type_name}"),
+                vec![TextEdit::insert(
+                    insert_pos,
+                    format!("{required_field}\n{indent}"),
+                )],
+            );
 
-        diagnostics.push(
-            LintDiagnostic::warning(
-                parent_location.start,
-                parent_location.end,
-                format!("Selection set on type '{parent_type_name}' should include the 'id' field"),
-                "require_id_field",
-            )
-            .with_fix(fix),
-        );
+            diagnostics.push(
+                LintDiagnostic::warning(
+                    parent_location.start,
+                    parent_location.end,
+                    format!(
+                        "Selection set on type '{parent_type_name}' should include the '{required_field}' field"
+                    ),
+                    "require_id_field",
+                )
+                .with_fix(fix),
+            );
+        }
     }
 }
 
@@ -445,10 +510,11 @@ fn extract_indentation(source: &str, pos: usize) -> String {
     }
 }
 
-/// Check if a fragment (or its nested fragments) contains the `id` field
-fn fragment_contains_id(
+/// Check if a fragment (or its nested fragments) contains the specified field
+fn fragment_contains_field(
     fragment_name: &str,
     parent_type_name: &str,
+    target_field: &str,
     context: &CheckContext,
     visited_fragments: &mut HashSet<String>,
 ) -> bool {
@@ -495,11 +561,12 @@ fn fragment_contains_id(
                     continue;
                 }
 
-                // Found the fragment, check its selection set for id
+                // Found the fragment, check its selection set for the target field
                 if let Some(selection_set) = frag.selection_set() {
-                    return check_fragment_selection_for_id(
+                    return check_fragment_selection_for_field(
                         &selection_set,
                         parent_type_name,
+                        target_field,
                         context,
                         visited_fragments,
                     );
@@ -511,14 +578,15 @@ fn fragment_contains_id(
     false
 }
 
-/// Check if a selection set within a fragment contains the `id` field
-/// This only checks for `id` at the top level of the selection set.
+/// Check if a selection set within a fragment contains the specified field
+/// This only checks for the field at the top level of the selection set.
 /// We do NOT recurse into nested field selections because:
 /// - `abilities { ...AbilityInfo }` selects `id` on Ability, not on the current type
-/// - We only care if `id` is selected directly on the current type
-fn check_fragment_selection_for_id(
+/// - We only care if the field is selected directly on the current type
+fn check_fragment_selection_for_field(
     selection_set: &cst::SelectionSet,
     parent_type_name: &str,
+    target_field: &str,
     context: &CheckContext,
     visited_fragments: &mut HashSet<String>,
 ) -> bool {
@@ -526,8 +594,8 @@ fn check_fragment_selection_for_id(
         match selection {
             cst::Selection::Field(field) => {
                 if let Some(field_name) = field.name() {
-                    // Check if this is the id field at the top level
-                    if field_name.text() == "id" {
+                    // Check if this is the target field at the top level
+                    if field_name.text() == target_field {
                         return true;
                     }
                     // NOTE: We intentionally do NOT recurse into nested field selections.
@@ -542,9 +610,10 @@ fn check_fragment_selection_for_id(
                 if let Some(fragment_name) = fragment_spread.fragment_name() {
                     if let Some(name) = fragment_name.name() {
                         let name_str = name.text().to_string();
-                        if fragment_contains_id(
+                        if fragment_contains_field(
                             &name_str,
                             parent_type_name,
+                            target_field,
                             context,
                             visited_fragments,
                         ) {
@@ -562,9 +631,10 @@ fn check_fragment_selection_for_id(
                         .and_then(|nt| nt.name())
                         .map_or_else(|| parent_type_name.to_string(), |n| n.text().to_string());
 
-                    if check_fragment_selection_for_id(
+                    if check_fragment_selection_for_field(
                         &nested_selection_set,
                         &inline_type,
+                        target_field,
                         context,
                         visited_fragments,
                     ) {
@@ -678,7 +748,7 @@ query GetUser {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0]
@@ -704,7 +774,7 @@ query GetUser {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -732,7 +802,7 @@ query GetUserPosts {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn about Post missing id
         assert_eq!(diagnostics.len(), 1);
@@ -767,7 +837,7 @@ query GetUserPostComments {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn about Comment and nested User missing id
         assert_eq!(diagnostics.len(), 2);
@@ -805,7 +875,7 @@ query GetStats {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -832,7 +902,7 @@ const GET_USER = gql`
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::TypeScript);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn about User missing id in the TypeScript file
         // Note: May produce duplicates due to issue #194
@@ -875,7 +945,7 @@ const GET_POSTS = gql`
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::TypeScript);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn about User and Post missing id in the second query
         assert_eq!(diagnostics.len(), 2);
@@ -912,7 +982,7 @@ const QUERY = gql`
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::TypeScript);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn about nested author (User type) missing id
         // Note: May produce duplicates due to issue #194
@@ -944,7 +1014,7 @@ query GetUser {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // No warning because fragment includes id
         assert_eq!(diagnostics.len(), 0);
@@ -971,7 +1041,7 @@ query GetUser {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should warn - both the fragment definition and the operation usage
         // The fragment itself is checked, and the operation using it is checked
@@ -1076,6 +1146,7 @@ query GetUser {
             query_content,
             query_metadata,
             project_files,
+            None,
         );
 
         // No warning because fragment includes id
@@ -1134,6 +1205,7 @@ query GetUser {
             query_content,
             query_metadata,
             project_files,
+            None,
         );
 
         // Should warn because fragment does not include id
@@ -1186,7 +1258,14 @@ export const GET_USER = gql`
             graphql_base_db::file_lookup(&db, project_files, ts_file_id)
                 .expect("TypeScript file should exist");
 
-        let diagnostics = rule.check(&db, ts_file_id, ts_content, ts_metadata, project_files);
+        let diagnostics = rule.check(
+            &db,
+            ts_file_id,
+            ts_content,
+            ts_metadata,
+            project_files,
+            None,
+        );
 
         // No warning because fragment includes id
         assert_eq!(
@@ -1223,7 +1302,7 @@ query GetPost {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // No warning because fragment includes id and is used inside inline fragment
         assert_eq!(
@@ -1272,7 +1351,7 @@ fragment BattleDetailed on Battle {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 because TrainerBasic includes id
         // Should only warn on BattleDetailed since Battle.id is not selected
@@ -1354,6 +1433,7 @@ fragment BattleDetailed on Battle {
             battle_content,
             battle_metadata,
             project_files,
+            None,
         );
 
         // Should NOT warn on trainer1 because TrainerBasic includes id
@@ -1417,7 +1497,7 @@ fragment BattleDetailed on Battle {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 in BattleDetailed because TrainerBasic includes id
         // The bug was that visited_fragments accumulates "TrainerBasic" when checking
@@ -1475,7 +1555,7 @@ fragment BattleDetailed on Battle {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 because TrainerBasic includes id
         // Even though BattleBasic is undefined, the trainer1 field's TrainerBasic spread
@@ -1530,7 +1610,7 @@ fragment TrainerBasic on Trainer {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 because TrainerBasic includes id
         let trainer_warnings: Vec<_> = diagnostics
@@ -1589,7 +1669,7 @@ export const BATTLE_FRAGMENT = gql`
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, ts_source, FileKind::TypeScript);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 because TrainerBasic includes id
         let trainer_warnings: Vec<_> = diagnostics
@@ -1646,7 +1726,7 @@ fragment BattleDetailed on Battle {
         let (file_id, content, metadata, project_files) =
             create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // Should NOT warn on trainer1 OR trainer2 because TrainerBasic includes id
         // Bug: visited_fragments might prevent second check of TrainerBasic
@@ -1658,6 +1738,197 @@ fragment BattleDetailed on Battle {
             trainer_warnings.len(),
             0,
             "Issue #376: Should not warn on any Trainer field when fragment spread contains id: {trainer_warnings:?}"
+        );
+    }
+
+    // =========================================================================
+    // Tests for configurable lint options
+    // =========================================================================
+
+    #[test]
+    fn test_custom_field_name_via_options() {
+        // Test that custom field names can be specified via options
+        let db = graphql_ide_db::RootDatabase::default();
+        let rule = RequireIdFieldRuleImpl;
+
+        let schema = r"
+type Query {
+    user(id: ID!): User
+}
+
+type User {
+    uuid: ID!
+    name: String!
+}
+";
+
+        let source = r#"
+query GetUser {
+    user(id: "1") {
+        name
+    }
+}
+"#;
+
+        let (file_id, content, metadata, project_files) =
+            create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
+
+        // With default options (fields: ["id"]), no warning because User doesn't have "id"
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "No warning with default options when type doesn't have 'id' field"
+        );
+
+        // With custom options (fields: ["uuid"]), should warn because User has "uuid" but it's not selected
+        let options = serde_json::json!({ "fields": ["uuid"] });
+        let diagnostics = rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(&options),
+        );
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Should warn when custom field 'uuid' is not selected"
+        );
+        assert!(diagnostics[0].message.contains("'uuid'"));
+    }
+
+    #[test]
+    fn test_multiple_required_fields() {
+        // Test that multiple required fields can be specified
+        let db = graphql_ide_db::RootDatabase::default();
+        let rule = RequireIdFieldRuleImpl;
+
+        let schema = r"
+type Query {
+    user(id: ID!): User
+}
+
+type User {
+    id: ID!
+    uuid: String!
+    name: String!
+}
+";
+
+        let source = r#"
+query GetUser {
+    user(id: "1") {
+        id
+        name
+    }
+}
+"#;
+
+        let (file_id, content, metadata, project_files) =
+            create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
+
+        // With options requiring both "id" and "uuid", should warn about missing "uuid"
+        let options = serde_json::json!({ "fields": ["id", "uuid"] });
+        let diagnostics = rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(&options),
+        );
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Should warn when 'uuid' is missing even though 'id' is present"
+        );
+        assert!(diagnostics[0].message.contains("'uuid'"));
+    }
+
+    #[test]
+    fn test_required_field_selected_via_fragment() {
+        // Test that custom required fields work with fragments
+        let db = graphql_ide_db::RootDatabase::default();
+        let rule = RequireIdFieldRuleImpl;
+
+        let schema = r"
+type Query {
+    user(id: ID!): User
+}
+
+type User {
+    nodeId: ID!
+    name: String!
+}
+";
+
+        let source = r#"
+fragment UserFields on User {
+    nodeId
+    name
+}
+
+query GetUser {
+    user(id: "1") {
+        ...UserFields
+    }
+}
+"#;
+
+        let (file_id, content, metadata, project_files) =
+            create_test_project(&db, schema, source, FileKind::ExecutableGraphQL);
+
+        // With options requiring "nodeId", no warning because fragment contains it
+        let options = serde_json::json!({ "fields": ["nodeId"] });
+        let diagnostics = rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(&options),
+        );
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "No warning when custom field is selected via fragment"
+        );
+    }
+
+    #[test]
+    fn test_empty_fields_list_disables_rule() {
+        // Test that an empty fields list effectively disables the rule
+        let db = graphql_ide_db::RootDatabase::default();
+        let rule = RequireIdFieldRuleImpl;
+
+        let source = r#"
+query GetUser {
+    user(id: "1") {
+        name
+        email
+    }
+}
+"#;
+
+        let (file_id, content, metadata, project_files) =
+            create_test_project(&db, TEST_SCHEMA, source, FileKind::ExecutableGraphQL);
+
+        // With empty fields list, no warnings
+        let options = serde_json::json!({ "fields": [] });
+        let diagnostics = rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(&options),
+        );
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "No warnings when fields list is empty"
         );
     }
 }

--- a/crates/graphql-linter/src/rules/unique_names.rs
+++ b/crates/graphql-linter/src/rules/unique_names.rs
@@ -26,6 +26,7 @@ impl ProjectLintRule for UniqueNamesRuleImpl {
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>> {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
 

--- a/crates/graphql-linter/src/rules/unused_fields.rs
+++ b/crates/graphql-linter/src/rules/unused_fields.rs
@@ -28,6 +28,7 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>> {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
 

--- a/crates/graphql-linter/src/rules/unused_fragments.rs
+++ b/crates/graphql-linter/src/rules/unused_fragments.rs
@@ -25,6 +25,7 @@ impl ProjectLintRule for UnusedFragmentsRuleImpl {
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>> {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
 

--- a/crates/graphql-linter/src/rules/unused_variables.rs
+++ b/crates/graphql-linter/src/rules/unused_variables.rs
@@ -42,6 +42,7 @@ impl StandaloneDocumentLintRule for UnusedVariablesRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         _project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
         let mut diagnostics = Vec::new();
 
@@ -321,7 +322,7 @@ query GetUser($id: ID!, $unused: String) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
@@ -361,7 +362,7 @@ query GetUser($id: ID!, $name: String) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -389,7 +390,7 @@ query GetUser($id: ID!, $skip: Boolean!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -420,7 +421,7 @@ query GetUser($id: ID!, $postId: ID!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -448,7 +449,7 @@ query GetUsers($ids: [ID!]!, $id1: ID!, $id2: ID!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         // $ids is unused
         assert_eq!(diagnostics.len(), 1);
@@ -478,7 +479,7 @@ query CreateUser($name: String!, $email: String!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -506,7 +507,7 @@ query GetUser($id: ID!, $unused1: String, $unused2: Int, $limit: Int) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 2);
         let messages: Vec<_> = diagnostics.iter().map(|d| &d.message).collect();
@@ -541,7 +542,7 @@ query GetUser {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }
@@ -570,7 +571,7 @@ mutation UpdateUser($id: ID!, $name: String!, $unused: Boolean) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("$unused"));
@@ -602,7 +603,7 @@ query GetUser($id: ID!, $include: Boolean!) {
         );
         let project_files = create_test_project_files(&db);
 
-        let diagnostics = rule.check(&db, file_id, content, metadata, project_files);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 0);
     }

--- a/crates/graphql-linter/src/traits.rs
+++ b/crates/graphql-linter/src/traits.rs
@@ -27,6 +27,9 @@ pub trait LintRule: Send + Sync {
 /// Examples: `redundant_fields`, `operation_naming`, `no_anonymous_operations`
 pub trait StandaloneDocumentLintRule: LintRule {
     /// Check a single file for issues
+    ///
+    /// The `options` parameter contains rule-specific configuration from `.graphqlrc.yaml`.
+    /// Rules should define their own options struct and deserialize from this JSON value.
     fn check(
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
@@ -34,6 +37,7 @@ pub trait StandaloneDocumentLintRule: LintRule {
         content: FileContent,
         metadata: FileMetadata,
         project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic>;
 }
 
@@ -47,6 +51,9 @@ pub trait StandaloneDocumentLintRule: LintRule {
 /// Examples: `deprecated_field`, `require_id_field`
 pub trait DocumentSchemaLintRule: LintRule {
     /// Check a single file against schema
+    ///
+    /// The `options` parameter contains rule-specific configuration from `.graphqlrc.yaml`.
+    /// Rules should define their own options struct and deserialize from this JSON value.
     fn check(
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
@@ -54,6 +61,7 @@ pub trait DocumentSchemaLintRule: LintRule {
         content: FileContent,
         metadata: FileMetadata,
         project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic>;
 }
 
@@ -65,10 +73,13 @@ pub trait DocumentSchemaLintRule: LintRule {
 /// Examples: `schema_naming_conventions`, `field_naming`
 pub trait StandaloneSchemaLintRule: LintRule {
     /// Check schema design
+    ///
+    /// The `options` parameter contains rule-specific configuration from `.graphqlrc.yaml`.
     fn check(
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>>;
 }
 
@@ -83,9 +94,12 @@ pub trait StandaloneSchemaLintRule: LintRule {
 pub trait ProjectLintRule: LintRule {
     /// Check the entire project
     /// Returns diagnostics grouped by file
+    ///
+    /// The `options` parameter contains rule-specific configuration from `.graphqlrc.yaml`.
     fn check(
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>>;
 }

--- a/crates/graphql-linter/tests/lint_integration.rs
+++ b/crates/graphql-linter/tests/lint_integration.rs
@@ -38,7 +38,8 @@ fn run_standalone_rules(
 
     for rule in rules {
         if config.is_enabled(rule.name()) {
-            let diagnostics = rule.check(db, file_id, content, metadata, project_files);
+            let options = config.get_options(rule.name());
+            let diagnostics = rule.check(db, file_id, content, metadata, project_files, options);
             all_diagnostics.extend(diagnostics);
         }
     }

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -988,7 +988,7 @@ impl LanguageServer for GraphQLLanguageServer {
             return Ok(None);
         };
 
-let host = self
+        let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
         let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
@@ -1017,7 +1017,7 @@ let host = self
             return Ok(None);
         };
 
-let host = self
+        let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
         let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
@@ -1048,7 +1048,7 @@ let host = self
             return Ok(None);
         };
 
-let host = self
+        let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
         let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
@@ -1081,7 +1081,7 @@ let host = self
             return Ok(None);
         };
 
-let host = self
+        let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
         let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {
@@ -1121,7 +1121,7 @@ let host = self
             return Ok(None);
         };
 
-let host = self
+        let host = self
             .workspace
             .get_or_create_host(&workspace_uri, &project_name);
         let Some(analysis) = Self::try_snapshot_with_timeout(&host).await else {

--- a/test-workspace/github/.graphqlrc.yaml
+++ b/test-workspace/github/.graphqlrc.yaml
@@ -13,6 +13,7 @@ projects:
       extends: recommended
       rules:
         no_deprecated: warn
+        require_id_field: [warn, { fields: ["id", "databaseId"] }]
 
   # Admin-specific operations (separate schema extensions)
   admin:
@@ -24,3 +25,7 @@ projects:
       extends: recommended
       rules:
         no_deprecated: error
+        require_id_field:
+          severity: error
+          options:
+            fields: ["id"]


### PR DESCRIPTION
## Summary

- Add ESLint-style rule options support to the linting system
- Rules can now accept custom configuration beyond just severity levels
- Implement configurable `fields` option for `require_id_field` rule

## Changes

### Configuration System
- Added ESLint-style array syntax: `rule: [warn, { options... }]`
- Added object syntax: `rule: { severity: warn, options: {...} }`
- Added `get_options()` method to `LintConfig`
- Custom deserializer to handle all configuration formats

### Rule Trait Updates
- All rule traits now accept `options: Option<&serde_json::Value>` parameter
- Rules can parse their own typed options from the JSON value
- Backward compatible - rules that don't need options can ignore the parameter

### `require_id_field` Rule Enhancement
- Added `RequireIdFieldOptions` struct with configurable `fields` array
- Default: `["id"]` (maintains current behavior)
- Users can now specify custom field names (e.g., `nodeId` for Relay)
- Users can require multiple fields if they exist on the type

## Example Configuration

```yaml
lint:
  rules:
    # Default: require 'id' field
    require_id_field: warn

    # Custom field name (Relay-style)
    require_id_field: [warn, { fields: ["nodeId"] }]

    # Multiple required fields
    require_id_field:
      severity: warn
      options:
        fields: ["id", "uuid", "nodeId"]
```

## Test plan

- [x] Config parsing tests for ESLint array syntax
- [x] Config parsing tests for object syntax with options
- [x] Tests for `get_options()` returning correct values
- [x] Tests for custom field names in `require_id_field`
- [x] Tests for multiple required fields
- [x] Tests for fragment resolution with custom fields
- [x] Tests for empty fields list (disables rule)
- [x] All existing tests pass
- [x] Clippy passes