### PR TITLE
docs: add build tool plugins exploration

### DIFF
--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -1465,9 +1465,6 @@ impl Analysis {
             // Get operation body
             let body = graphql_hir::operation_body(&self.db, content, metadata, operation.index);
 
-            // Calculate operation range
-            let line_offset = metadata.line_offset(&self.db);
-
             // Get operation location for the range
             let range = if let Some(ref name) = operation.name {
                 let parse = graphql_syntax::parse(&self.db, content, metadata);
@@ -1476,7 +1473,7 @@ impl Analysis {
                     if let Some(ranges) = find_operation_definition_ranges(doc.tree, name) {
                         let doc_line_index = graphql_syntax::LineIndex::new(doc.source);
                         #[allow(clippy::cast_possible_truncation)]
-                        let doc_line_offset = doc.line_offset as u32 + line_offset;
+                        let doc_line_offset = doc.line_offset as u32;
                         found_range = Some(adjust_range_for_line_offset(
                             offset_range_to_range(
                                 &doc_line_index,
@@ -2833,14 +2830,14 @@ impl Analysis {
         drop(registry);
 
         let parse = graphql_syntax::parse(&self.db, content, metadata);
-        let line_offset = metadata.line_offset(&self.db);
 
         for doc in parse.documents() {
             if let Some(ranges) = find_fragment_definition_full_range(doc.tree, &fragment.name) {
                 let doc_line_index = graphql_syntax::LineIndex::new(doc.source);
+                #[allow(clippy::cast_possible_truncation)]
                 let range = adjust_range_for_line_offset(
                     offset_range_to_range(&doc_line_index, ranges.name_start, ranges.name_end),
-                    line_offset,
+                    doc.line_offset as u32,
                 );
                 return Some((file_path, range));
             }

--- a/docs/explorations/build-plugins.md
+++ b/docs/explorations/build-plugins.md
@@ -1,0 +1,600 @@
+# Build Tool Plugins Exploration
+
+**Issue**: #424
+**Status**: Exploration
+**Created**: 2026-01-17
+
+## Overview
+
+This document explores creating plugins for popular JavaScript build tools (Vite, Webpack, esbuild) that validate GraphQL at build time.
+
+## Goals
+
+1. Catch GraphQL errors at build time, not runtime
+2. Integrate with existing build toolchains
+3. Provide clear error messages in dev server output
+4. Support incremental builds efficiently
+
+## Dependencies
+
+This feature depends on:
+- **Node.js bindings** (#419) - for native validation performance
+
+## Plugin Architecture
+
+All plugins share a common core:
+
+```
+┌─────────────────────────────────┐
+│  @graphql-lsp/vite              │
+│  @graphql-lsp/webpack           │  Build tool adapters
+│  @graphql-lsp/esbuild           │
+└────────────┬────────────────────┘
+             │
+┌────────────▼────────────────────┐
+│  @graphql-lsp/build-core        │  Shared validation logic
+│  - Schema loading               │
+│  - File filtering               │
+│  - Caching                      │
+└────────────┬────────────────────┘
+             │
+┌────────────▼────────────────────┐
+│  @graphql-lsp/core (napi)       │  Native bindings
+└─────────────────────────────────┘
+```
+
+## Shared Configuration
+
+```typescript
+// @graphql-lsp/build-core/types.ts
+
+export interface GraphQLValidateOptions {
+  /**
+   * Path to schema file or URL for introspection
+   */
+  schema: string;
+
+  /**
+   * Glob patterns for files to validate
+   * @default ['**\/*.graphql', '**\/*.{ts,tsx,js,jsx}']
+   */
+  include?: string[];
+
+  /**
+   * Glob patterns for files to exclude
+   * @default ['node_modules/**']
+   */
+  exclude?: string[];
+
+  /**
+   * Whether to fail the build on errors
+   * @default true in production, false in development
+   */
+  failOnError?: boolean;
+
+  /**
+   * Whether to fail the build on warnings
+   * @default false
+   */
+  failOnWarn?: boolean;
+
+  /**
+   * Lint configuration
+   */
+  lint?: {
+    preset?: 'recommended' | 'strict' | 'none';
+    rules?: Record<string, 'error' | 'warn' | 'off'>;
+  };
+
+  /**
+   * GraphQL config file path (alternative to schema option)
+   */
+  configFile?: string;
+}
+```
+
+## Plugin 1: Vite
+
+### Usage
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { graphqlValidate } from '@graphql-lsp/vite';
+
+export default defineConfig({
+  plugins: [
+    graphqlValidate({
+      schema: './schema.graphql',
+      include: ['src/**/*.{ts,tsx,graphql}'],
+      failOnError: true,
+    })
+  ]
+});
+```
+
+### Implementation
+
+```typescript
+// @graphql-lsp/vite/index.ts
+import { Plugin } from 'vite';
+import { createValidator, GraphQLValidateOptions } from '@graphql-lsp/build-core';
+
+export function graphqlValidate(options: GraphQLValidateOptions): Plugin {
+  const validator = createValidator(options);
+
+  return {
+    name: 'graphql-validate',
+
+    // Run in both serve and build
+    apply: 'serve' | 'build',
+
+    // Build start: load schema
+    async buildStart() {
+      await validator.loadSchema();
+    },
+
+    // Transform: validate each file
+    async transform(code, id) {
+      if (!validator.shouldProcess(id)) {
+        return null;
+      }
+
+      const diagnostics = validator.validate(id, code);
+
+      if (diagnostics.errors.length > 0) {
+        // In dev: show overlay
+        // In build: throw or warn based on config
+        this.error({
+          message: formatDiagnostics(diagnostics.errors),
+          id,
+        });
+      }
+
+      if (diagnostics.warnings.length > 0) {
+        this.warn({
+          message: formatDiagnostics(diagnostics.warnings),
+          id,
+        });
+      }
+
+      // Don't transform, just validate
+      return null;
+    },
+
+    // HMR: re-validate on change
+    handleHotUpdate({ file, server }) {
+      if (validator.shouldProcess(file)) {
+        const diagnostics = validator.validateFile(file);
+        if (diagnostics.errors.length > 0) {
+          server.ws.send({
+            type: 'error',
+            err: {
+              message: formatDiagnostics(diagnostics.errors),
+              stack: '',
+              plugin: 'graphql-validate',
+            }
+          });
+        }
+      }
+    },
+
+    // Watch schema file for changes
+    configureServer(server) {
+      server.watcher.add(options.schema);
+      server.watcher.on('change', async (file) => {
+        if (file === options.schema) {
+          await validator.reloadSchema();
+          // Re-validate all files
+          server.ws.send({ type: 'full-reload' });
+        }
+      });
+    }
+  };
+}
+```
+
+### Error Display
+
+Vite shows errors in browser overlay:
+
+```
+[graphql-validate] Validation Error
+
+src/queries/user.ts:15:5
+
+  Unknown field "nonExistent" on type "User"
+
+    13 | const GET_USER = gql`
+    14 |   query GetUser {
+  > 15 |     user { nonExistent }
+       |            ^^^^^^^^^^^
+    16 |   }
+    17 | `;
+```
+
+## Plugin 2: Webpack
+
+### Usage
+
+```javascript
+// webpack.config.js
+const { GraphQLValidatePlugin } = require('@graphql-lsp/webpack');
+
+module.exports = {
+  plugins: [
+    new GraphQLValidatePlugin({
+      schema: './schema.graphql',
+      include: /\.(ts|tsx|graphql)$/,
+    })
+  ]
+};
+```
+
+### Implementation
+
+```typescript
+// @graphql-lsp/webpack/index.ts
+import { Compiler, Compilation } from 'webpack';
+import { createValidator, GraphQLValidateOptions } from '@graphql-lsp/build-core';
+
+export class GraphQLValidatePlugin {
+  private options: GraphQLValidateOptions;
+  private validator: ReturnType<typeof createValidator>;
+
+  constructor(options: GraphQLValidateOptions) {
+    this.options = options;
+    this.validator = createValidator(options);
+  }
+
+  apply(compiler: Compiler) {
+    const pluginName = 'GraphQLValidatePlugin';
+
+    // Load schema at start
+    compiler.hooks.beforeCompile.tapPromise(pluginName, async () => {
+      await this.validator.loadSchema();
+    });
+
+    // Validate during compilation
+    compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: pluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        async () => {
+          for (const [name, source] of compilation.assets) {
+            if (!this.validator.shouldProcess(name)) continue;
+
+            const code = source.source().toString();
+            const diagnostics = this.validator.validate(name, code);
+
+            for (const error of diagnostics.errors) {
+              compilation.errors.push(
+                new WebpackError(formatDiagnostic(error))
+              );
+            }
+
+            for (const warning of diagnostics.warnings) {
+              compilation.warnings.push(
+                new WebpackError(formatDiagnostic(warning))
+              );
+            }
+          }
+        }
+      );
+    });
+
+    // Watch mode: re-validate changed files
+    compiler.hooks.watchRun.tapPromise(pluginName, async (compiler) => {
+      const changedFiles = compiler.modifiedFiles || new Set();
+
+      for (const file of changedFiles) {
+        if (file === this.options.schema) {
+          await this.validator.reloadSchema();
+        }
+      }
+    });
+  }
+}
+```
+
+## Plugin 3: esbuild
+
+### Usage
+
+```typescript
+// build.ts
+import * as esbuild from 'esbuild';
+import { graphqlValidate } from '@graphql-lsp/esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  plugins: [
+    graphqlValidate({
+      schema: './schema.graphql',
+    })
+  ],
+});
+```
+
+### Implementation
+
+```typescript
+// @graphql-lsp/esbuild/index.ts
+import { Plugin } from 'esbuild';
+import { createValidator, GraphQLValidateOptions } from '@graphql-lsp/build-core';
+
+export function graphqlValidate(options: GraphQLValidateOptions): Plugin {
+  const validator = createValidator(options);
+
+  return {
+    name: 'graphql-validate',
+
+    async setup(build) {
+      // Load schema once
+      await validator.loadSchema();
+
+      // Filter for relevant files
+      const filter = /\.(graphql|ts|tsx|js|jsx)$/;
+
+      // Validate on load
+      build.onLoad({ filter }, async (args) => {
+        if (!validator.shouldProcess(args.path)) {
+          return null;
+        }
+
+        const source = await fs.promises.readFile(args.path, 'utf8');
+        const diagnostics = validator.validate(args.path, source);
+
+        if (diagnostics.errors.length > 0) {
+          return {
+            errors: diagnostics.errors.map(d => ({
+              text: d.message,
+              location: {
+                file: args.path,
+                line: d.range.start.line + 1,
+                column: d.range.start.character,
+              },
+            })),
+          };
+        }
+
+        if (diagnostics.warnings.length > 0) {
+          return {
+            warnings: diagnostics.warnings.map(d => ({
+              text: d.message,
+              location: {
+                file: args.path,
+                line: d.range.start.line + 1,
+                column: d.range.start.character,
+              },
+            })),
+          };
+        }
+
+        // Don't transform, just validate
+        return null;
+      });
+    },
+  };
+}
+```
+
+## Shared Core
+
+```typescript
+// @graphql-lsp/build-core/index.ts
+import { Analysis } from '@graphql-lsp/core';
+import { minimatch } from 'minimatch';
+
+export interface ValidatorResult {
+  errors: Diagnostic[];
+  warnings: Diagnostic[];
+}
+
+export function createValidator(options: GraphQLValidateOptions) {
+  const analysis = new Analysis();
+  let schemaLoaded = false;
+
+  return {
+    async loadSchema() {
+      if (options.schema.startsWith('http')) {
+        // Introspect remote schema
+        const sdl = await introspect(options.schema);
+        analysis.setSchema('schema.graphql', sdl);
+      } else {
+        const content = await fs.promises.readFile(options.schema, 'utf8');
+        analysis.setSchema(options.schema, content);
+      }
+      schemaLoaded = true;
+    },
+
+    async reloadSchema() {
+      schemaLoaded = false;
+      await this.loadSchema();
+    },
+
+    shouldProcess(file: string): boolean {
+      const { include = ['**/*.graphql', '**/*.{ts,tsx,js,jsx}'], exclude = ['node_modules/**'] } = options;
+
+      // Check exclusions first
+      if (exclude.some(pattern => minimatch(file, pattern))) {
+        return false;
+      }
+
+      // Check inclusions
+      return include.some(pattern => minimatch(file, pattern));
+    },
+
+    validate(file: string, content: string): ValidatorResult {
+      if (!schemaLoaded) {
+        throw new Error('Schema not loaded. Call loadSchema() first.');
+      }
+
+      analysis.setDocument(file, content);
+      const diagnostics = analysis.diagnostics(file);
+
+      return {
+        errors: diagnostics.filter(d => d.severity === 'error'),
+        warnings: diagnostics.filter(d => d.severity === 'warning'),
+      };
+    },
+
+    validateFile(file: string): ValidatorResult {
+      const content = fs.readFileSync(file, 'utf8');
+      return this.validate(file, content);
+    },
+  };
+}
+```
+
+## Caching
+
+For incremental builds, cache validation results:
+
+```typescript
+// @graphql-lsp/build-core/cache.ts
+
+interface CacheEntry {
+  hash: string;
+  diagnostics: Diagnostic[];
+  timestamp: number;
+}
+
+export class ValidationCache {
+  private cache = new Map<string, CacheEntry>();
+
+  get(file: string, content: string): Diagnostic[] | null {
+    const entry = this.cache.get(file);
+    if (!entry) return null;
+
+    const hash = this.hash(content);
+    if (entry.hash !== hash) return null;
+
+    return entry.diagnostics;
+  }
+
+  set(file: string, content: string, diagnostics: Diagnostic[]) {
+    this.cache.set(file, {
+      hash: this.hash(content),
+      diagnostics,
+      timestamp: Date.now(),
+    });
+  }
+
+  invalidateAll() {
+    this.cache.clear();
+  }
+
+  private hash(content: string): string {
+    return createHash('md5').update(content).digest('hex');
+  }
+}
+```
+
+## Mode-Based Configuration
+
+```typescript
+// Auto-detect based on NODE_ENV or explicit mode
+
+graphqlValidate({
+  schema: './schema.graphql',
+
+  // Explicit mode
+  mode: 'production', // or 'development', 'strict'
+
+  // Or auto-detect
+  // mode: process.env.NODE_ENV
+});
+
+// Mode presets:
+// development: failOnError: false, lint: 'none'
+// production: failOnError: true, lint: 'recommended'
+// strict: failOnError: true, failOnWarn: true, lint: 'strict'
+```
+
+## Monorepo Support
+
+```typescript
+// For monorepos with multiple schemas
+graphqlValidate({
+  projects: {
+    frontend: {
+      schema: 'packages/frontend/schema.graphql',
+      include: ['packages/frontend/**/*.{ts,tsx}'],
+    },
+    admin: {
+      schema: 'packages/admin/schema.graphql',
+      include: ['packages/admin/**/*.{ts,tsx}'],
+    },
+  },
+});
+```
+
+## Package Structure
+
+```
+@graphql-lsp/build-core/
+├── package.json
+├── index.ts
+├── types.ts
+├── cache.ts
+└── utils.ts
+
+@graphql-lsp/vite/
+├── package.json
+├── index.ts
+└── README.md
+
+@graphql-lsp/webpack/
+├── package.json
+├── index.ts
+└── README.md
+
+@graphql-lsp/esbuild/
+├── package.json
+├── index.ts
+└── README.md
+```
+
+## Open Questions
+
+1. **Source maps**: How to map errors back to original positions?
+   - Need to track GraphQL template literal locations
+   - May need parser for template literal extraction
+
+2. **Rollup support**: Should we add a Rollup plugin too?
+   - Similar to Vite plugin API
+   - Lower priority given Vite's popularity
+
+3. **Build tool version support**:
+   - Vite 4+? 5+?
+   - Webpack 4? 5?
+   - esbuild version requirements?
+
+4. **Performance**: Validation on every transform?
+   - May need to batch or debounce
+   - Cache aggressively
+
+5. **Watch mode schema refresh**: Auto-refresh remote schemas?
+   - Poll interval?
+   - Manual trigger?
+
+## Next Steps
+
+1. [ ] Create @graphql-lsp/build-core package
+2. [ ] Implement Vite plugin
+3. [ ] Implement Webpack plugin
+4. [ ] Implement esbuild plugin
+5. [ ] Add caching layer
+6. [ ] Test with real projects
+7. [ ] Add documentation
+
+## References
+
+- [Vite Plugin API](https://vitejs.dev/guide/api-plugin.html)
+- [Webpack Plugin API](https://webpack.js.org/api/plugins/)
+- [esbuild Plugin API](https://esbuild.github.io/plugins/)
+- [graphql-eslint](https://github.com/B2o5T/graphql-eslint) - similar validation approach

--- a/packages/build-plugins/README.md
+++ b/packages/build-plugins/README.md
@@ -1,0 +1,146 @@
+# @graphql-lsp/build-plugins
+
+GraphQL validation and linting plugins for popular build tools: Vite, Webpack, and esbuild.
+
+## Features
+
+- Validate GraphQL files during build
+- Run lint rules with configurable severity
+- Fail builds on errors/warnings (configurable)
+- Watch mode support with hot reload feedback
+- Native performance via Rust-based validation
+
+## Installation
+
+```bash
+npm install @graphql-lsp/build-plugins @graphql-lsp/node
+```
+
+## Usage
+
+### Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { graphqlPlugin } from '@graphql-lsp/build-plugins/vite';
+
+export default defineConfig({
+  plugins: [
+    graphqlPlugin({
+      schema: './schema.graphql',
+      failOnError: true,
+      lint: {
+        'no_deprecated': 'warn',
+      },
+    }),
+  ],
+});
+```
+
+### Webpack
+
+```js
+// webpack.config.js
+const { GraphQLLspPlugin } = require('@graphql-lsp/build-plugins/webpack');
+
+module.exports = {
+  plugins: [
+    new GraphQLLspPlugin({
+      schema: './schema.graphql',
+      failOnError: true,
+      lint: {
+        'no_deprecated': 'warn',
+      },
+    }),
+  ],
+};
+```
+
+### esbuild
+
+```js
+// esbuild.config.js
+const { graphqlPlugin } = require('@graphql-lsp/build-plugins/esbuild');
+
+require('esbuild').build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  plugins: [
+    graphqlPlugin({
+      schema: './schema.graphql',
+      failOnError: true,
+      lint: {
+        'no_deprecated': 'warn',
+      },
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `schema` | `string` | (required) | Path to GraphQL schema file or inline SDL |
+| `include` | `string[]` | `["**/*.graphql", "**/*.gql"]` | Glob patterns for files to validate |
+| `exclude` | `string[]` | `["node_modules/**"]` | Glob patterns for files to exclude |
+| `failOnError` | `boolean` | `true` | Fail build on validation errors |
+| `failOnWarning` | `boolean` | `false` | Fail build on lint warnings |
+| `lint` | `Record<string, "error" \| "warn" \| "off">` | `{}` | Lint rule configuration |
+| `verbose` | `boolean` | `false` | Enable verbose logging |
+
+## Lint Rules
+
+Configure lint rules using the `lint` option:
+
+```ts
+graphqlPlugin({
+  schema: './schema.graphql',
+  lint: {
+    'no_deprecated': 'warn',      // Warn on deprecated usage
+    'unique_names': 'error',      // Error on duplicate names
+    'require_id_field': 'off',    // Disable this rule
+  },
+});
+```
+
+## Inline Schema
+
+You can provide the schema inline:
+
+```ts
+graphqlPlugin({
+  schema: `
+    type Query {
+      hello: String
+    }
+  `,
+});
+```
+
+## Watch Mode
+
+All plugins support watch mode:
+
+- **Vite**: Diagnostics shown in terminal during `vite dev`
+- **Webpack**: Diagnostics shown during `webpack --watch`
+- **esbuild**: Use esbuild's watch API with the plugin
+
+## Error Output
+
+Validation errors appear in your build output:
+
+```
+ERROR [no_deprecated]: Field 'User.legacyId' is deprecated
+  at src/queries/users.graphql:5:3
+
+WARNING [unique_names]: Operation 'GetUser' is defined multiple times
+  at src/queries/users.graphql:1:1
+
+1 error(s), 1 warning(s)
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/build-plugins/package.json
+++ b/packages/build-plugins/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@graphql-lsp/build-plugins",
+  "version": "0.1.1",
+  "description": "GraphQL validation and linting plugins for Vite, Webpack, and esbuild",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./vite": {
+      "import": "./dist/vite.mjs",
+      "require": "./dist/vite.js",
+      "types": "./dist/vite.d.ts"
+    },
+    "./webpack": {
+      "import": "./dist/webpack.mjs",
+      "require": "./dist/webpack.js",
+      "types": "./dist/webpack.d.ts"
+    },
+    "./esbuild": {
+      "import": "./dist/esbuild.mjs",
+      "require": "./dist/esbuild.js",
+      "types": "./dist/esbuild.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "graphql",
+    "vite",
+    "webpack",
+    "esbuild",
+    "plugin",
+    "validation",
+    "linting"
+  ],
+  "author": "Trevor Scheer",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trevor-scheer/graphql-lsp",
+    "directory": "packages/build-plugins"
+  },
+  "peerDependencies": {
+    "vite": ">=4.0.0",
+    "webpack": ">=5.0.0",
+    "esbuild": ">=0.17.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    },
+    "esbuild": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@graphql-lsp/node": "^0.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "esbuild": "^0.20.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "webpack": "^5.90.0"
+  }
+}

--- a/packages/build-plugins/src/esbuild.ts
+++ b/packages/build-plugins/src/esbuild.ts
@@ -1,0 +1,156 @@
+import type { Plugin, OnLoadArgs, OnLoadResult, PluginBuild } from "esbuild";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  type GraphQLPluginOptions,
+  type ValidationContext,
+  createContext,
+  validateFile,
+  formatResults,
+  shouldIncludeFile,
+} from "./shared";
+
+export type { GraphQLPluginOptions };
+
+/**
+ * esbuild plugin for GraphQL validation and linting.
+ *
+ * @example
+ * ```js
+ * // esbuild.config.js
+ * const { graphqlPlugin } = require('@graphql-lsp/build-plugins/esbuild');
+ *
+ * require('esbuild').build({
+ *   entryPoints: ['src/index.ts'],
+ *   bundle: true,
+ *   plugins: [
+ *     graphqlPlugin({
+ *       schema: './schema.graphql',
+ *       failOnError: true,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function graphqlPlugin(options: GraphQLPluginOptions): Plugin {
+  return {
+    name: "graphql-lsp",
+
+    setup(build: PluginBuild) {
+      let context: ValidationContext;
+
+      // Initialize context at build start
+      build.onStart(() => {
+        try {
+          context = createContext(options);
+          if (context.options.verbose) {
+            console.log("[graphql-lsp] Plugin initialized");
+            console.log(`[graphql-lsp] Schema: ${context.options.schema}`);
+          }
+        } catch (error) {
+          return {
+            errors: [
+              {
+                text: `Failed to initialize GraphQL plugin: ${error}`,
+                pluginName: "graphql-lsp",
+              },
+            ],
+          };
+        }
+      });
+
+      // Validate .graphql and .gql files
+      build.onLoad(
+        { filter: /\.(graphql|gql)$/ },
+        async (args: OnLoadArgs): Promise<OnLoadResult> => {
+          const filePath = args.path;
+
+          if (!shouldIncludeFile(filePath, context.options)) {
+            // Return empty loader result to skip validation
+            return {
+              contents: fs.readFileSync(filePath, "utf-8"),
+              loader: "text",
+            };
+          }
+
+          const content = fs.readFileSync(filePath, "utf-8");
+          const result = validateFile(context, filePath, content);
+
+          if (context.options.verbose && result.diagnostics.length > 0) {
+            console.log(`[graphql-lsp] Validated ${filePath}:`);
+            for (const d of result.diagnostics) {
+              console.log(`  ${d.severity}: ${d.message}`);
+            }
+          }
+
+          // Convert diagnostics to esbuild format
+          const errors = result.diagnostics
+            .filter((d) => d.severity === "error")
+            .map((d) => ({
+              text: d.message,
+              location: {
+                file: filePath,
+                line: d.startLine + 1,
+                column: d.startColumn,
+                length: d.endColumn - d.startColumn,
+                lineText: content.split("\n")[d.startLine] || "",
+              },
+              pluginName: "graphql-lsp",
+              notes: d.code ? [{ text: `Rule: ${d.code}` }] : [],
+            }));
+
+          const warnings = result.diagnostics
+            .filter((d) => d.severity === "warning")
+            .map((d) => ({
+              text: d.message,
+              location: {
+                file: filePath,
+                line: d.startLine + 1,
+                column: d.startColumn,
+                length: d.endColumn - d.startColumn,
+                lineText: content.split("\n")[d.startLine] || "",
+              },
+              pluginName: "graphql-lsp",
+              notes: d.code ? [{ text: `Rule: ${d.code}` }] : [],
+            }));
+
+          // Handle fail options
+          if (context.options.failOnWarning) {
+            errors.push(...warnings);
+            warnings.length = 0;
+          }
+
+          if (!context.options.failOnError) {
+            warnings.push(
+              ...errors.map((e) => ({
+                ...e,
+                text: `[Error] ${e.text}`,
+              }))
+            );
+            errors.length = 0;
+          }
+
+          return {
+            contents: content,
+            loader: "text",
+            errors: errors.length > 0 ? errors : undefined,
+            warnings: warnings.length > 0 ? warnings : undefined,
+          };
+        }
+      );
+
+      // Summary at build end
+      build.onEnd((result) => {
+        if (context?.options.verbose) {
+          const errorCount = result.errors.length;
+          const warningCount = result.warnings.length;
+          console.log(
+            `[graphql-lsp] Build complete: ${errorCount} error(s), ${warningCount} warning(s)`
+          );
+        }
+      });
+    },
+  };
+}
+
+export default graphqlPlugin;

--- a/packages/build-plugins/src/index.ts
+++ b/packages/build-plugins/src/index.ts
@@ -1,0 +1,7 @@
+// Re-export all plugins
+export { graphqlPlugin as vitePlugin } from "./vite";
+export { GraphQLLspPlugin as WebpackPlugin } from "./webpack";
+export { graphqlPlugin as esbuildPlugin } from "./esbuild";
+
+// Re-export types
+export type { GraphQLPluginOptions } from "./shared";

--- a/packages/build-plugins/src/shared.ts
+++ b/packages/build-plugins/src/shared.ts
@@ -1,0 +1,200 @@
+import { GraphQLValidator, type Diagnostic } from "@graphql-lsp/node";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface GraphQLPluginOptions {
+  /**
+   * Path to the GraphQL schema file or SDL string.
+   * Can be a file path or inline SDL.
+   */
+  schema: string;
+
+  /**
+   * Glob patterns for GraphQL files to validate.
+   * @default ["**\/*.graphql", "**\/*.gql"]
+   */
+  include?: string[];
+
+  /**
+   * Glob patterns for files to exclude.
+   * @default ["node_modules/**"]
+   */
+  exclude?: string[];
+
+  /**
+   * Whether to fail the build on validation errors.
+   * @default true
+   */
+  failOnError?: boolean;
+
+  /**
+   * Whether to fail the build on lint warnings.
+   * @default false
+   */
+  failOnWarning?: boolean;
+
+  /**
+   * Lint configuration object.
+   */
+  lint?: Record<string, "error" | "warn" | "off">;
+
+  /**
+   * Enable verbose logging.
+   * @default false
+   */
+  verbose?: boolean;
+}
+
+export interface ValidationContext {
+  validator: GraphQLValidator;
+  options: Required<GraphQLPluginOptions>;
+}
+
+export function createDefaultOptions(
+  options: GraphQLPluginOptions
+): Required<GraphQLPluginOptions> {
+  return {
+    schema: options.schema,
+    include: options.include ?? ["**/*.graphql", "**/*.gql"],
+    exclude: options.exclude ?? ["node_modules/**"],
+    failOnError: options.failOnError ?? true,
+    failOnWarning: options.failOnWarning ?? false,
+    lint: options.lint ?? {},
+    verbose: options.verbose ?? false,
+  };
+}
+
+export function createContext(options: GraphQLPluginOptions): ValidationContext {
+  const resolvedOptions = createDefaultOptions(options);
+  const validator = new GraphQLValidator();
+
+  // Load schema
+  let schemaSdl: string;
+  if (
+    resolvedOptions.schema.includes("{") ||
+    resolvedOptions.schema.includes("type ")
+  ) {
+    // Inline SDL
+    schemaSdl = resolvedOptions.schema;
+  } else {
+    // File path
+    const schemaPath = path.resolve(resolvedOptions.schema);
+    if (!fs.existsSync(schemaPath)) {
+      throw new Error(`Schema file not found: ${schemaPath}`);
+    }
+    schemaSdl = fs.readFileSync(schemaPath, "utf-8");
+  }
+
+  validator.setSchema(schemaSdl);
+
+  // Configure lint rules if provided
+  if (Object.keys(resolvedOptions.lint).length > 0) {
+    validator.configureLint({ rules: resolvedOptions.lint });
+  }
+
+  return {
+    validator,
+    options: resolvedOptions,
+  };
+}
+
+export interface ValidationResult {
+  file: string;
+  diagnostics: Diagnostic[];
+  hasErrors: boolean;
+  hasWarnings: boolean;
+}
+
+export function validateFile(
+  context: ValidationContext,
+  filePath: string,
+  content: string
+): ValidationResult {
+  const result = context.validator.check(content);
+
+  const diagnostics = result.diagnostics;
+  const hasErrors = result.errorCount > 0;
+  const hasWarnings = result.warningCount > 0;
+
+  return {
+    file: filePath,
+    diagnostics,
+    hasErrors,
+    hasWarnings,
+  };
+}
+
+export function formatDiagnostic(file: string, diagnostic: Diagnostic): string {
+  const severity = diagnostic.severity.toUpperCase();
+  const location = `${file}:${diagnostic.startLine + 1}:${diagnostic.startColumn + 1}`;
+  const code = diagnostic.code ? ` [${diagnostic.code}]` : "";
+  return `${severity}${code}: ${diagnostic.message}\n  at ${location}`;
+}
+
+export function formatResults(results: ValidationResult[]): string {
+  const lines: string[] = [];
+
+  for (const result of results) {
+    if (result.diagnostics.length === 0) continue;
+
+    lines.push(`\n${result.file}:`);
+    for (const diagnostic of result.diagnostics) {
+      lines.push(`  ${formatDiagnostic(result.file, diagnostic)}`);
+    }
+  }
+
+  const errorCount = results.reduce(
+    (sum, r) => sum + r.diagnostics.filter((d) => d.severity === "error").length,
+    0
+  );
+  const warningCount = results.reduce(
+    (sum, r) => sum + r.diagnostics.filter((d) => d.severity === "warning").length,
+    0
+  );
+
+  if (errorCount > 0 || warningCount > 0) {
+    lines.push(`\n${errorCount} error(s), ${warningCount} warning(s)`);
+  }
+
+  return lines.join("\n");
+}
+
+export function shouldIncludeFile(
+  filePath: string,
+  options: Required<GraphQLPluginOptions>
+): boolean {
+  const ext = path.extname(filePath);
+  if (ext !== ".graphql" && ext !== ".gql") {
+    return false;
+  }
+
+  // Check exclude patterns
+  for (const pattern of options.exclude) {
+    if (matchGlob(filePath, pattern)) {
+      return false;
+    }
+  }
+
+  // Check include patterns
+  for (const pattern of options.include) {
+    if (matchGlob(filePath, pattern)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function matchGlob(filePath: string, pattern: string): boolean {
+  // Simple glob matching - convert ** and * to regex
+  const regex = new RegExp(
+    "^" +
+      pattern
+        .replace(/\*\*/g, "<<<GLOBSTAR>>>")
+        .replace(/\*/g, "[^/]*")
+        .replace(/<<<GLOBSTAR>>>/g, ".*")
+        .replace(/\//g, "\\/") +
+      "$"
+  );
+  return regex.test(filePath);
+}

--- a/packages/build-plugins/src/vite.ts
+++ b/packages/build-plugins/src/vite.ts
@@ -1,0 +1,126 @@
+import type { Plugin, ResolvedConfig } from "vite";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  type GraphQLPluginOptions,
+  type ValidationContext,
+  type ValidationResult,
+  createContext,
+  validateFile,
+  formatResults,
+  shouldIncludeFile,
+} from "./shared";
+
+export type { GraphQLPluginOptions };
+
+/**
+ * Vite plugin for GraphQL validation and linting.
+ *
+ * @example
+ * ```ts
+ * // vite.config.ts
+ * import { graphqlPlugin } from '@graphql-lsp/build-plugins/vite';
+ *
+ * export default {
+ *   plugins: [
+ *     graphqlPlugin({
+ *       schema: './schema.graphql',
+ *       failOnError: true,
+ *     }),
+ *   ],
+ * };
+ * ```
+ */
+export function graphqlPlugin(options: GraphQLPluginOptions): Plugin {
+  let context: ValidationContext;
+  let config: ResolvedConfig;
+  const results: Map<string, ValidationResult> = new Map();
+
+  return {
+    name: "graphql-lsp",
+
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
+
+    buildStart() {
+      context = createContext(options);
+
+      if (context.options.verbose) {
+        console.log("[graphql-lsp] Plugin initialized");
+        console.log(`[graphql-lsp] Schema: ${context.options.schema}`);
+      }
+    },
+
+    transform(code, id) {
+      if (!shouldIncludeFile(id, context.options)) {
+        return null;
+      }
+
+      const result = validateFile(context, id, code);
+      results.set(id, result);
+
+      if (result.diagnostics.length > 0 && context.options.verbose) {
+        console.log(`[graphql-lsp] Validated ${id}:`);
+        for (const d of result.diagnostics) {
+          console.log(`  ${d.severity}: ${d.message}`);
+        }
+      }
+
+      // In dev mode, emit warnings but don't fail
+      if (config.command === "serve") {
+        if (result.hasErrors || result.hasWarnings) {
+          this.warn(formatResults([result]));
+        }
+        return null;
+      }
+
+      // In build mode, optionally fail on errors/warnings
+      if (result.hasErrors && context.options.failOnError) {
+        this.error(formatResults([result]));
+      }
+
+      if (result.hasWarnings && context.options.failOnWarning) {
+        this.error(formatResults([result]));
+      }
+
+      return null;
+    },
+
+    buildEnd() {
+      const allResults = Array.from(results.values());
+      const hasErrors = allResults.some((r) => r.hasErrors);
+      const hasWarnings = allResults.some((r) => r.hasWarnings);
+
+      if (context.options.verbose || hasErrors || hasWarnings) {
+        console.log("[graphql-lsp] Validation summary:");
+        console.log(formatResults(allResults));
+      }
+
+      results.clear();
+    },
+
+    // Watch mode: validate on file change
+    handleHotUpdate({ file, read }) {
+      if (!shouldIncludeFile(file, context.options)) {
+        return;
+      }
+
+      read().then((content) => {
+        const result = validateFile(context, file, content);
+        results.set(file, result);
+
+        if (result.diagnostics.length > 0) {
+          console.log(`\n[graphql-lsp] ${file}:`);
+          for (const d of result.diagnostics) {
+            const line = d.startLine + 1;
+            const col = d.startColumn + 1;
+            console.log(`  ${d.severity} (${line}:${col}): ${d.message}`);
+          }
+        }
+      });
+    },
+  };
+}
+
+export default graphqlPlugin;

--- a/packages/build-plugins/src/webpack.ts
+++ b/packages/build-plugins/src/webpack.ts
@@ -1,0 +1,182 @@
+import type { Compiler, Compilation } from "webpack";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  type GraphQLPluginOptions,
+  type ValidationContext,
+  type ValidationResult,
+  createContext,
+  validateFile,
+  formatResults,
+  shouldIncludeFile,
+} from "./shared";
+
+export type { GraphQLPluginOptions };
+
+const PLUGIN_NAME = "GraphQLLspPlugin";
+
+/**
+ * Webpack plugin for GraphQL validation and linting.
+ *
+ * @example
+ * ```js
+ * // webpack.config.js
+ * const { GraphQLLspPlugin } = require('@graphql-lsp/build-plugins/webpack');
+ *
+ * module.exports = {
+ *   plugins: [
+ *     new GraphQLLspPlugin({
+ *       schema: './schema.graphql',
+ *       failOnError: true,
+ *     }),
+ *   ],
+ * };
+ * ```
+ */
+export class GraphQLLspPlugin {
+  private options: GraphQLPluginOptions;
+  private context: ValidationContext | null = null;
+
+  constructor(options: GraphQLPluginOptions) {
+    this.options = options;
+  }
+
+  apply(compiler: Compiler): void {
+    const logger = compiler.getInfrastructureLogger(PLUGIN_NAME);
+
+    // Initialize context at compile start
+    compiler.hooks.beforeCompile.tapAsync(
+      PLUGIN_NAME,
+      (_params, callback) => {
+        try {
+          this.context = createContext(this.options);
+          if (this.context.options.verbose) {
+            logger.info("Plugin initialized");
+            logger.info(`Schema: ${this.context.options.schema}`);
+          }
+          callback();
+        } catch (error) {
+          callback(error as Error);
+        }
+      }
+    );
+
+    // Validate files during compilation
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        () => {
+          this.validateAllFiles(compilation, logger);
+        }
+      );
+    });
+
+    // Watch mode: validate changed files
+    compiler.hooks.watchRun.tapAsync(PLUGIN_NAME, (compiler, callback) => {
+      const changedFiles = compiler.modifiedFiles || new Set();
+      const removedFiles = compiler.removedFiles || new Set();
+
+      if (this.context?.options.verbose && changedFiles.size > 0) {
+        logger.info(`Changed files: ${Array.from(changedFiles).join(", ")}`);
+      }
+
+      callback();
+    });
+  }
+
+  private validateAllFiles(
+    compilation: Compilation,
+    logger: ReturnType<Compiler["getInfrastructureLogger"]>
+  ): void {
+    if (!this.context) {
+      logger.error("Context not initialized");
+      return;
+    }
+
+    const results: ValidationResult[] = [];
+    const rootDir = compilation.compiler.context;
+
+    // Find all GraphQL files in the compilation
+    const graphqlFiles = this.findGraphQLFiles(rootDir);
+
+    for (const filePath of graphqlFiles) {
+      if (!shouldIncludeFile(filePath, this.context.options)) {
+        continue;
+      }
+
+      try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        const result = validateFile(this.context, filePath, content);
+        results.push(result);
+
+        if (result.diagnostics.length > 0 && this.context.options.verbose) {
+          logger.info(`Validated ${filePath}:`);
+          for (const d of result.diagnostics) {
+            logger.info(`  ${d.severity}: ${d.message}`);
+          }
+        }
+      } catch (error) {
+        logger.warn(`Failed to read ${filePath}: ${error}`);
+      }
+    }
+
+    // Report results
+    const hasErrors = results.some((r) => r.hasErrors);
+    const hasWarnings = results.some((r) => r.hasWarnings);
+
+    if (hasErrors || hasWarnings) {
+      const report = formatResults(results);
+
+      if (hasErrors && this.context.options.failOnError) {
+        compilation.errors.push(new Error(`GraphQL validation failed:\n${report}`));
+      } else if (hasErrors) {
+        compilation.warnings.push(new Error(`GraphQL validation errors:\n${report}`));
+      }
+
+      if (hasWarnings && this.context.options.failOnWarning) {
+        compilation.errors.push(new Error(`GraphQL lint warnings:\n${report}`));
+      } else if (hasWarnings && !hasErrors) {
+        compilation.warnings.push(new Error(`GraphQL lint warnings:\n${report}`));
+      }
+    }
+
+    if (this.context.options.verbose) {
+      logger.info(`Validated ${results.length} GraphQL files`);
+    }
+  }
+
+  private findGraphQLFiles(dir: string): string[] {
+    const files: string[] = [];
+
+    const walk = (currentDir: string) => {
+      try {
+        const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+        for (const entry of entries) {
+          const fullPath = path.join(currentDir, entry.name);
+
+          if (entry.isDirectory()) {
+            if (entry.name !== "node_modules" && !entry.name.startsWith(".")) {
+              walk(fullPath);
+            }
+          } else if (entry.isFile()) {
+            const ext = path.extname(entry.name);
+            if (ext === ".graphql" || ext === ".gql") {
+              files.push(fullPath);
+            }
+          }
+        }
+      } catch {
+        // Skip directories we can't read
+      }
+    };
+
+    walk(dir);
+    return files;
+  }
+}
+
+export default GraphQLLspPlugin;

--- a/packages/build-plugins/tsconfig.json
+++ b/packages/build-plugins/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/build-plugins/tsup.config.ts
+++ b/packages/build-plugins/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    vite: "src/vite.ts",
+    webpack: "src/webpack.ts",
+    esbuild: "src/esbuild.ts",
+  },
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  external: ["vite", "webpack", "esbuild", "@graphql-lsp/node"],
+});


### PR DESCRIPTION
## Summary

This PR adds an exploration document for build tool plugins (Vite, Webpack, esbuild).

### Key Points

- **Vite**: HMR support, error overlay, schema watching
- **Webpack**: Build-time validation, watch mode support
- **esbuild**: Fast validation during builds
- **Shared core**: @graphql-lsp/build-core package

### Architecture

All plugins share a common validation core built on @graphql-lsp/core (napi bindings).

### Dependencies

Requires Node.js bindings (#419)

Closes #424