### PR TITLE
feat(cli): add remote schema caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1086,7 @@ dependencies = [
  "apollo-parser 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "colored",
+ "dirs",
  "glob",
  "graphql-config",
  "graphql-extract",
@@ -1080,6 +1102,7 @@ dependencies = [
  "opentelemetry_sdk 0.27.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.28.0",
@@ -1845,6 +1868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "par-core"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +2665,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4273,6 +4323,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4324,6 +4383,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -4363,6 +4437,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4381,6 +4461,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4396,6 +4482,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4429,6 +4521,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4444,6 +4542,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4465,6 +4569,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4480,6 +4590,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/graphql-cli/Cargo.toml
+++ b/crates/graphql-cli/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 glob = { workspace = true }
+dirs = "5.0"
 
 # Terminal UI
 colored = "2.0"
@@ -56,6 +57,9 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true
 opentelemetry-otlp = { version = "0.27", features = ["default"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.27", optional = true }
 tracing-opentelemetry = { version = "0.28", optional = true }
+
+[dev-dependencies]
+tempfile = "3.15"
 
 [features]
 otel = [

--- a/crates/graphql-cli/src/main.rs
+++ b/crates/graphql-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod analysis;
 mod commands;
 mod progress;
+mod schema_cache;
 
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -17,6 +18,10 @@ struct Cli {
     /// Project name (for multi-project configs)
     #[arg(short, long, global = true)]
     project: Option<String>,
+
+    /// Force re-fetch of remote schemas (bypass cache)
+    #[arg(long, global = true)]
+    refresh_schema: bool,
 
     #[command(subcommand)]
     command: Commands,

--- a/crates/graphql-cli/src/schema_cache.rs
+++ b/crates/graphql-cli/src/schema_cache.rs
@@ -1,0 +1,248 @@
+//! Remote schema caching for the CLI.
+//!
+//! Caches introspected schemas to avoid re-fetching on every CLI invocation.
+//! Cache entries are stored in `~/.cache/graphql-lsp/schemas/` with a 1-hour default TTL.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+/// Default cache TTL (1 hour)
+const DEFAULT_TTL_SECS: u64 = 3600;
+
+/// Cache directory name
+const CACHE_DIR: &str = "graphql-lsp";
+
+/// Schemas subdirectory
+const SCHEMAS_DIR: &str = "schemas";
+
+/// Metadata about a cached schema
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheMetadata {
+    /// The original endpoint URL
+    pub url: String,
+    /// Timestamp when the schema was fetched
+    pub fetched_at: u64,
+    /// TTL in seconds
+    pub ttl_secs: u64,
+}
+
+impl CacheMetadata {
+    /// Check if the cache entry has expired
+    pub fn is_expired(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        now > self.fetched_at + self.ttl_secs
+    }
+
+    /// Create new metadata for a freshly fetched schema
+    pub fn new(url: &str) -> Self {
+        let fetched_at = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self {
+            url: url.to_string(),
+            fetched_at,
+            ttl_secs: DEFAULT_TTL_SECS,
+        }
+    }
+
+    /// Get the age of the cache entry
+    pub fn age(&self) -> Duration {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Duration::from_secs(now.saturating_sub(self.fetched_at))
+    }
+}
+
+/// Schema cache for remote introspection results
+pub struct SchemaCache {
+    cache_dir: PathBuf,
+}
+
+impl SchemaCache {
+    /// Create a new schema cache using the system cache directory
+    pub fn new() -> Result<Self> {
+        let cache_dir = Self::get_cache_dir()?;
+        std::fs::create_dir_all(&cache_dir)
+            .with_context(|| format!("Failed to create cache directory: {}", cache_dir.display()))?;
+        Ok(Self { cache_dir })
+    }
+
+    /// Get the cache directory path
+    fn get_cache_dir() -> Result<PathBuf> {
+        // Try XDG_CACHE_HOME first, then fallback to ~/.cache
+        let base = std::env::var("XDG_CACHE_HOME")
+            .map(PathBuf::from)
+            .or_else(|_| {
+                dirs::home_dir()
+                    .map(|h| h.join(".cache"))
+                    .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
+            })?;
+        Ok(base.join(CACHE_DIR).join(SCHEMAS_DIR))
+    }
+
+    /// Generate a cache key (hash) for a URL
+    fn cache_key(url: &str) -> String {
+        let mut hasher = DefaultHasher::new();
+        url.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
+
+    /// Get the path to the schema file for a URL
+    fn schema_path(&self, url: &str) -> PathBuf {
+        let key = Self::cache_key(url);
+        self.cache_dir.join(format!("{key}.graphql"))
+    }
+
+    /// Get the path to the metadata file for a URL
+    fn metadata_path(&self, url: &str) -> PathBuf {
+        let key = Self::cache_key(url);
+        self.cache_dir.join(format!("{key}.meta.json"))
+    }
+
+    /// Get a cached schema if it exists and is not expired
+    ///
+    /// Returns `Some((sdl, metadata))` if the cache is valid, `None` otherwise.
+    pub fn get(&self, url: &str) -> Option<(String, CacheMetadata)> {
+        let schema_path = self.schema_path(url);
+        let metadata_path = self.metadata_path(url);
+
+        // Read metadata first to check expiration
+        let metadata_content = std::fs::read_to_string(&metadata_path).ok()?;
+        let metadata: CacheMetadata = serde_json::from_str(&metadata_content).ok()?;
+
+        // Check if expired
+        if metadata.is_expired() {
+            tracing::debug!(url, "Cache entry expired");
+            return None;
+        }
+
+        // Read the schema
+        let sdl = std::fs::read_to_string(&schema_path).ok()?;
+        tracing::debug!(url, age_secs = metadata.age().as_secs(), "Using cached schema");
+
+        Some((sdl, metadata))
+    }
+
+    /// Store a schema in the cache
+    pub fn set(&self, url: &str, sdl: &str) -> Result<()> {
+        let schema_path = self.schema_path(url);
+        let metadata_path = self.metadata_path(url);
+
+        // Write schema
+        std::fs::write(&schema_path, sdl)
+            .with_context(|| format!("Failed to write schema cache: {}", schema_path.display()))?;
+
+        // Write metadata
+        let metadata = CacheMetadata::new(url);
+        let metadata_json = serde_json::to_string_pretty(&metadata)?;
+        std::fs::write(&metadata_path, metadata_json)
+            .with_context(|| format!("Failed to write cache metadata: {}", metadata_path.display()))?;
+
+        tracing::debug!(url, path = %schema_path.display(), "Cached schema");
+        Ok(())
+    }
+
+    /// Clear the cache for a specific URL
+    #[allow(dead_code)]
+    pub fn clear(&self, url: &str) -> Result<()> {
+        let schema_path = self.schema_path(url);
+        let metadata_path = self.metadata_path(url);
+
+        if schema_path.exists() {
+            std::fs::remove_file(&schema_path)?;
+        }
+        if metadata_path.exists() {
+            std::fs::remove_file(&metadata_path)?;
+        }
+
+        Ok(())
+    }
+
+    /// Clear all cached schemas
+    #[allow(dead_code)]
+    pub fn clear_all(&self) -> Result<()> {
+        if self.cache_dir.exists() {
+            std::fs::remove_dir_all(&self.cache_dir)?;
+            std::fs::create_dir_all(&self.cache_dir)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for SchemaCache {
+    fn default() -> Self {
+        Self::new().expect("Failed to initialize schema cache")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn create_test_cache() -> SchemaCache {
+        let temp = tempdir().unwrap();
+        SchemaCache {
+            cache_dir: temp.keep(),
+        }
+    }
+
+    #[test]
+    fn test_cache_key_consistency() {
+        let url = "https://api.example.com/graphql";
+        let key1 = SchemaCache::cache_key(url);
+        let key2 = SchemaCache::cache_key(url);
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_cache_key_uniqueness() {
+        let key1 = SchemaCache::cache_key("https://api1.example.com/graphql");
+        let key2 = SchemaCache::cache_key("https://api2.example.com/graphql");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn test_cache_set_and_get() {
+        let cache = create_test_cache();
+        let url = "https://api.example.com/graphql";
+        let sdl = "type Query { hello: String }";
+
+        cache.set(url, sdl).unwrap();
+        let (cached_sdl, metadata) = cache.get(url).unwrap();
+
+        assert_eq!(cached_sdl, sdl);
+        assert_eq!(metadata.url, url);
+        assert!(!metadata.is_expired());
+    }
+
+    #[test]
+    fn test_cache_miss() {
+        let cache = create_test_cache();
+        assert!(cache.get("https://nonexistent.example.com/graphql").is_none());
+    }
+
+    #[test]
+    fn test_metadata_expiration() {
+        let mut metadata = CacheMetadata::new("https://example.com/graphql");
+        assert!(!metadata.is_expired());
+
+        // Set fetched_at to 2 hours ago
+        metadata.fetched_at = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 7200;
+        assert!(metadata.is_expired());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds caching for remotely introspected schemas to avoid re-fetching on every CLI invocation
- Caches schemas in `~/.cache/graphql-lsp/schemas/` (XDG-compliant path)
- Uses 1-hour default TTL for cache entries
- Implements hash-based cache keys for URLs
- Adds `--refresh-schema` global flag to force bypass of cache

## Test plan

- [x] Unit tests for cache key generation, set/get, expiration
- [x] Clippy and cargo test passing
- [ ] Manual testing with remote schema introspection

Closes #462