### PR TITLE
fix(lsp): fix startup performance on large schema files

### DIFF
--- a/crates/graphql-ide/src/file_registry.rs
+++ b/crates/graphql-ide/src/file_registry.rs
@@ -83,10 +83,14 @@ impl FileRegistry {
 
         // Check if file already exists
         if let Some(&existing_id) = self.uri_to_id.get(uri_str) {
-            // File exists - update content in place using Salsa setter
-            // This only invalidates queries that depend on this specific file's content
+            // File exists - only update if content actually changed.
+            // Salsa's input setters unconditionally bump the revision, so setting
+            // identical content would invalidate all dependent queries and trigger
+            // expensive recomputation across the project.
             if let Some(&existing_content) = self.id_to_content.get(&existing_id) {
-                existing_content.set_text(db).to(content_arc);
+                if *existing_content.text(db) != *content_arc {
+                    existing_content.set_text(db).to(content_arc);
+                }
 
                 // Update metadata if needed (kind changed)
                 let metadata = self.id_to_metadata.get(&existing_id).copied().unwrap();

--- a/crates/graphql-ide/src/symbols.rs
+++ b/crates/graphql-ide/src/symbols.rs
@@ -4,10 +4,12 @@
 //! - Document symbols (Cmd+Shift+O) - hierarchical outline of a file
 //! - Workspace symbols (Cmd+T) - search across all files
 
+use std::collections::HashMap;
+
 use crate::helpers::{adjust_range_for_line_offset, format_type_ref, offset_range_to_range};
 use crate::symbol::{
-    extract_all_definitions, find_field_definition_full_range, find_fragment_definition_full_range,
-    find_operation_definition_ranges, find_type_definition_full_range,
+    extract_all_definitions, find_fragment_definition_full_range, find_operation_definition_ranges,
+    find_type_definition_full_range, SymbolRanges,
 };
 use crate::types::{DocumentSymbol, FilePath, Location, SymbolKind, WorkspaceSymbol};
 use crate::FileRegistry;
@@ -49,6 +51,7 @@ pub fn document_symbols(
         let doc_line_offset = doc.line_offset as u32;
 
         let definitions = extract_all_definitions(doc.tree);
+        let field_ranges_map = extract_all_field_ranges(doc.tree);
 
         for (name, kind, ranges) in definitions {
             let range = adjust_range_for_line_offset(
@@ -61,37 +64,20 @@ pub fn document_symbols(
             );
 
             let symbol = match kind {
-                "object" => {
-                    let children = get_field_children(
+                "object" | "interface" | "input" => {
+                    let children = get_field_children_from_map(
                         &structure,
                         &name,
-                        doc.tree,
+                        &field_ranges_map,
                         &doc_line_index,
                         doc_line_offset,
                     );
-                    DocumentSymbol::new(name, SymbolKind::Type, range, selection_range)
-                        .with_children(children)
-                }
-                "interface" => {
-                    let children = get_field_children(
-                        &structure,
-                        &name,
-                        doc.tree,
-                        &doc_line_index,
-                        doc_line_offset,
-                    );
-                    DocumentSymbol::new(name, SymbolKind::Interface, range, selection_range)
-                        .with_children(children)
-                }
-                "input" => {
-                    let children = get_field_children(
-                        &structure,
-                        &name,
-                        doc.tree,
-                        &doc_line_index,
-                        doc_line_offset,
-                    );
-                    DocumentSymbol::new(name, SymbolKind::Input, range, selection_range)
+                    let sym_kind = match kind {
+                        "object" => SymbolKind::Type,
+                        "interface" => SymbolKind::Interface,
+                        _ => SymbolKind::Input,
+                    };
+                    DocumentSymbol::new(name, sym_kind, range, selection_range)
                         .with_children(children)
                 }
                 "union" => DocumentSymbol::new(name, SymbolKind::Union, range, selection_range),
@@ -205,11 +191,97 @@ pub fn workspace_symbols(
     symbols
 }
 
-/// Get field children for a type definition.
-fn get_field_children(
+/// Extract field ranges for all type definitions in a single AST pass.
+///
+/// Returns a map of type name to field name/range pairs. This avoids the
+/// per-field AST walk that causes O(n^3) behavior and hangs the LSP on
+/// large generated schema files.
+fn extract_all_field_ranges(
+    tree: &apollo_parser::SyntaxTree,
+) -> HashMap<String, Vec<(String, SymbolRanges)>> {
+    use apollo_parser::cst::{self, CstNode};
+
+    let doc = tree.document();
+    let mut map: HashMap<String, Vec<(String, SymbolRanges)>> = HashMap::new();
+
+    for definition in doc.definitions() {
+        match &definition {
+            cst::Definition::ObjectTypeDefinition(obj) => {
+                if let (Some(name), Some(fields_def)) = (obj.name(), obj.fields_definition()) {
+                    map.insert(
+                        name.text().to_string(),
+                        collect_field_ranges(fields_def.field_definitions()),
+                    );
+                }
+            }
+            cst::Definition::InterfaceTypeDefinition(iface) => {
+                if let (Some(name), Some(fields_def)) = (iface.name(), iface.fields_definition()) {
+                    map.insert(
+                        name.text().to_string(),
+                        collect_field_ranges(fields_def.field_definitions()),
+                    );
+                }
+            }
+            cst::Definition::InputObjectTypeDefinition(input) => {
+                if let (Some(name), Some(fields_def)) =
+                    (input.name(), input.input_fields_definition())
+                {
+                    let field_ranges: Vec<(String, SymbolRanges)> = fields_def
+                        .input_value_definitions()
+                        .filter_map(|field| {
+                            let field_name = field.name()?;
+                            let name_range = field_name.syntax().text_range();
+                            let def_range = field.syntax().text_range();
+                            Some((
+                                field_name.text().to_string(),
+                                SymbolRanges {
+                                    name_start: name_range.start().into(),
+                                    name_end: name_range.end().into(),
+                                    def_start: def_range.start().into(),
+                                    def_end: def_range.end().into(),
+                                },
+                            ))
+                        })
+                        .collect();
+                    map.insert(name.text().to_string(), field_ranges);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    map
+}
+
+/// Collect field name/range pairs from a `FieldDefinition` iterator.
+fn collect_field_ranges(
+    fields: impl Iterator<Item = apollo_parser::cst::FieldDefinition>,
+) -> Vec<(String, SymbolRanges)> {
+    use apollo_parser::cst::CstNode;
+
+    fields
+        .filter_map(|field| {
+            let name = field.name()?;
+            let name_range = name.syntax().text_range();
+            let def_range = field.syntax().text_range();
+            Some((
+                name.text().to_string(),
+                SymbolRanges {
+                    name_start: name_range.start().into(),
+                    name_end: name_range.end().into(),
+                    def_start: def_range.start().into(),
+                    def_end: def_range.end().into(),
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Get field children for a type definition using pre-extracted field ranges.
+fn get_field_children_from_map(
     structure: &graphql_hir::FileStructureData,
     type_name: &str,
-    tree: &apollo_parser::SyntaxTree,
+    field_ranges_map: &HashMap<String, Vec<(String, SymbolRanges)>>,
     line_index: &graphql_syntax::LineIndex,
     line_offset: u32,
 ) -> Vec<DocumentSymbol> {
@@ -221,10 +293,14 @@ fn get_field_children(
         return Vec::new();
     };
 
+    let Some(field_ranges) = field_ranges_map.get(type_name) else {
+        return Vec::new();
+    };
+
     let mut children = Vec::new();
 
     for field in &type_def.fields {
-        if let Some(ranges) = find_field_definition_full_range(tree, type_name, &field.name) {
+        if let Some((_, ranges)) = field_ranges.iter().find(|(n, _)| n == field.name.as_ref()) {
             let range = adjust_range_for_line_offset(
                 offset_range_to_range(line_index, ranges.def_start, ranges.def_end),
                 line_offset,


### PR DESCRIPTION
## Summary

- Fix O(n^3) `document_symbols` hang on large generated schema files by replacing per-field AST walks with a single-pass field range extraction
- Prevent unnecessary Salsa cache invalidation when opening files with unchanged content
- Suppress Salsa internal tracing that floods logs during startup

## Changes

- `crates/graphql-ide/src/symbols.rs`: Replace `get_field_children` (which called `find_field_definition_full_range` per field, walking the full AST each time) with `extract_all_field_ranges` that builds a `HashMap<TypeName, Vec<(FieldName, Ranges)>>` in a single AST pass. Also handles `InputObjectTypeDefinition` properly via `input_value_definitions()` instead of a fragile CST cast. Deduplicates the object/interface/input match arms.
- `crates/graphql-ide/src/file_registry.rs`: Guard `set_text` behind a content equality check so Salsa revisions only bump when content actually changes. Previously, opening an already-loaded file would unconditionally set identical content, invalidating all dependent queries and triggering expensive recomputation across the project.
- `crates/graphql-lsp/src/lib.rs`: Add `salsa=warn` directive to the tracing filter. Salsa's tracked functions emit INFO-level logs for every query execution, producing thousands of lines during startup.

## Test Plan

1. Open a workspace containing a large generated schema file (1000+ type definitions)
2. Verify the LSP starts without hanging
3. Open the schema file and invoke document symbols (Cmd+Shift+O) — should respond without delay
4. Verify that opening an already-loaded file does not trigger full project revalidation (observable via DEBUG-level logs showing no Salsa revision bump)