### PR TITLE
feat(lsp): prewarm field coverage during initialization

### DIFF
--- a/crates/graphql-lsp/src/server.rs
+++ b/crates/graphql-lsp/src/server.rs
@@ -497,6 +497,15 @@ async fn load_all_project_files_background(
                 .await;
         }
 
+        // Prewarm field coverage analysis - this triggers operation_body() for all operations,
+        // so the first hover doesn't block on a project-wide query
+        let prewarm_start = std::time::Instant::now();
+        let _ = snapshot.field_coverage();
+        tracing::debug!(
+            "Prewarmed field coverage in {:.2}ms",
+            prewarm_start.elapsed().as_secs_f64() * 1000.0
+        );
+
         let project_msg = format!(
             "Project '{}' loaded: {} files in {:.1}s",
             project_name,


### PR DESCRIPTION
## Summary

- Prewarm field coverage analysis during background initialization to eliminate first-hover delay
- After files are loaded and diagnostics are published, `snapshot.field_coverage()` is called which triggers all `operation_body()` Salsa queries upfront

## Problem

When hovering over a field for the first time, `analyze_field_usage()` is called which iterates through all operations calling `operation_body()` for each one. With many operations, this causes a noticeable delay on first hover:

```
2026-01-28T20:18:32.762699Z  INFO ThreadId(01) salsa::function::execute: operation_body(Id(705e)): executing query
... (repeated for every operation)
```

## Solution

Call `snapshot.field_coverage()` during background initialization after files are loaded. This prewarms the Salsa cache so first hover is instant.

The prewarming happens after diagnostics are published, so the editor already shows "ready" status with issues highlighted before prewarming completes.

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` passes
- [x] Manual verification: first hover on a field should not trigger a cascade of `operation_body` log messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)