### PR TITLE
feat(ide): add Salsa cache pre-warming for faster IDE features

### DIFF
--- a/crates/graphql-ide/src/folding_ranges.rs
+++ b/crates/graphql-ide/src/folding_ranges.rs
@@ -71,6 +71,7 @@ pub fn folding_ranges(
 }
 
 /// Collect folding ranges from a definition
+#[allow(clippy::too_many_lines)]
 fn collect_definition_folding_ranges(
     definition: &Definition,
     line_index: &graphql_syntax::LineIndex,


### PR DESCRIPTION
## Summary

- Add `prewarm_caches()` method to `Analysis` that eagerly computes and caches the expensive aggregate HIR queries that IDE features depend on
- Call pre-warming after background initialization and on `textDocument/didOpen`
- Ensures hover, goto-definition, and references are fast on first use

## Motivation

While diagnostics implicitly warm some Salsa caches, **not all caches are warmed**:

| Cache | Warmed by validation? | Warmed by lints? |
|-------|----------------------|------------------|
| `schema_types()` | ✅ Yes | Also by `unused_fields` |
| `all_fragments()` | ❌ No | Only by `unused_fields`, `unused_fragments` |
| `all_operations()` | ❌ No | Only by `unused_fields` |

If project lints are disabled (or a user has a minimal lint config), the first goto-definition to a fragment or first references lookup would hit cold caches.

Explicit pre-warming guarantees all caches are warm regardless of lint configuration.

## Test plan

- [x] Added unit tests for `prewarm_caches()` method
- [x] Verified caches are populated after pre-warming
- [x] Verified graceful handling when no project files are set
- [x] All existing tests pass