### PR TITLE
feat(cli): aggregate JSON output into valid JSON

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -216,21 +216,30 @@ Colorized, human-readable output with context:
 
 ### JSON
 
-Machine-readable JSON output:
+Machine-readable aggregated JSON output:
 
 ```json
 {
   "success": false,
-  "errors": [
+  "files": [
     {
       "file": "src/queries.graphql",
-      "message": "Cannot query field \"invalidField\" on type \"User\"",
-      "severity": "error",
-      "line": 5,
-      "column": 3
+      "errors": [
+        {
+          "message": "Cannot query field \"invalidField\" on type \"User\"",
+          "severity": "error",
+          "location": {
+            "start": { "line": 5, "column": 3 },
+            "end": { "line": 5, "column": 15 }
+          }
+        }
+      ]
     }
   ],
-  "warnings": []
+  "stats": {
+    "total_files": 1,
+    "total_errors": 1
+  }
 }
 ```
 
@@ -430,16 +439,25 @@ $ graphql validate --format json
 
 {
   "success": false,
-  "files_validated": 15,
-  "errors": [
+  "files": [
     {
       "file": "src/queries.graphql",
-      "message": "Cannot query field \"invalidField\" on type \"User\"",
-      "severity": "error",
-      "line": 5,
-      "column": 3
+      "errors": [
+        {
+          "message": "Cannot query field \"invalidField\" on type \"User\"",
+          "severity": "error",
+          "location": {
+            "start": { "line": 5, "column": 3 },
+            "end": { "line": 5, "column": 15 }
+          }
+        }
+      ]
     }
-  ]
+  ],
+  "stats": {
+    "total_files": 1,
+    "total_errors": 1
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Collect all diagnostics into a single JSON object with aggregated fields instead of printing individual JSON objects line-by-line (JSONL format)
- New JSON output structure includes `success`, `files`, and `stats` fields
- Update documentation to reflect the new JSON output format

The new output structure:
```json
{
  "success": false,
  "files": [
    {
      "file": "src/queries.graphql",
      "errors": [...],
      "warnings": [...]
    }
  ],
  "stats": {
    "total_files": 1,
    "total_errors": 1,
    "total_warnings": 0
  }
}
```

## Test plan
- [x] Build passes (`cargo build --package graphql-cli`)
- [x] Clippy passes (`cargo clippy --package graphql-cli`)
- [x] Tests pass (`cargo test --package graphql-cli`)
- [ ] Manual testing: run `graphql validate --format json` and verify aggregated JSON output
- [ ] Manual testing: run `graphql lint --format json` and verify output is valid JSON

Closes #460