### PR TITLE
refactor: make Parse.tree private and require documents() iterator

### DIFF
--- a/crates/graphql-linter/src/rules/no_anonymous_operations.rs
+++ b/crates/graphql-linter/src/rules/no_anonymous_operations.rs
@@ -62,32 +62,25 @@ impl StandaloneDocumentLintRule for NoAnonymousOperationsRuleImpl {
             return diagnostics;
         }
 
-        // Check operations in the main document (for .graphql files only)
-        // For TS/JS files, parse.tree is the first block and we check all blocks below
-        let file_kind = metadata.kind(db);
-        if file_kind == graphql_db::FileKind::ExecutableGraphQL
-            || file_kind == graphql_db::FileKind::Schema
-        {
-            let doc_cst = parse.tree.document();
+        // Check operations in all documents (handles both pure GraphQL and TS/JS files)
+        for doc in parse.documents() {
+            let doc_cst = doc.tree.document();
+            let mut doc_diagnostics = Vec::new();
             for definition in doc_cst.definitions() {
                 if let cst::Definition::OperationDefinition(operation) = definition {
-                    check_operation_has_name(&operation, &mut diagnostics);
+                    check_operation_has_name(&operation, &mut doc_diagnostics);
                 }
             }
-        }
-
-        // Check operations in extracted blocks (TypeScript/JavaScript)
-        for block in &parse.blocks {
-            let block_doc = block.tree.document();
-            let mut block_diagnostics = Vec::new();
-            for definition in block_doc.definitions() {
-                if let cst::Definition::OperationDefinition(operation) = definition {
-                    check_operation_has_name(&operation, &mut block_diagnostics);
+            // Add block context for embedded GraphQL (line_offset > 0)
+            #[allow(clippy::cast_possible_truncation)]
+            for diag in doc_diagnostics {
+                if let Some(source) = doc.source {
+                    diagnostics.push(
+                        diag.with_block_context(doc.line_offset, std::sync::Arc::from(source)),
+                    );
+                } else {
+                    diagnostics.push(diag);
                 }
-            }
-            // Add block context to each diagnostic for proper position calculation
-            for diag in block_diagnostics {
-                diagnostics.push(diag.with_block_context(block.line, block.source.clone()));
             }
         }
 

--- a/crates/graphql-linter/src/rules/operation_name_suffix.rs
+++ b/crates/graphql-linter/src/rules/operation_name_suffix.rs
@@ -40,42 +40,56 @@ impl StandaloneDocumentLintRule for OperationNameSuffixRuleImpl {
             return diagnostics;
         }
 
-        // Walk the CST
-        let doc_cst = parse.tree.document();
+        // Walk all documents (handles both pure GraphQL and TS/JS files)
+        for doc in parse.documents() {
+            let doc_cst = doc.tree.document();
+            let mut doc_diagnostics = Vec::new();
 
-        for definition in doc_cst.definitions() {
-            if let cst::Definition::OperationDefinition(operation) = definition {
-                // Only check named operations
-                if let Some(name) = operation.name() {
-                    use super::{get_operation_kind, OperationKind};
-                    let name_text = name.text();
+            for definition in doc_cst.definitions() {
+                if let cst::Definition::OperationDefinition(operation) = definition {
+                    // Only check named operations
+                    if let Some(name) = operation.name() {
+                        use super::{get_operation_kind, OperationKind};
+                        let name_text = name.text();
 
-                    // Determine the operation type
-                    let op_kind = operation
-                        .operation_type()
-                        .map_or(OperationKind::Query, |op_type| get_operation_kind(&op_type));
+                        // Determine the operation type
+                        let op_kind = operation
+                            .operation_type()
+                            .map_or(OperationKind::Query, |op_type| get_operation_kind(&op_type));
 
-                    let expected_suffix = match op_kind {
-                        OperationKind::Mutation => "Mutation",
-                        OperationKind::Subscription => "Subscription",
-                        OperationKind::Query => "Query",
-                    };
+                        let expected_suffix = match op_kind {
+                            OperationKind::Mutation => "Mutation",
+                            OperationKind::Subscription => "Subscription",
+                            OperationKind::Query => "Query",
+                        };
 
-                    if !name_text.ends_with(expected_suffix) {
-                        let syntax = name.syntax();
-                        let text_range = syntax.text_range();
-                        let start_offset: usize = text_range.start().into();
-                        let end_offset: usize = text_range.end().into();
+                        if !name_text.ends_with(expected_suffix) {
+                            let syntax = name.syntax();
+                            let text_range = syntax.text_range();
+                            let start_offset: usize = text_range.start().into();
+                            let end_offset: usize = text_range.end().into();
 
-                        diagnostics.push(LintDiagnostic::warning(
-                            start_offset,
-                            end_offset,
-                            format!(
-                                "Operation name '{name_text}' should end with '{expected_suffix}'. Consider renaming to '{name_text}{expected_suffix}'."
-                            ),
-                            "operation_name_suffix",
-                        ));
+                            doc_diagnostics.push(LintDiagnostic::warning(
+                                start_offset,
+                                end_offset,
+                                format!(
+                                    "Operation name '{name_text}' should end with '{expected_suffix}'. Consider renaming to '{name_text}{expected_suffix}'."
+                                ),
+                                "operation_name_suffix",
+                            ));
+                        }
                     }
+                }
+            }
+
+            // Add block context for embedded GraphQL (line_offset > 0)
+            for diag in doc_diagnostics {
+                if let Some(source) = doc.source {
+                    diagnostics.push(
+                        diag.with_block_context(doc.line_offset, std::sync::Arc::from(source)),
+                    );
+                } else {
+                    diagnostics.push(diag);
                 }
             }
         }

--- a/crates/graphql-linter/src/rules/unused_variables.rs
+++ b/crates/graphql-linter/src/rules/unused_variables.rs
@@ -50,32 +50,24 @@ impl StandaloneDocumentLintRule for UnusedVariablesRuleImpl {
             return diagnostics;
         }
 
-        // Check operations in the main document (for .graphql files only)
-        // For TS/JS files, parse.tree is the first block and we check all blocks below
-        let file_kind = metadata.kind(db);
-        if file_kind == graphql_db::FileKind::ExecutableGraphQL
-            || file_kind == graphql_db::FileKind::Schema
-        {
-            let doc_cst = parse.tree.document();
+        // Check operations in all documents (handles both pure GraphQL and TS/JS files)
+        for doc in parse.documents() {
+            let doc_cst = doc.tree.document();
+            let mut doc_diagnostics = Vec::new();
             for definition in doc_cst.definitions() {
                 if let cst::Definition::OperationDefinition(operation) = definition {
-                    check_operation_for_unused_variables(&operation, &mut diagnostics);
+                    check_operation_for_unused_variables(&operation, &mut doc_diagnostics);
                 }
             }
-        }
-
-        // Check operations in extracted blocks (TypeScript/JavaScript)
-        for block in &parse.blocks {
-            let block_doc = block.tree.document();
-            let mut block_diagnostics = Vec::new();
-            for definition in block_doc.definitions() {
-                if let cst::Definition::OperationDefinition(operation) = definition {
-                    check_operation_for_unused_variables(&operation, &mut block_diagnostics);
+            // Add block context for embedded GraphQL (line_offset > 0)
+            for diag in doc_diagnostics {
+                if let Some(source) = doc.source {
+                    diagnostics.push(
+                        diag.with_block_context(doc.line_offset, std::sync::Arc::from(source)),
+                    );
+                } else {
+                    diagnostics.push(diag);
                 }
-            }
-            // Add block context to each diagnostic for proper position calculation
-            for diag in block_diagnostics {
-                diagnostics.push(diag.with_block_context(block.line, block.source.clone()));
             }
         }
 

--- a/crates/graphql-linter/src/schema_utils.rs
+++ b/crates/graphql-linter/src/schema_utils.rs
@@ -55,10 +55,12 @@ pub fn extract_root_type_names(
 
         let parse = graphql_syntax::parse(db, content, metadata);
 
-        // Look for schema definition
-        for definition in &parse.ast.definitions {
-            if let apollo_compiler::ast::Definition::SchemaDefinition(schema_def) = definition {
-                return extract_from_schema_definition(schema_def);
+        // Look for schema definition in all documents
+        for doc in parse.documents() {
+            for definition in &doc.ast.definitions {
+                if let apollo_compiler::ast::Definition::SchemaDefinition(schema_def) = definition {
+                    return extract_from_schema_definition(schema_def);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Makes `Parse.tree`, `Parse.ast`, and `Parse.blocks` private to prevent silent failures when accessing these fields directly on TypeScript/JavaScript files with embedded GraphQL
- Adds accessor methods: `is_embedded()`, `blocks()`, `main_tree()`, `main_ast()`
- Updates all callers across the codebase to use the `documents()` iterator for uniform document handling

## Test plan
- [x] All existing tests pass (`cargo test --workspace`)
- [x] Clippy passes without warnings
- [x] Code is formatted

Closes #401