### PR TITLE
fix(ide): hover for fields in TypeScript files

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -1184,12 +1184,12 @@ impl Analysis {
         match symbol {
             Symbol::FieldName { name } => {
                 let types = graphql_hir::schema_types(&self.db, project_files);
-                let parent_ctx = find_parent_type_at_offset(&parse.tree, offset)?;
+                let parent_ctx = find_parent_type_at_offset(block_context.tree, offset)?;
 
                 // Use walk_type_stack_to_offset to properly resolve the parent type,
                 // which handles inline fragments correctly
                 let parent_type_name = symbol::walk_type_stack_to_offset(
-                    &parse.tree,
+                    block_context.tree,
                     types,
                     offset,
                     &parent_ctx.root_type,


### PR DESCRIPTION
## Summary

- Fix hover functionality for fields in TypeScript/JavaScript files with embedded GraphQL
- The `hover` function was using `parse.tree` for parent type resolution, but for TS/JS files this is an empty placeholder tree
- Now correctly uses `block_context.tree` which contains the actual GraphQL content

## Test plan

- [x] Added failing test `test_hover_field_in_typescript_file` that reproduces issue #398
- [x] Verified test passes after fix
- [x] All existing tests pass

Fixes #398