### PR TITLE
feat(config): add structured config validation with overlapping file detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-ide"
-version = "0.1.0"
+version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "apollo-parser 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/graphql-config/src/lib.rs
+++ b/crates/graphql-config/src/lib.rs
@@ -1,9 +1,11 @@
 mod config;
 mod error;
 mod loader;
+mod validation;
 
 pub use config::{
     DocumentsConfig, GraphQLConfig, IntrospectionSchemaConfig, ProjectConfig, SchemaConfig,
 };
 pub use error::{ConfigError, Result};
 pub use loader::{find_config, load_config, load_config_from_str};
+pub use validation::{validate, ConfigValidationError, FileType, Location};

--- a/crates/graphql-config/src/validation.rs
+++ b/crates/graphql-config/src/validation.rs
@@ -1,0 +1,438 @@
+//! Configuration validation module.
+//!
+//! Provides validation for GraphQL configuration files, returning structured
+//! errors that can be easily converted to diagnostics by consumers.
+
+use crate::GraphQLConfig;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// A location within a config file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Location {
+    pub line: u32,
+    pub start_column: u32,
+    pub end_column: u32,
+}
+
+/// The type of file pattern that caused a conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileType {
+    Schema,
+    Document,
+}
+
+impl std::fmt::Display for FileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Schema => write!(f, "schema"),
+            Self::Document => write!(f, "documents"),
+        }
+    }
+}
+
+/// A validation error found in a GraphQL configuration file.
+#[derive(Debug, Clone)]
+pub enum ConfigValidationError {
+    /// A pattern matches files that also belong to other projects.
+    OverlappingPattern {
+        /// The project name that has the conflicting pattern.
+        project: String,
+        /// The pattern that matched.
+        pattern: String,
+        /// Whether this is a schema or document pattern.
+        file_type: FileType,
+        /// The files matched by this pattern that also belong to other projects.
+        overlapping_files: Vec<PathBuf>,
+        /// Which occurrence of this pattern in the config file (0-indexed).
+        /// Needed when the same pattern appears under multiple projects.
+        occurrence: usize,
+    },
+}
+
+impl ConfigValidationError {
+    /// Returns the error code for this validation error.
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::OverlappingPattern { .. } => "overlapping-files",
+        }
+    }
+
+    /// Returns a human-readable error message.
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::OverlappingPattern {
+                file_type,
+                overlapping_files,
+                ..
+            } => {
+                let count = overlapping_files.len();
+                if count == 1 {
+                    let name = overlapping_files[0].file_name().map_or_else(
+                        || "1 file".to_string(),
+                        |n| format!("'{}'", n.to_string_lossy()),
+                    );
+                    format!("This {file_type} pattern causes {name} to belong to multiple projects")
+                } else {
+                    format!("This {file_type} pattern causes {count} files to belong to multiple projects")
+                }
+            }
+        }
+    }
+
+    /// Returns the location of this error in the config file content, if it can be determined.
+    #[must_use]
+    pub fn location(&self, config_content: &str) -> Option<Location> {
+        match self {
+            Self::OverlappingPattern {
+                pattern,
+                occurrence,
+                ..
+            } => find_pattern_location(config_content, pattern, *occurrence),
+        }
+    }
+}
+
+/// Validate a GraphQL configuration.
+///
+/// Returns a list of all validation errors found. An empty list means the
+/// configuration is valid.
+#[must_use]
+pub fn validate(config: &GraphQLConfig, workspace_path: &Path) -> Vec<ConfigValidationError> {
+    let mut errors = Vec::new();
+    errors.extend(validate_file_uniqueness(config, workspace_path));
+    errors
+}
+
+/// Validate that no file belongs to multiple projects.
+fn validate_file_uniqueness(
+    config: &GraphQLConfig,
+    workspace_path: &Path,
+) -> Vec<ConfigValidationError> {
+    // Map from canonical file path to list of (project_name, pattern, type)
+    let mut file_to_projects: HashMap<PathBuf, Vec<(String, String, FileType)>> = HashMap::new();
+
+    for (project_name, project_config) in config.projects() {
+        for pattern in project_config.schema.paths() {
+            if pattern.starts_with("http://") || pattern.starts_with("https://") {
+                continue;
+            }
+
+            for file_path in resolve_pattern_to_files(pattern, workspace_path) {
+                file_to_projects.entry(file_path).or_default().push((
+                    project_name.to_string(),
+                    pattern.to_string(),
+                    FileType::Schema,
+                ));
+            }
+        }
+
+        if let Some(documents_config) = &project_config.documents {
+            for pattern in documents_config.patterns() {
+                if pattern.trim().starts_with('!') {
+                    continue;
+                }
+
+                for file_path in resolve_pattern_to_files(pattern, workspace_path) {
+                    file_to_projects.entry(file_path).or_default().push((
+                        project_name.to_string(),
+                        pattern.to_string(),
+                        FileType::Document,
+                    ));
+                }
+            }
+        }
+    }
+
+    // Group overlapping files by (project, pattern) so each pattern produces one error
+    let mut pattern_to_files: HashMap<(String, String, FileType), Vec<PathBuf>> = HashMap::new();
+
+    for (file_path, matches) in file_to_projects {
+        let unique_projects: HashSet<&str> = matches.iter().map(|(p, _, _)| p.as_str()).collect();
+        if unique_projects.len() > 1 {
+            for (project, pattern, file_type) in matches {
+                pattern_to_files
+                    .entry((project, pattern, file_type))
+                    .or_default()
+                    .push(file_path.clone());
+            }
+        }
+    }
+
+    // Create one error per (project, pattern), tracking occurrence index for
+    // patterns that appear multiple times in the config file
+    let mut pattern_occurrences: HashMap<String, usize> = HashMap::new();
+    pattern_to_files
+        .into_iter()
+        .map(|((project, pattern, file_type), overlapping_files)| {
+            let occurrence = *pattern_occurrences.entry(pattern.clone()).or_insert(0);
+            *pattern_occurrences.get_mut(&pattern).unwrap() += 1;
+            ConfigValidationError::OverlappingPattern {
+                project,
+                pattern,
+                file_type,
+                overlapping_files,
+                occurrence,
+            }
+        })
+        .collect()
+}
+
+/// Find the Nth occurrence of a pattern string in config content.
+fn find_pattern_location(
+    config_content: &str,
+    pattern: &str,
+    occurrence: usize,
+) -> Option<Location> {
+    let mut found = 0;
+    for (line_num, line) in config_content.lines().enumerate() {
+        if let Some(col) = line.find(pattern) {
+            if found == occurrence {
+                #[allow(clippy::cast_possible_truncation)]
+                return Some(Location {
+                    line: line_num as u32,
+                    start_column: col as u32,
+                    end_column: (col + pattern.len()) as u32,
+                });
+            }
+            found += 1;
+        }
+    }
+    None
+}
+
+/// Resolve a glob pattern to actual file paths.
+fn resolve_pattern_to_files(pattern: &str, workspace_path: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+
+    for expanded_pattern in expand_braces(pattern) {
+        let full_pattern = workspace_path.join(&expanded_pattern);
+
+        if let Ok(paths) = glob::glob(&full_pattern.display().to_string()) {
+            for entry in paths.flatten() {
+                if entry.is_file() {
+                    // Skip node_modules
+                    if entry.components().any(|c| c.as_os_str() == "node_modules") {
+                        continue;
+                    }
+
+                    if let Ok(canonical) = entry.canonicalize() {
+                        files.push(canonical);
+                    } else {
+                        files.push(entry);
+                    }
+                }
+            }
+        }
+    }
+
+    files
+}
+
+/// Expand brace patterns like `{ts,tsx}` into multiple patterns.
+fn expand_braces(pattern: &str) -> Vec<String> {
+    if let Some(start) = pattern.find('{') {
+        if let Some(end) = pattern.find('}') {
+            let before = &pattern[..start];
+            let after = &pattern[end + 1..];
+            let options = &pattern[start + 1..end];
+
+            return options
+                .split(',')
+                .map(|opt| format!("{before}{opt}{after}"))
+                .collect();
+        }
+    }
+
+    vec![pattern.to_string()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ProjectConfig, SchemaConfig};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_validate_detects_overlapping_patterns() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+
+        // Create schema directory and file
+        let schema_dir = workspace_path.join("schema");
+        std::fs::create_dir(&schema_dir).unwrap();
+        let mut schema_file = std::fs::File::create(schema_dir.join("schema.graphql")).unwrap();
+        writeln!(schema_file, "type Query {{ hello: String }}").unwrap();
+
+        let config = GraphQLConfig::Multi {
+            projects: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "project1".to_string(),
+                    ProjectConfig {
+                        schema: SchemaConfig::Path("schema/*.graphql".to_string()),
+                        documents: None,
+                        include: None,
+                        exclude: None,
+                        extensions: None,
+                        lint: None,
+                    },
+                );
+                map.insert(
+                    "project2".to_string(),
+                    ProjectConfig {
+                        schema: SchemaConfig::Path("schema/*.graphql".to_string()),
+                        documents: None,
+                        include: None,
+                        exclude: None,
+                        extensions: None,
+                        lint: None,
+                    },
+                );
+                map
+            },
+        };
+
+        let errors = validate(&config, workspace_path);
+
+        // One error per (project, pattern) — two projects, same pattern
+        assert_eq!(
+            errors.len(),
+            2,
+            "Should detect two overlapping patterns: {errors:?}"
+        );
+
+        for error in &errors {
+            assert_eq!(error.code(), "overlapping-files");
+            assert!(error.message().contains("schema.graphql"));
+        }
+    }
+
+    #[test]
+    fn test_validate_no_errors_when_no_overlap() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+
+        // Create separate schema directories
+        let schema1_dir = workspace_path.join("schema1");
+        std::fs::create_dir(&schema1_dir).unwrap();
+        let mut schema1_file = std::fs::File::create(schema1_dir.join("schema.graphql")).unwrap();
+        writeln!(schema1_file, "type Query {{ hello: String }}").unwrap();
+
+        let schema2_dir = workspace_path.join("schema2");
+        std::fs::create_dir(&schema2_dir).unwrap();
+        let mut schema2_file = std::fs::File::create(schema2_dir.join("schema.graphql")).unwrap();
+        writeln!(schema2_file, "type Query {{ world: String }}").unwrap();
+
+        let config = GraphQLConfig::Multi {
+            projects: {
+                let mut map = std::collections::HashMap::new();
+                map.insert(
+                    "project1".to_string(),
+                    ProjectConfig {
+                        schema: SchemaConfig::Path("schema1/*.graphql".to_string()),
+                        documents: None,
+                        include: None,
+                        exclude: None,
+                        extensions: None,
+                        lint: None,
+                    },
+                );
+                map.insert(
+                    "project2".to_string(),
+                    ProjectConfig {
+                        schema: SchemaConfig::Path("schema2/*.graphql".to_string()),
+                        documents: None,
+                        include: None,
+                        exclude: None,
+                        extensions: None,
+                        lint: None,
+                    },
+                );
+                map
+            },
+        };
+
+        let errors = validate(&config, workspace_path);
+        assert!(errors.is_empty(), "Should not detect any errors");
+    }
+
+    #[test]
+    fn test_error_location_in_yaml() {
+        let config_content = r#"
+projects:
+  github:
+    schema: test-workspace/github/schema/*.graphql
+    documents: test-workspace/github/operations/*.graphql
+"#;
+
+        let error = ConfigValidationError::OverlappingPattern {
+            project: "github".to_string(),
+            pattern: "test-workspace/github/schema/*.graphql".to_string(),
+            file_type: FileType::Schema,
+            overlapping_files: vec![PathBuf::from("test.graphql")],
+            occurrence: 0,
+        };
+
+        let location = error.location(config_content);
+        assert!(location.is_some());
+        let loc = location.unwrap();
+        assert_eq!(loc.line, 3);
+    }
+
+    #[test]
+    fn test_error_location_nth_occurrence() {
+        let config_content = r#"
+projects:
+  github:
+    schema: schema/*.graphql
+  admin:
+    schema: schema/*.graphql
+"#;
+
+        let first = ConfigValidationError::OverlappingPattern {
+            project: "github".to_string(),
+            pattern: "schema/*.graphql".to_string(),
+            file_type: FileType::Schema,
+            overlapping_files: vec![PathBuf::from("test.graphql")],
+            occurrence: 0,
+        };
+        let second = ConfigValidationError::OverlappingPattern {
+            project: "admin".to_string(),
+            pattern: "schema/*.graphql".to_string(),
+            file_type: FileType::Schema,
+            overlapping_files: vec![PathBuf::from("test.graphql")],
+            occurrence: 1,
+        };
+
+        let loc0 = first.location(config_content).unwrap();
+        let loc1 = second.location(config_content).unwrap();
+        assert_eq!(loc0.line, 3);
+        assert_eq!(loc1.line, 5);
+    }
+
+    #[test]
+    fn test_error_location_in_json() {
+        let config_content = r#"{
+  "projects": {
+    "github": {
+      "schema": "test-workspace/github/schema/*.graphql"
+    }
+  }
+}"#;
+
+        let error = ConfigValidationError::OverlappingPattern {
+            project: "github".to_string(),
+            pattern: "test-workspace/github/schema/*.graphql".to_string(),
+            file_type: FileType::Schema,
+            overlapping_files: vec![PathBuf::from("test.graphql")],
+            occurrence: 0,
+        };
+
+        let location = error.location(config_content);
+        assert!(location.is_some());
+    }
+}

--- a/crates/graphql-ide/Cargo.toml
+++ b/crates/graphql-ide/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "graphql-ide"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/trevor-scheer/graphql-lsp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 description = "IDE features for GraphQL Language Server"
 keywords = ["graphql", "ide", "language-server"]
 categories = ["development-tools"]

--- a/crates/graphql-ide/src/folding_ranges.rs
+++ b/crates/graphql-ide/src/folding_ranges.rs
@@ -71,6 +71,7 @@ pub fn folding_ranges(
 }
 
 /// Collect folding ranges from a definition
+#[allow(clippy::too_many_lines)]
 fn collect_definition_folding_ranges(
     definition: &Definition,
     line_index: &graphql_syntax::LineIndex,

--- a/crates/graphql-ide/src/helpers.rs
+++ b/crates/graphql-ide/src/helpers.rs
@@ -592,6 +592,7 @@ pub fn format_type_ref(type_ref: &graphql_hir::TypeRef) -> String {
 }
 
 /// Convert a filesystem path to a file:// URI
+#[must_use]
 pub fn path_to_file_uri(path: &std::path::Path) -> String {
     let path_str = path.to_string_lossy();
 

--- a/crates/graphql-ide/src/lib.rs
+++ b/crates/graphql-ide/src/lib.rs
@@ -70,11 +70,9 @@ pub use types::{
 };
 
 // Re-export helpers for internal use
-use helpers::{
-    adjust_range_for_line_offset, convert_diagnostic, offset_range_to_range, path_to_file_uri,
-};
-// Re-export for use in symbol module
-pub use helpers::unwrap_type_to_name;
+use helpers::{adjust_range_for_line_offset, convert_diagnostic, offset_range_to_range};
+// Re-export for use in symbol module and LSP
+pub use helpers::{path_to_file_uri, unwrap_type_to_name};
 
 use symbol::{find_fragment_definition_full_range, find_operation_definition_ranges};
 


### PR DESCRIPTION
## Summary

- Adds a `validation` module to the `graphql-config` crate with an extensible `ConfigValidationError` enum
- Detects when file glob patterns cause files to belong to multiple projects (overlapping files)
- Publishes diagnostics on the config file itself, highlighting each conflicting pattern
- Shows an error toast with an "Open Config" action to help the user fix their config

## Changes

- **New**: `crates/graphql-config/src/validation.rs` — `validate()` entry point, `ConfigValidationError` enum with `code()`, `message()`, `location()` methods, file uniqueness validation, brace expansion, pattern location tracking
- **Modified**: `crates/graphql-config/src/lib.rs` — exports new validation module
- **Modified**: `crates/graphql-lsp/src/server.rs` — calls `graphql_config::validate()` during both background and sync init, converts errors to LSP diagnostics via generic `validation_errors_to_diagnostics()` helper
- **Modified**: `crates/graphql-ide/Cargo.toml` — removed `glob` dependency (validation now lives in graphql-config)

## Design

The `ConfigValidationError` enum is designed to be extensible — new validation types can be added as variants with their own `code()`, `message()`, and `location()` implementations. The LSP layer stays thin: it just iterates errors and converts them to diagnostics.

Errors are grouped per `(project, pattern)` to avoid noisy diagnostics (e.g., one bad glob matching 30 files produces one diagnostic, not 30). Both sides of a conflict are highlighted via Nth-occurrence tracking in the config file.

## Test plan

- [x] Open VSCode with a multi-project config where two projects share overlapping schema/document globs
- [x] Verify diagnostics appear on the config file highlighting both conflicting patterns
- [x] Verify error toast appears with "Open Config" action
- [ ] Fix the config (make patterns non-overlapping) and verify diagnostics clear

🤖 Generated with [Claude Code](https://claude.ai/code)