### PR TITLE
Clean up linter README sections

### DIFF
--- a/crates/graphql-linter/README.md
+++ b/crates/graphql-linter/README.md
@@ -266,8 +266,6 @@ See individual rule documentation for available options.
 ### redundant_fields
 
 **Type**: StandaloneDocumentRule
-**Default**: `off` (opt-in)
-**Performance**: Fast
 
 Detects fields in a selection set that are redundant because they are already included in a sibling fragment spread. This helps keep queries clean and maintainable by avoiding duplication.
 
@@ -303,9 +301,6 @@ The rule handles:
 ### require_id_field
 
 **Type**: DocumentSchemaRule
-**Default**: `off` (opt-in)
-**Preset**: Not in `recommended` (opinionated rule)
-**Performance**: Fast
 
 Warns when selection sets on types that have an `id` field don't include it. This is useful for ensuring cache normalization works correctly with tools like Apollo Client.
 
@@ -372,8 +367,6 @@ query GetUser {
 ### no_deprecated
 
 **Type**: DocumentSchemaRule
-**Default**: `warn`
-**Performance**: Fast
 
 Warns when using fields marked as deprecated in the schema.
 
@@ -396,8 +389,6 @@ query {
 ### unique_names
 
 **Type**: ProjectRule
-**Default**: `error`
-**Performance**: Fast (project-wide but efficient)
 
 Ensures operation and fragment names are unique across the project.
 
@@ -420,8 +411,6 @@ query GetUser {
 ### unused_fields
 
 **Type**: ProjectRule
-**Default**: `off` (opt-in)
-**Performance**: Expensive on large schemas
 
 Detects schema fields that are never queried in any operation or fragment.
 


### PR DESCRIPTION
Remove redundant Default and Performance callouts from rule documentation. The recommended preset table already documents which rules are included, making "Default" misleading. Performance callouts add noise without actionable value.

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

<!-- Bullet list of key changes -->

-

## Consulted SME Agents

<!--
List which SME agents from .claude/agents/ were consulted for this PR.
Format: **agent-name.md**: Key guidance received

Example:
- **lsp.md**: Confirmed response format for textDocument/definition
- **rust-analyzer.md**: Recommended query-based architecture
-->

-

## Manual Testing Plan

<!--
Steps for manually verifying these changes.

Examples:
- Run `cargo build` and open VSCode to verify hover works on type references
- Execute `graphql lint --project frontend` and confirm new rule triggers
- Open a .ts file with embedded GraphQL and verify diagnostics appear

Leave empty or write "N/A" if no manual testing is needed.

IMPORTANT: Do NOT mention automated test results, clippy results, or CI status
anywhere in the PR description. Statements like "all tests passing" or "clippy
clean" are unnecessary - CI enforces these automatically and they add no value.
This section is ONLY for manual verification steps that reviewers can follow.
-->

-

## Related Issues

<!-- Link to related issues if any (e.g., Fixes #123, Closes #456) -->
