### PR TITLE
fix(lsp): skip empty diagnostic publishes during initial load

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -490,15 +490,6 @@ async fn load_all_project_files_background(
                 .await;
         }
 
-        // Publish empty diagnostics for files without issues
-        for loaded_file in &loaded_files {
-            if !all_diagnostics_map.contains_key(&loaded_file.path) {
-                if let Ok(file_uri) = Uri::from_str(loaded_file.path.as_str()) {
-                    client.publish_diagnostics(file_uri, vec![], None).await;
-                }
-            }
-        }
-
         let project_msg = format!(
             "Project '{}' loaded: {} files in {:.1}s",
             project_name,


### PR DESCRIPTION
## Summary

- Skip publishing empty diagnostic arrays for files without issues during initial project load, reducing unnecessary LSP traffic on large projects

## Changes

- `crates/graphql-lsp/src/server.rs`: Remove the loop that published empty diagnostics for every file without issues after initial load. On large projects (10k+ files), the vast majority of files have no issues, so this loop was sending thousands of empty `textDocument/publishDiagnostics` notifications with no user-visible benefit (files start with no diagnostics by default).

## Test Plan

1. Open a workspace with many files
2. Verify diagnostics still appear correctly for files that have issues
3. Verify no unnecessary empty diagnostic publishes in debug logs