### PR TITLE
docs: clarify graphql-config format support (YAML/JSON only)

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -210,11 +210,15 @@ Errors and warnings appear as annotations in GitHub pull requests.
 
 ## Configuration
 
-The CLI uses `.graphqlrc` configuration files. It searches for:
+The CLI uses standard GraphQL configuration files (YAML or JSON only). It searches for these files in order:
 
-- `.graphqlrc` (YAML or JSON)
 - `.graphqlrc.yml` / `.graphqlrc.yaml`
 - `.graphqlrc.json`
+- `.graphqlrc` (YAML or JSON, auto-detected)
+- `graphql.config.yml` / `graphql.config.yaml`
+- `graphql.config.json`
+
+**Note:** JavaScript/TypeScript configs (`graphql.config.js`, `graphql.config.ts`) are not supported. See [config README](../config/README.md#note-on-javascripttypescript-configs) for migration guidance.
 
 ### Basic Configuration
 

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -202,18 +202,37 @@ Checks if a project configuration uses a remote URL for its schema.
 
 ## Supported Configuration Files
 
-The library searches for these files in order:
+The library searches for these files in order of preference:
 
-1. `.graphqlrc` (YAML or JSON)
-2. `.graphqlrc.yml`
-3. `.graphqlrc.yaml`
-4. `.graphqlrc.json`
+1. `.graphqlrc.yml`
+2. `.graphqlrc.yaml`
+3. `.graphqlrc.json`
+4. `.graphqlrc` (YAML or JSON, auto-detected)
+5. `graphql.config.yml`
+6. `graphql.config.yaml`
+7. `graphql.config.json`
 
-Future support planned for:
+### Note on JavaScript/TypeScript Configs
 
-- `graphql.config.js`
-- `graphql.config.ts`
-- `graphql` section in `package.json`
+This library only supports YAML and JSON configuration formats. JavaScript and TypeScript config files (`graphql.config.js`, `graphql.config.ts`) are **not supported**.
+
+If you're migrating from a JS/TS config, convert your configuration to YAML or JSON. Most configurations can be directly translated since the schema is the same:
+
+```javascript
+// graphql.config.js (NOT SUPPORTED)
+module.exports = {
+  schema: 'schema.graphql',
+  documents: 'src/**/*.graphql',
+};
+```
+
+```yaml
+# .graphqlrc.yml (equivalent)
+schema: schema.graphql
+documents: src/**/*.graphql
+```
+
+For dynamic configuration needs (rare), consider using environment variables or generating the YAML/JSON config as a build step.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Clarify that JavaScript/TypeScript configuration files (`graphql.config.js`, `graphql.config.ts`) are not supported
- Add migration guidance for users coming from JS/TS configs
- Update the list of supported config files to accurately reflect what the loader supports

This PR re-applies the changes from #472 after the project rename (#499) which changed crate paths from `crates/graphql-*` to `crates/*`.

## Test plan
- [x] Review documentation changes for accuracy
- [x] Verify the listed config files match `loader.rs` implementation

Closes #463

https://claude.ai/code/session_015YDnBvUE62GrgtD4hSZvig