### PR TITLE
refactor: add FileKind helper methods for cleaner file categorization

### DIFF
--- a/crates/graphql-analysis/src/lib.rs
+++ b/crates/graphql-analysis/src/lib.rs
@@ -93,8 +93,6 @@ fn file_validation_diagnostics_impl(
     metadata: graphql_db::FileMetadata,
     project_files: graphql_db::ProjectFiles,
 ) -> Arc<Vec<Diagnostic>> {
-    use graphql_db::FileKind;
-
     let mut diagnostics = Vec::new();
 
     let parse = graphql_syntax::parse(db, content, metadata);
@@ -128,25 +126,22 @@ fn file_validation_diagnostics_impl(
         "Determining validation path for file"
     );
 
-    match file_kind {
-        FileKind::Schema => {
-            tracing::info!("Running schema validation");
-            let schema_diagnostics = schema_validation::validate_schema_file(db, content, metadata);
-            tracing::info!(
-                schema_diagnostic_count = schema_diagnostics.len(),
-                "Schema validation completed"
-            );
-            diagnostics.extend(schema_diagnostics.iter().cloned());
-        }
-        FileKind::ExecutableGraphQL | FileKind::TypeScript | FileKind::JavaScript => {
-            tracing::info!("Running document validation");
-            let doc_diagnostics = validation::validate_file(db, content, metadata, project_files);
-            tracing::info!(
-                document_diagnostic_count = doc_diagnostics.len(),
-                "Document validation completed"
-            );
-            diagnostics.extend(doc_diagnostics.iter().cloned());
-        }
+    if file_kind.is_schema() {
+        tracing::info!("Running schema validation");
+        let schema_diagnostics = schema_validation::validate_schema_file(db, content, metadata);
+        tracing::info!(
+            schema_diagnostic_count = schema_diagnostics.len(),
+            "Schema validation completed"
+        );
+        diagnostics.extend(schema_diagnostics.iter().cloned());
+    } else if file_kind.is_document() {
+        tracing::info!("Running document validation");
+        let doc_diagnostics = validation::validate_file(db, content, metadata, project_files);
+        tracing::info!(
+            document_diagnostic_count = doc_diagnostics.len(),
+            "Document validation completed"
+        );
+        diagnostics.extend(doc_diagnostics.iter().cloned());
     }
 
     Arc::new(diagnostics)

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -53,6 +53,26 @@ pub enum FileKind {
     JavaScript,
 }
 
+impl FileKind {
+    /// Returns true if this is a schema file
+    #[must_use]
+    pub const fn is_schema(self) -> bool {
+        matches!(self, Self::Schema)
+    }
+
+    /// Returns true if this is a document file (operations/fragments)
+    ///
+    /// This includes pure GraphQL executable files and TypeScript/JavaScript
+    /// files with embedded GraphQL.
+    #[must_use]
+    pub const fn is_document(self) -> bool {
+        matches!(
+            self,
+            Self::ExecutableGraphQL | Self::TypeScript | Self::JavaScript
+        )
+    }
+}
+
 /// Input: Content of a file
 /// This is set by the LSP layer when files are opened/changed
 #[salsa::input]

--- a/crates/graphql-ide/src/file_registry.rs
+++ b/crates/graphql-ide/src/file_registry.rs
@@ -213,11 +213,11 @@ impl FileRegistry {
             file_entries.insert(file_id, entry);
 
             // Categorize by kind for ID lists
-            match metadata.kind(db) {
-                FileKind::Schema => schema_ids.push(file_id),
-                FileKind::ExecutableGraphQL | FileKind::TypeScript | FileKind::JavaScript => {
-                    document_ids.push(file_id);
-                }
+            let kind = metadata.kind(db);
+            if kind.is_schema() {
+                schema_ids.push(file_id);
+            } else if kind.is_document() {
+                document_ids.push(file_id);
             }
         }
 


### PR DESCRIPTION
## Summary

Follow-up to #408. Adds `is_schema()` and `is_document()` helper methods to `FileKind` enum, allowing lower layers to categorize files without knowing specific enum variants.

**Before:**
```rust
match kind {
    FileKind::Schema => { ... }
    FileKind::ExecutableGraphQL | FileKind::TypeScript | FileKind::JavaScript => { ... }
}
```

**After:**
```rust
if kind.is_schema() { ... } else if kind.is_document() { ... }
```

Benefits:
- Lower layers don't need to import or match on specific variants
- Adding new embedded languages won't require changes in lower layers
- Intent is clearer: "is this a document?" vs "is this one of these three specific types?"

## Test plan

- [x] All 333 existing tests pass
- [x] Clippy clean