### PR TITLE
feat(ide): add add_files_batch method for efficient batch loading

### DIFF
--- a/crates/graphql-hir/src/lib.rs
+++ b/crates/graphql-hir/src/lib.rs
@@ -216,8 +216,7 @@ pub fn project_fragment_name_index(
     let mut name_counts: HashMap<Arc<str>, usize> = HashMap::new();
 
     for file_id in doc_ids.iter() {
-        if let Some((content, metadata)) =
-            graphql_base_db::file_lookup(db, project_files, *file_id)
+        if let Some((content, metadata)) = graphql_base_db::file_lookup(db, project_files, *file_id)
         {
             let frag_names = file_defined_fragment_names(db, *file_id, content, metadata);
             for name in frag_names.iter() {

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -1062,10 +1062,13 @@ impl AnalysisHost {
             }
         }
 
-        // Batch add all files
-        for (file_path, content, file_kind) in files_to_add {
-            self.add_file(&file_path, &content, file_kind);
-        }
+        // Batch add all files using add_files_batch for O(n) performance
+        // Convert owned strings to borrowed for the batch API
+        let batch_refs: Vec<(FilePath, &str, FileKind)> = files_to_add
+            .iter()
+            .map(|(path, content, kind)| (path.clone(), content.as_str(), *kind))
+            .collect();
+        self.add_files_batch(&batch_refs);
 
         loaded_files
     }

--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -429,19 +429,8 @@ documents: "**/*.graphql"
                     total_files_loaded
                 );
 
-                tracing::info!(
-                    "Rebuilding ProjectFiles index for {} files...",
-                    total_files_loaded
-                );
-                let rebuild_start = std::time::Instant::now();
-                {
-                    let mut host_guard = host.lock().await;
-                    host_guard.rebuild_project_files();
-                }
-                tracing::info!(
-                    "ProjectFiles rebuild took {:.2}s",
-                    rebuild_start.elapsed().as_secs_f64()
-                );
+                // Note: load_documents_from_config uses add_files_batch internally,
+                // which rebuilds the ProjectFiles index automatically
 
                 // Publish initial diagnostics for all loaded files
                 tracing::info!(


### PR DESCRIPTION
## Summary

Part of #348 fix (Section 8: Document and Test Batch Loading Pattern).

Adds `add_files_batch()` method to AnalysisHost that:
- Adds multiple files in a single operation
- Rebuilds the project index only once at the end
- Provides O(n) instead of O(n²) performance

This prevents accidental performance regressions from the O(n²) pattern of calling `add_file + rebuild_project_files` in a loop.

### Usage

```rust
let files = vec![
    (FilePath::new("file:///schema.graphql"), schema_content, FileKind::Schema),
    (FilePath::new("file:///query.graphql"), query_content, FileKind::ExecutableGraphQL),
];
host.add_files_batch(&files);
```

## Tests Added

- `test_add_files_batch`: Basic batch loading works
- `test_add_files_batch_empty`: Empty batch doesn't panic
- `test_add_files_batch_update_existing`: Updating existing files works
- `test_batch_loading_is_efficient`: 100 files load quickly (< 5s)

## Test plan

- [ ] Existing tests pass
- [ ] Build succeeds with no clippy warnings
- [ ] New tests pass