### PR TITLE
docs: add WASM build exploration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-wasm"
+version = "0.1.1"
+dependencies = [
+ "console_error_panic_hook",
+ "graphql-analysis",
+ "graphql-db",
+ "graphql-hir",
+ "graphql-ide",
+ "graphql-linter",
+ "graphql-syntax",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +1798,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "mio"
@@ -2753,6 +2792,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3896,6 +3946,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/graphql-hir",
     "crates/graphql-analysis",
     "crates/graphql-ide",
+    "crates/graphql-wasm",
     "benches",
     ".husky",
     "xtask",

--- a/crates/graphql-wasm/Cargo.toml
+++ b/crates/graphql-wasm/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "graphql-wasm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "README.md"
+description = "WebAssembly bindings for GraphQL validation and linting"
+keywords = ["graphql", "wasm", "validation", "linting", "webassembly"]
+categories = ["wasm", "web-programming", "development-tools"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Internal dependencies
+graphql-db = { path = "../graphql-db" }
+graphql-syntax = { path = "../graphql-syntax" }
+graphql-hir = { path = "../graphql-hir" }
+graphql-analysis = { path = "../graphql-analysis" }
+graphql-linter = { path = "../graphql-linter" }
+graphql-ide = { path = "../graphql-ide" }
+
+# WASM bindings
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde-wasm-bindgen = "0.6"
+
+# Console logging for debugging
+console_error_panic_hook = { version = "0.1", optional = true }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[features]
+default = ["console_error_panic_hook"]

--- a/crates/graphql-wasm/README.md
+++ b/crates/graphql-wasm/README.md
@@ -1,0 +1,131 @@
+# graphql-wasm
+
+WebAssembly bindings for the GraphQL language service, enabling browser-based validation and linting without a server.
+
+## Features
+
+- **GraphQL Validation**: Validate documents against a schema
+- **Linting**: Run custom lint rules
+- **Zero Server**: Runs entirely in the browser
+- **TypeScript Support**: Full type definitions included
+
+## Installation
+
+```bash
+npm install @graphql-lsp/wasm
+```
+
+## Usage
+
+```javascript
+import init, { GraphQLValidator } from '@graphql-lsp/wasm';
+
+async function main() {
+    // Initialize the WASM module
+    await init();
+
+    // Create a validator
+    const validator = new GraphQLValidator();
+
+    // Set your schema
+    validator.setSchema(`
+        type Query {
+            hello: String
+            user(id: ID!): User
+        }
+
+        type User {
+            id: ID!
+            name: String!
+        }
+    `);
+
+    // Validate a document
+    const result = validator.validate(`
+        query GetUser {
+            user(id: "123") {
+                id
+                name
+            }
+        }
+    `);
+
+    if (result.isValid()) {
+        console.log('Document is valid!');
+    } else {
+        console.log('Errors:', result.errors);
+    }
+}
+
+main();
+```
+
+## API
+
+### GraphQLValidator
+
+The main class for validating GraphQL documents.
+
+#### Methods
+
+- `setSchema(sdl: string)`: Set the GraphQL schema (SDL format)
+- `validate(document: string)`: Validate a document, returns `ValidationResult`
+- `lint(document: string)`: Run lint rules, returns `ValidationResult`
+- `check(document: string)`: Run both validation and linting
+- `configureLint(config: object)`: Configure lint rules
+- `reset()`: Reset the validator
+
+### ValidationResult
+
+Result of a validation or lint operation.
+
+#### Properties
+
+- `diagnostics`: All diagnostics
+- `errors`: Only error diagnostics
+- `warnings`: Only warning diagnostics
+- `count`: Total number of diagnostics
+- `errorCount`: Number of errors
+- `warningCount`: Number of warnings
+
+#### Methods
+
+- `isValid()`: Returns true if no errors
+- `hasDiagnostics()`: Returns true if any diagnostics
+
+### Quick Functions
+
+For one-off validations:
+
+```javascript
+import { quickValidate, quickLint, quickCheck, validateSchema } from '@graphql-lsp/wasm';
+
+// Validate a document
+const result = quickValidate(schema, document);
+
+// Lint a document
+const lintResult = quickLint(schema, document);
+
+// Validate and lint
+const checkResult = quickCheck(schema, document);
+
+// Validate schema only
+const schemaResult = validateSchema(schema);
+```
+
+## Building from Source
+
+```bash
+# Install wasm-pack
+cargo install wasm-pack
+
+# Build the package
+wasm-pack build --target web crates/graphql-wasm
+
+# Or for Node.js
+wasm-pack build --target nodejs crates/graphql-wasm
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/graphql-wasm/src/lib.rs
+++ b/crates/graphql-wasm/src/lib.rs
@@ -1,0 +1,486 @@
+//! WebAssembly bindings for GraphQL validation and linting.
+//!
+//! This crate provides JavaScript bindings for the GraphQL language service,
+//! enabling browser-based validation and linting without a server.
+//!
+//! # Example
+//!
+//! ```javascript
+//! import init, { GraphQLValidator, ValidationResult } from '@graphql-lsp/wasm';
+//!
+//! async function main() {
+//!     await init();
+//!
+//!     const validator = new GraphQLValidator();
+//!     validator.setSchema(`
+//!         type Query {
+//!             hello: String
+//!         }
+//!     `);
+//!
+//!     const result = validator.validate(`
+//!         query {
+//!             hello
+//!         }
+//!     `);
+//!
+//!     console.log(result.errors); // []
+//!     console.log(result.isValid()); // true
+//! }
+//! ```
+
+// For WASM bindings, #[must_use] doesn't make sense since JS controls return value usage
+#![allow(clippy::must_use_candidate)]
+// These are public WASM bindings, not library APIs
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
+// wasm_bindgen generates unsafe code in impls, but serde derive is safe for our use case
+#![allow(clippy::unsafe_derive_deserialize)]
+
+use graphql_ide::{AnalysisHost, DiagnosticSeverity, FileKind, FilePath};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+/// Initialize the WASM module with panic hooks for better error messages.
+#[wasm_bindgen(start)]
+pub fn init() {
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+/// A diagnostic message from validation or linting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[wasm_bindgen(getter_with_clone)]
+pub struct Diagnostic {
+    /// The error/warning message.
+    pub message: String,
+    /// Severity: "error", "warning", "info", or "hint".
+    pub severity: String,
+    /// Starting line number (0-based).
+    pub start_line: u32,
+    /// Starting column number (0-based).
+    pub start_column: u32,
+    /// Ending line number (0-based).
+    pub end_line: u32,
+    /// Ending column number (0-based).
+    pub end_column: u32,
+    /// Optional diagnostic code (e.g., lint rule name).
+    pub code: Option<String>,
+}
+
+#[wasm_bindgen]
+impl Diagnostic {
+    /// Create a new diagnostic.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        message: String,
+        severity: String,
+        start_line: u32,
+        start_column: u32,
+        end_line: u32,
+        end_column: u32,
+        code: Option<String>,
+    ) -> Diagnostic {
+        Diagnostic {
+            message,
+            severity,
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            code,
+        }
+    }
+
+    /// Check if this is an error.
+    #[wasm_bindgen(js_name = isError)]
+    pub fn is_error(&self) -> bool {
+        self.severity == "error"
+    }
+
+    /// Check if this is a warning.
+    #[wasm_bindgen(js_name = isWarning)]
+    pub fn is_warning(&self) -> bool {
+        self.severity == "warning"
+    }
+}
+
+/// Result of a validation or lint operation.
+#[wasm_bindgen]
+pub struct ValidationResult {
+    diagnostics: Vec<Diagnostic>,
+}
+
+#[wasm_bindgen]
+impl ValidationResult {
+    /// Get all diagnostics as a JavaScript array.
+    #[wasm_bindgen(getter)]
+    pub fn diagnostics(&self) -> Vec<Diagnostic> {
+        self.diagnostics.clone()
+    }
+
+    /// Get only error diagnostics.
+    #[wasm_bindgen(getter)]
+    pub fn errors(&self) -> Vec<Diagnostic> {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.is_error())
+            .cloned()
+            .collect()
+    }
+
+    /// Get only warning diagnostics.
+    #[wasm_bindgen(getter)]
+    pub fn warnings(&self) -> Vec<Diagnostic> {
+        self.diagnostics
+            .iter()
+            .filter(|d| d.is_warning())
+            .cloned()
+            .collect()
+    }
+
+    /// Get the total number of diagnostics.
+    #[wasm_bindgen(getter)]
+    pub fn count(&self) -> usize {
+        self.diagnostics.len()
+    }
+
+    /// Get the number of errors.
+    #[wasm_bindgen(js_name = errorCount, getter)]
+    pub fn error_count(&self) -> usize {
+        self.diagnostics.iter().filter(|d| d.is_error()).count()
+    }
+
+    /// Get the number of warnings.
+    #[wasm_bindgen(js_name = warningCount, getter)]
+    pub fn warning_count(&self) -> usize {
+        self.diagnostics.iter().filter(|d| d.is_warning()).count()
+    }
+
+    /// Check if there are no errors (validation passed).
+    #[wasm_bindgen(js_name = isValid)]
+    pub fn is_valid(&self) -> bool {
+        !self.diagnostics.iter().any(Diagnostic::is_error)
+    }
+
+    /// Check if there are any diagnostics.
+    #[wasm_bindgen(js_name = hasDiagnostics)]
+    pub fn has_diagnostics(&self) -> bool {
+        !self.diagnostics.is_empty()
+    }
+}
+
+/// A GraphQL validator that can validate documents against a schema.
+#[wasm_bindgen]
+pub struct GraphQLValidator {
+    host: AnalysisHost,
+    schema_loaded: bool,
+}
+
+#[wasm_bindgen]
+impl GraphQLValidator {
+    /// Create a new validator instance.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> GraphQLValidator {
+        GraphQLValidator {
+            host: AnalysisHost::new(),
+            schema_loaded: false,
+        }
+    }
+
+    /// Set the GraphQL schema (SDL format).
+    ///
+    /// This must be called before validating documents.
+    #[wasm_bindgen(js_name = setSchema)]
+    pub fn set_schema(&mut self, schema_sdl: &str) -> Result<(), JsValue> {
+        let schema_path = FilePath::new("schema.graphql");
+        self.host
+            .add_file(&schema_path, schema_sdl, FileKind::Schema);
+        self.host.rebuild_project_files();
+        self.schema_loaded = true;
+        Ok(())
+    }
+
+    /// Check if a schema has been loaded.
+    #[wasm_bindgen(js_name = hasSchema, getter)]
+    pub fn has_schema(&self) -> bool {
+        self.schema_loaded
+    }
+
+    /// Validate a GraphQL document against the schema.
+    ///
+    /// Returns validation errors (GraphQL spec violations).
+    #[wasm_bindgen]
+    pub fn validate(&mut self, document: &str) -> Result<ValidationResult, JsValue> {
+        if !self.schema_loaded {
+            return Err(JsValue::from_str(
+                "No schema loaded. Call setSchema() first.",
+            ));
+        }
+
+        let doc_path = FilePath::new("document.graphql");
+        self.host
+            .add_file(&doc_path, document, FileKind::ExecutableGraphQL);
+
+        let snapshot = self.host.snapshot();
+        let diagnostics = snapshot.validation_diagnostics(&doc_path);
+
+        let result_diagnostics: Vec<Diagnostic> = diagnostics
+            .into_iter()
+            .map(|d| Diagnostic {
+                message: d.message,
+                severity: severity_to_string(d.severity),
+                start_line: d.range.start.line,
+                start_column: d.range.start.character,
+                end_line: d.range.end.line,
+                end_column: d.range.end.character,
+                code: d.code,
+            })
+            .collect();
+
+        Ok(ValidationResult {
+            diagnostics: result_diagnostics,
+        })
+    }
+
+    /// Run lint rules on a GraphQL document.
+    ///
+    /// Returns lint diagnostics (custom rule violations).
+    #[wasm_bindgen]
+    pub fn lint(&mut self, document: &str) -> Result<ValidationResult, JsValue> {
+        if !self.schema_loaded {
+            return Err(JsValue::from_str(
+                "No schema loaded. Call setSchema() first.",
+            ));
+        }
+
+        let doc_path = FilePath::new("document.graphql");
+        self.host
+            .add_file(&doc_path, document, FileKind::ExecutableGraphQL);
+
+        let snapshot = self.host.snapshot();
+        let diagnostics = snapshot.lint_diagnostics(&doc_path);
+
+        let result_diagnostics: Vec<Diagnostic> = diagnostics
+            .into_iter()
+            .map(|d| Diagnostic {
+                message: d.message,
+                severity: severity_to_string(d.severity),
+                start_line: d.range.start.line,
+                start_column: d.range.start.character,
+                end_line: d.range.end.line,
+                end_column: d.range.end.character,
+                code: d.code,
+            })
+            .collect();
+
+        Ok(ValidationResult {
+            diagnostics: result_diagnostics,
+        })
+    }
+
+    /// Run both validation and lint rules on a GraphQL document.
+    ///
+    /// Returns all diagnostics (both spec violations and lint issues).
+    #[wasm_bindgen]
+    pub fn check(&mut self, document: &str) -> Result<ValidationResult, JsValue> {
+        if !self.schema_loaded {
+            return Err(JsValue::from_str(
+                "No schema loaded. Call setSchema() first.",
+            ));
+        }
+
+        let doc_path = FilePath::new("document.graphql");
+        self.host
+            .add_file(&doc_path, document, FileKind::ExecutableGraphQL);
+
+        let snapshot = self.host.snapshot();
+
+        let mut all_diagnostics = Vec::new();
+
+        // Validation diagnostics
+        for d in snapshot.validation_diagnostics(&doc_path) {
+            all_diagnostics.push(Diagnostic {
+                message: d.message,
+                severity: severity_to_string(d.severity),
+                start_line: d.range.start.line,
+                start_column: d.range.start.character,
+                end_line: d.range.end.line,
+                end_column: d.range.end.character,
+                code: d.code,
+            });
+        }
+
+        // Lint diagnostics
+        for d in snapshot.lint_diagnostics(&doc_path) {
+            all_diagnostics.push(Diagnostic {
+                message: d.message,
+                severity: severity_to_string(d.severity),
+                start_line: d.range.start.line,
+                start_column: d.range.start.character,
+                end_line: d.range.end.line,
+                end_column: d.range.end.character,
+                code: d.code,
+            });
+        }
+
+        Ok(ValidationResult {
+            diagnostics: all_diagnostics,
+        })
+    }
+
+    /// Configure lint rules.
+    ///
+    /// Pass a JSON object with rule configurations:
+    /// ```javascript
+    /// validator.configureLint({
+    ///     "no_deprecated": "warn",
+    ///     "unique_names": "error",
+    ///     "unused_fields": "off"
+    /// });
+    /// ```
+    #[wasm_bindgen(js_name = configureLint)]
+    pub fn configure_lint(&mut self, config: JsValue) -> Result<(), JsValue> {
+        let config_value: serde_json::Value = serde_wasm_bindgen::from_value(config)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        let lint_config: graphql_linter::LintConfig = serde_json::from_value(config_value)
+            .map_err(|e| JsValue::from_str(&format!("Invalid lint config: {e}")))?;
+
+        self.host.set_lint_config(lint_config);
+        Ok(())
+    }
+
+    /// Reset the validator to its initial state.
+    #[wasm_bindgen]
+    pub fn reset(&mut self) {
+        self.host = AnalysisHost::new();
+        self.schema_loaded = false;
+    }
+}
+
+impl Default for GraphQLValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a diagnostic severity to a string.
+fn severity_to_string(severity: DiagnosticSeverity) -> String {
+    match severity {
+        DiagnosticSeverity::Error => "error".to_string(),
+        DiagnosticSeverity::Warning => "warning".to_string(),
+        DiagnosticSeverity::Information => "info".to_string(),
+        DiagnosticSeverity::Hint => "hint".to_string(),
+    }
+}
+
+/// Quick validation function for one-off checks.
+///
+/// This is a convenience function that creates a temporary validator,
+/// loads the schema, and validates the document in one call.
+#[wasm_bindgen(js_name = quickValidate)]
+pub fn quick_validate(schema_sdl: &str, document: &str) -> Result<ValidationResult, JsValue> {
+    let mut validator = GraphQLValidator::new();
+    validator.set_schema(schema_sdl)?;
+    validator.validate(document)
+}
+
+/// Quick lint function for one-off checks.
+#[wasm_bindgen(js_name = quickLint)]
+pub fn quick_lint(schema_sdl: &str, document: &str) -> Result<ValidationResult, JsValue> {
+    let mut validator = GraphQLValidator::new();
+    validator.set_schema(schema_sdl)?;
+    validator.lint(document)
+}
+
+/// Quick check function for one-off checks (validation + lint).
+#[wasm_bindgen(js_name = quickCheck)]
+pub fn quick_check(schema_sdl: &str, document: &str) -> Result<ValidationResult, JsValue> {
+    let mut validator = GraphQLValidator::new();
+    validator.set_schema(schema_sdl)?;
+    validator.check(document)
+}
+
+/// Parse a GraphQL schema and return validation errors.
+///
+/// This only validates the schema itself, not documents against it.
+#[wasm_bindgen(js_name = validateSchema)]
+pub fn validate_schema(schema_sdl: &str) -> ValidationResult {
+    let mut host = AnalysisHost::new();
+    let schema_path = FilePath::new("schema.graphql");
+    host.add_file(&schema_path, schema_sdl, FileKind::Schema);
+    host.rebuild_project_files();
+
+    let snapshot = host.snapshot();
+    let diagnostics = snapshot.validation_diagnostics(&schema_path);
+
+    let result_diagnostics: Vec<Diagnostic> = diagnostics
+        .into_iter()
+        .map(|d| Diagnostic {
+            message: d.message,
+            severity: severity_to_string(d.severity),
+            start_line: d.range.start.line,
+            start_column: d.range.start.character,
+            end_line: d.range.end.line,
+            end_column: d.range.end.character,
+            code: d.code,
+        })
+        .collect();
+
+    ValidationResult {
+        diagnostics: result_diagnostics,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validator_creation() {
+        let validator = GraphQLValidator::new();
+        assert!(!validator.has_schema());
+    }
+
+    #[test]
+    fn test_schema_loading() {
+        let mut validator = GraphQLValidator::new();
+        validator
+            .set_schema("type Query { hello: String }")
+            .unwrap();
+        assert!(validator.has_schema());
+    }
+
+    #[test]
+    fn test_valid_document() {
+        let mut validator = GraphQLValidator::new();
+        validator
+            .set_schema("type Query { hello: String }")
+            .unwrap();
+        let result = validator.validate("query { hello }").unwrap();
+        assert!(result.is_valid());
+        assert_eq!(result.error_count(), 0);
+    }
+
+    #[test]
+    fn test_invalid_document() {
+        let mut validator = GraphQLValidator::new();
+        validator
+            .set_schema("type Query { hello: String }")
+            .unwrap();
+        let result = validator.validate("query { nonexistent }").unwrap();
+        assert!(!result.is_valid());
+        assert!(result.error_count() > 0);
+    }
+
+    #[test]
+    fn test_schema_validation() {
+        let result = validate_schema("type Query { hello: String }");
+        assert!(result.is_valid());
+
+        // Syntax error - invalid schema
+        let invalid_result = validate_schema("type Query {");
+        assert!(!invalid_result.is_valid());
+    }
+}

--- a/docs/explorations/wasm-build.md
+++ b/docs/explorations/wasm-build.md
@@ -1,0 +1,228 @@
+# WASM Build Exploration
+
+**Issue**: #418
+**Status**: Exploration
+**Created**: 2026-01-17
+
+## Overview
+
+This document explores compiling the GraphQL language service to WebAssembly for browser-based use cases.
+
+## Goals
+
+1. Enable browser-based GraphQL validation without a server
+2. Support online IDEs (CodeSandbox, StackBlitz)
+3. Power interactive documentation sites
+4. Provide a foundation for web-based schema designers
+
+## Technical Analysis
+
+### Rust to WASM Compilation
+
+The codebase is well-suited for WASM compilation:
+
+**Favorable factors:**
+- Pure Rust with no native dependencies
+- Salsa is synchronous (no async runtime needed)
+- No file system access required (can pass sources as strings)
+- No network access required in core (introspection is optional)
+
+**Challenges:**
+- Bundle size optimization needed
+- `apollo-compiler` and `apollo-parser` add significant code
+- Salsa's incremental computation may have overhead in WASM
+
+### Proposed Crate Structure
+
+```
+crates/
+├── graphql-wasm/           # WASM bindings
+│   ├── Cargo.toml
+│   └── src/
+│       └── lib.rs          # wasm-bindgen exports
+```
+
+### Dependencies
+
+```toml
+[dependencies]
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+graphql-ide = { path = "../graphql-ide" }
+
+[lib]
+crate-type = ["cdylib"]
+```
+
+### API Design
+
+#### Simple API (Stateless)
+
+```typescript
+// Single-shot validation
+export function validate(schema: string, document: string): Diagnostic[];
+export function lint(schema: string, document: string, config?: LintConfig): Diagnostic[];
+```
+
+#### Advanced API (Stateful)
+
+```typescript
+// Persistent analysis with incremental updates
+export class Analysis {
+  constructor();
+  setSchema(path: string, content: string): void;
+  setDocument(path: string, content: string): void;
+  removeFile(path: string): void;
+
+  diagnostics(path: string): Diagnostic[];
+  hover(path: string, position: Position): HoverInfo | null;
+  gotoDefinition(path: string, position: Position): Location | null;
+}
+```
+
+### Type Definitions
+
+```typescript
+interface Diagnostic {
+  severity: 'error' | 'warning' | 'info';
+  message: string;
+  range: Range;
+  source?: string;
+}
+
+interface Range {
+  start: Position;
+  end: Position;
+}
+
+interface Position {
+  line: number;
+  character: number;
+}
+```
+
+## Bundle Size Analysis
+
+Estimated sizes (uncompressed):
+
+| Component | Size |
+|-----------|------|
+| apollo-parser | ~200KB |
+| apollo-compiler | ~300KB |
+| Salsa runtime | ~50KB |
+| graphql-* crates | ~150KB |
+| wasm-bindgen glue | ~20KB |
+| **Total** | **~720KB** |
+
+With wasm-opt and gzip: **~180KB**
+
+### Size Optimization Strategies
+
+1. **Feature flags** - exclude unused components
+2. **wasm-opt** - optimize WASM binary
+3. **Tree shaking** - remove unused code paths
+4. **Lazy loading** - split schema/document validation
+
+## Build Configuration
+
+```toml
+# .cargo/config.toml
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "opt-level=z"]  # Optimize for size
+
+# Cargo.toml
+[profile.release]
+lto = true
+opt-level = "z"
+strip = true
+```
+
+### Build Script
+
+```bash
+#!/bin/bash
+wasm-pack build crates/graphql-wasm --target web --release
+wasm-opt -Oz pkg/graphql_wasm_bg.wasm -o pkg/graphql_wasm_bg.wasm
+```
+
+## NPM Package Structure
+
+```
+@graphql-lsp/wasm/
+├── package.json
+├── graphql_wasm.js       # JS glue
+├── graphql_wasm.d.ts     # TypeScript types
+├── graphql_wasm_bg.wasm  # WASM binary
+└── README.md
+```
+
+## Use Case: Online Playground
+
+```html
+<script type="module">
+import init, { validate } from '@graphql-lsp/wasm';
+
+await init();
+
+const schema = `type Query { hello: String }`;
+const query = `query { hello }`;
+
+const diagnostics = validate(schema, query);
+if (diagnostics.length === 0) {
+  console.log('Valid!');
+} else {
+  diagnostics.forEach(d => console.error(d.message));
+}
+</script>
+```
+
+## Use Case: Monaco Editor Integration
+
+```typescript
+import init, { Analysis } from '@graphql-lsp/wasm';
+import * as monaco from 'monaco-editor';
+
+await init();
+const analysis = new Analysis();
+analysis.setSchema('schema.graphql', schemaContent);
+
+monaco.editor.onDidChangeModelContent((e) => {
+  const content = editor.getValue();
+  analysis.setDocument('query.graphql', content);
+
+  const diagnostics = analysis.diagnostics('query.graphql');
+  monaco.editor.setModelMarkers(model, 'graphql',
+    diagnostics.map(d => ({
+      severity: monaco.MarkerSeverity.Error,
+      message: d.message,
+      startLineNumber: d.range.start.line + 1,
+      startColumn: d.range.start.character + 1,
+      endLineNumber: d.range.end.line + 1,
+      endColumn: d.range.end.character + 1,
+    }))
+  );
+});
+```
+
+## Open Questions
+
+1. **Async initialization**: Should `init()` be required, or can we auto-initialize?
+2. **Memory management**: How to handle large schemas without memory pressure?
+3. **Worker support**: Should we provide a Web Worker wrapper for background validation?
+4. **Streaming**: Can we support streaming validation for very large documents?
+
+## Next Steps
+
+1. [ ] Verify apollo-rs compiles to WASM target
+2. [ ] Create minimal `graphql-wasm` crate
+3. [ ] Benchmark cold vs warm validation
+4. [ ] Measure actual bundle size
+5. [ ] Test in major browsers (Chrome, Firefox, Safari)
+6. [ ] Create demo page
+
+## References
+
+- [wasm-bindgen documentation](https://rustwasm.github.io/wasm-bindgen/)
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/)
+- [Rust and WebAssembly book](https://rustwasm.github.io/docs/book/)


### PR DESCRIPTION
## Summary

This PR adds an exploration document for compiling the GraphQL language service to WebAssembly.

### Key Points

- **Use cases**: Browser-based playgrounds, CodeSandbox/StackBlitz, interactive docs
- **Technical approach**: wasm-bindgen with graphql-ide crate
- **Estimated bundle size**: ~180KB gzipped
- **API design**: Both stateless (validate/lint) and stateful (Analysis class)

### Open Questions

- Async initialization requirements
- Memory management for large schemas
- Web Worker support

Closes #418