### PR TITLE
refactor: remove legacy metadata.line_offset field

### DIFF
--- a/crates/graphql-analysis/src/schema_validation.rs
+++ b/crates/graphql-analysis/src/schema_validation.rs
@@ -42,22 +42,17 @@ pub fn validate_schema_file(
                 "Schema validation failed"
             );
 
-            // Get line offset for TypeScript/JavaScript extraction
-            let line_offset = metadata.line_offset(db);
-
             #[allow(clippy::cast_possible_truncation, clippy::option_if_let_else)]
             for apollo_diag in with_errors.errors.iter() {
                 let range = if let Some(loc_range) = apollo_diag.line_column_range() {
                     DiagnosticRange {
                         start: Position {
                             // apollo-compiler uses 1-indexed, we use 0-indexed
-                            // Casting usize to u32 is safe for line/column numbers in practice
-                            // Add line_offset to adjust for TypeScript/JavaScript extraction
-                            line: loc_range.start.line.saturating_sub(1) as u32 + line_offset,
+                            line: loc_range.start.line.saturating_sub(1) as u32,
                             character: loc_range.start.column.saturating_sub(1) as u32,
                         },
                         end: Position {
-                            line: loc_range.end.line.saturating_sub(1) as u32 + line_offset,
+                            line: loc_range.end.line.saturating_sub(1) as u32,
                             character: loc_range.end.column.saturating_sub(1) as u32,
                         },
                     }

--- a/crates/graphql-cli/src/analysis.rs
+++ b/crates/graphql-cli/src/analysis.rs
@@ -98,7 +98,7 @@ impl CliAnalysisHost {
                     _ => FileKind::ExecutableGraphQL, // .graphql, .gql, or unknown
                 };
 
-                host.add_file(&FilePath::new(path.to_string_lossy()), &content, kind, 0);
+                host.add_file(&FilePath::new(path.to_string_lossy()), &content, kind);
                 loaded_files.push(path);
             }
         }
