### PR TITLE
refactor(vscode): require config file for extension activation

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -13,7 +13,6 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onLanguage:graphql",
     "workspaceContains:**/graphql.config.{yaml,yml,json}",
     "workspaceContains:**/.graphqlrc{.yaml,.yml,.json,}"
   ],


### PR DESCRIPTION
## Summary

- Remove `onLanguage:graphql` activation event
- Extension now only activates when a GraphQL config file is present

## Rationale

The LSP depends on having a schema and document configuration. Without a config file, the LSP has no way to know:
- Where the schema is located
- Which files contain GraphQL documents
- What lint rules to apply

The config file serves as the explicit opt-in signal that this is a GraphQL project. Activating on `.graphql` files alone would lead to an unconfigured state where we'd have to infer everything or show confusing errors.

## Test plan

- [ ] Open a workspace without a GraphQL config - extension should NOT activate
- [ ] Add `.graphqlrc.yaml` to workspace - extension should activate
- [ ] Verify LSP features work after activation