### PR TITLE
perf: add Rust build caching to prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,6 +35,14 @@ jobs:
             echo "No changesets found, skipping release preparation"
           fi
 
+      - name: Setup Rust toolchain
+        if: steps.check.outputs.changeset_count > 0
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        if: steps.check.outputs.changeset_count > 0
+        uses: Swatinem/rust-cache@v2
+
       - name: Install knope
         if: steps.check.outputs.changeset_count > 0
         uses: knope-dev/action@v2.1.0


### PR DESCRIPTION
## Summary
- Adds `dtolnay/rust-toolchain` and `Swatinem/rust-cache` to the prepare-release workflow
- Caches compiled Rust dependencies between workflow runs
- Significantly speeds up the `cargo check --workspace` step run by knope

## Test plan
- [ ] CI passes
- [ ] Subsequent workflow runs show cache hits

---
Generated with [Claude Code](https://claude.ai/code)