@@ -336,7 +336,7 @@ impl CliAnalysisHost {
         // For simplicity, default to ExecutableGraphQL kind
         let kind = FileKind::ExecutableGraphQL;
 
-        self.host.add_file(&file_path, content, kind, 0);
+        self.host.add_file(&file_path, content, kind);
 
         // Update loaded files list if this is a new file
         if !self.loaded_files.contains(&path.to_path_buf()) {

--- a/crates/graphql-db/src/lib.rs
+++ b/crates/graphql-db/src/lib.rs
@@ -87,10 +87,6 @@ pub struct FileMetadata {
     pub file_id: FileId,
     pub uri: FileUri,
     pub kind: FileKind,
-    /// Line offset for extracted GraphQL (0 for pure GraphQL files)
-    /// For TypeScript/JavaScript files, this is the line number where the GraphQL starts
-    #[default]
-    pub line_offset: u32,
 }
 
 /// Input: Schema file ID list (identity only)

--- a/crates/graphql-ide/src/analysis_host_isolation.rs
+++ b/crates/graphql-ide/src/analysis_host_isolation.rs
@@ -16,7 +16,7 @@ fn test_analysis_host_isolation_between_projects() {
     // Project 1: StarWars
     let mut host1 = AnalysisHost::new();
     let path1 = FilePath::new("file:///starwars/schema.graphql");
-    host1.add_file(&path1, "type Query { hero: String }", FileKind::Schema, 0);
+    host1.add_file(&path1, "type Query { hero: String }", FileKind::Schema);
     host1.rebuild_project_files();
 
     // Scope the snapshot so it's dropped before the next mutation
@@ -31,12 +31,7 @@ fn test_analysis_host_isolation_between_projects() {
     // Project 2: Pokemon
     let mut host2 = AnalysisHost::new();
     let path2 = FilePath::new("file:///pokemon/schema.graphql");
-    host2.add_file(
-        &path2,
-        "type Query { pokemon: String }",
-        FileKind::Schema,
-        0,
-    );
+    host2.add_file(&path2, "type Query { pokemon: String }", FileKind::Schema);
     host2.rebuild_project_files();
 
     {
@@ -49,7 +44,7 @@ fn test_analysis_host_isolation_between_projects() {
 
     // Add a file to project 1 that would be invalid in project 2
     let file1 = FilePath::new("file:///starwars/query.graphql");
-    host1.add_file(&file1, "query { hero }", FileKind::ExecutableGraphQL, 0);
+    host1.add_file(&file1, "query { hero }", FileKind::ExecutableGraphQL);
     host1.rebuild_project_files();
 
     {
@@ -62,7 +57,7 @@ fn test_analysis_host_isolation_between_projects() {
 
     // Add a file to project 2 that would be invalid in project 1
     let file2 = FilePath::new("file:///pokemon/query.graphql");
-    host2.add_file(&file2, "query { pokemon }", FileKind::ExecutableGraphQL, 0);
+    host2.add_file(&file2, "query { pokemon }", FileKind::ExecutableGraphQL);
     host2.rebuild_project_files();
 
     {
@@ -79,7 +74,6 @@ fn test_analysis_host_isolation_between_projects() {
         &file1_invalid,
         "query { pokemon }",
         FileKind::ExecutableGraphQL,
-        0,
     );
     host1.rebuild_project_files();
 
@@ -96,7 +90,6 @@ fn test_analysis_host_isolation_between_projects() {
         &file2_invalid,
         "query { hero }",
         FileKind::ExecutableGraphQL,
-        0,
     );
     host2.rebuild_project_files();
 

--- a/crates/graphql-ide/src/file_registry.rs
+++ b/crates/graphql-ide/src/file_registry.rs
@@ -74,7 +74,6 @@ impl FileRegistry {
         path: &FilePath,
         content: &str,
         kind: FileKind,
-        line_offset: u32,
     ) -> (FileId, FileContent, FileMetadata, bool)
     where
         DB: salsa::Database,
@@ -89,13 +88,10 @@ impl FileRegistry {
             if let Some(&existing_content) = self.id_to_content.get(&existing_id) {
                 existing_content.set_text(db).to(content_arc);
 
-                // Update metadata if needed (kind or line_offset changed)
+                // Update metadata if needed (kind changed)
                 let metadata = self.id_to_metadata.get(&existing_id).copied().unwrap();
                 if metadata.kind(db) != kind {
                     metadata.set_kind(db).to(kind);
-                }
-                if metadata.line_offset(db) != line_offset {
-                    metadata.set_line_offset(db).to(line_offset);
                 }
 
                 // Note: FileEntry is NOT updated here - it still points to the same
@@ -119,9 +115,6 @@ impl FileRegistry {
         // Create new FileMetadata
         let uri = FileUri::new(uri_str);
         let metadata = FileMetadata::new(db, file_id, uri, kind);
-        if line_offset > 0 {
-            metadata.set_line_offset(db).to(line_offset);
-        }
         self.id_to_metadata.insert(file_id, metadata);
 
         // Create new FileEntry (for granular caching)
@@ -284,7 +277,6 @@ mod tests {
             &path,
             "type Query { hello: String }",
             FileKind::Schema,
-            0,
         );
 
         // Should indicate this is a new file
@@ -314,7 +306,6 @@ mod tests {
             &path,
             "type Query { hello: String }",
             FileKind::Schema,
-            0,
         );
         assert!(is_new1);
 
@@ -324,7 +315,6 @@ mod tests {
             &path,
             "type Query { world: String }",
             FileKind::Schema,
-            0,
         );
 
         // Should indicate this is NOT a new file (just an update)
@@ -352,7 +342,6 @@ mod tests {
             &path,
             "type Query { hello: String }",
             FileKind::Schema,
-            0,
         );
 
         // Remove the file
@@ -376,14 +365,12 @@ mod tests {
             &path1,
             "type Query { hello: String }",
             FileKind::Schema,
-            0,
         );
         let (file_id2, _, _, _) = registry.add_file(
             &mut db,
             &path2,
             "type Mutation { update: Boolean }",
             FileKind::Schema,
-            0,
         );
 
         let all_ids = registry.all_file_ids();

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -775,19 +775,14 @@ impl LanguageServer for GraphQLLanguageServer {
         // For TS/JS files, store the original source and let the parsing layer handle extraction.
         // This preserves block boundaries and allows proper validation of separate documents.
         let final_content = content;
-        let line_offset = 0;
         let final_kind = file_kind;
 
         // === PHASE 3: Update file and get snapshot in one lock (optimized path) ===
         let file_path = graphql_ide::FilePath::new(uri.to_string());
         let snapshot = {
             let mut host_guard = host.lock().await;
-            let (_is_new, snapshot) = host_guard.update_file_and_snapshot(
-                &file_path,
-                &final_content,
-                final_kind,
-                line_offset,
-            );
+            let (_is_new, snapshot) =
+                host_guard.update_file_and_snapshot(&file_path, &final_content, final_kind);
             snapshot
         };
 
@@ -830,19 +825,14 @@ impl LanguageServer for GraphQLLanguageServer {
             // For TS/JS files, store the original source and let the parsing layer handle extraction.
             // This preserves block boundaries and allows proper validation of separate documents.
             let final_content = change.text.clone();
-            let line_offset = 0;
             let final_kind = file_kind;
 
             // === PHASE 3: Update file and get snapshot in one lock (optimized path) ===
             let file_path = graphql_ide::FilePath::new(uri.to_string());
             let snapshot = {
                 let mut host_guard = host.lock().await;
-                let (_is_new, snapshot) = host_guard.update_file_and_snapshot(
-                    &file_path,
-                    &final_content,
-                    final_kind,
-                    line_offset,
-                );
+                let (_is_new, snapshot) =
+                    host_guard.update_file_and_snapshot(&file_path, &final_content, final_kind);
                 snapshot
             };
 


### PR DESCRIPTION
## Summary
- Remove redundant `line_offset` field from `FileMetadata` since extraction already provides offsets per-document via `doc.line_offset`
- Simplify offset calculations across graphql-analysis, graphql-ide, graphql-cli, and graphql-lsp crates
- Update `FileRegistry::add_file()` and `AnalysisHost::add_file()` signatures to no longer take line_offset parameter

## Details

The `metadata.line_offset` field was always 0 in production because:
- For **pure GraphQL files**: both `doc.line_offset` and `metadata.line_offset` are always 0
- For **embedded GraphQL (TS/JS)**: the offset comes from the extraction process (`doc.line_offset`), not from metadata

This refactoring removes ~250 lines of redundant code and simplifies the offset handling by using only the extraction-provided offsets.

## Test plan
- [x] All existing tests pass
- [x] Clippy checks pass
- [x] Code formatted

Fixes #415