### PR TITLE
Rename packages to include graphql-analyzer prefix

### DIFF
--- a/.changeset/README
+++ b/.changeset/README
@@ -19,12 +19,12 @@ That's it! When your PR is merged to main, CI will automatically:
 
 This project has 4 independently versioned packages:
 
-| Package  | Description             | Changelog                     |
-| -------- | ----------------------- | ----------------------------- |
-| `cli`    | GraphQL CLI tool        | `crates/cli/CHANGELOG.md`     |
-| `lsp`    | GraphQL Language Server | `crates/lsp/CHANGELOG.md`     |
-| `mcp`    | GraphQL MCP Server      | `crates/mcp/CHANGELOG.md`     |
-| `vscode` | VSCode Extension        | `editors/vscode/CHANGELOG.md` |
+| Package                   | Description             | Changelog                     |
+| ------------------------- | ----------------------- | ----------------------------- |
+| `graphql-analyzer-cli`    | GraphQL CLI tool        | `crates/cli/CHANGELOG.md`     |
+| `graphql-analyzer-lsp`    | GraphQL Language Server | `crates/lsp/CHANGELOG.md`     |
+| `graphql-analyzer-mcp`    | GraphQL MCP Server      | `crates/mcp/CHANGELOG.md`     |
+| `graphql-analyzer-vscode` | VSCode Extension        | `editors/vscode/CHANGELOG.md` |
 
 ## Changeset Format
 
@@ -32,8 +32,8 @@ Create a file in `.changeset/` with any name ending in `.md`:
 
 ```markdown
 ---
-cli: patch
-lsp: minor
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: minor
 ---
 
 Add new feature to CLI and LSP
@@ -53,7 +53,7 @@ List the packages affected and their bump type. Only include packages that have 
 
 ```markdown
 ---
-cli: patch
+graphql-analyzer-cli: patch
 ---
 
 Fix argument parsing bug
@@ -63,9 +63,9 @@ Fix argument parsing bug
 
 ```markdown
 ---
-cli: minor
-lsp: minor
-mcp: minor
+graphql-analyzer-cli: minor
+graphql-analyzer-lsp: minor
+graphql-analyzer-mcp: minor
 ---
 
 Add support for new GraphQL directive
@@ -75,7 +75,7 @@ Add support for new GraphQL directive
 
 ```markdown
 ---
-vscode: patch
+graphql-analyzer-vscode: patch
 ---
 
 Fix syntax highlighting for fragments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
           INSTALL_LINK=$'\n\n---\n\n📦 **[Installation Instructions](https://github.com/trevor-scheer/graphql-analyzer#installation)**'
 
           # Append to each release
-          for TAG in "cli/v${CLI_VERSION}" "lsp/v${LSP_VERSION}" "mcp/v${MCP_VERSION}"; do
+          for TAG in "graphql-analyzer-cli/v${CLI_VERSION}" "graphql-analyzer-lsp/v${LSP_VERSION}" "graphql-analyzer-mcp/v${MCP_VERSION}"; do
             if CURRENT_BODY=$(gh release view "$TAG" --json body -q .body 2>/dev/null); then
               gh release edit "$TAG" --notes "${CURRENT_BODY}${INSTALL_LINK}"
             fi

--- a/knope.toml
+++ b/knope.toml
@@ -4,26 +4,26 @@
 # Multi-package setup: each component has independent versioning and changelogs.
 # Changesets specify which package(s) they affect:
 #   ---
-#   cli: patch
-#   lsp: minor
+#   graphql-analyzer-cli: patch
+#   graphql-analyzer-lsp: minor
 #   ---
 
-[packages.cli]
+[packages.graphql-analyzer-cli]
 versioned_files = ["crates/cli/Cargo.toml"]
 changelog = "crates/cli/CHANGELOG.md"
 assets = "artifacts/graphql-cli-*"
 
-[packages.lsp]
+[packages.graphql-analyzer-lsp]
 versioned_files = ["crates/lsp/Cargo.toml"]
 changelog = "crates/lsp/CHANGELOG.md"
 assets = "artifacts/graphql-lsp-*"
 
-[packages.mcp]
+[packages.graphql-analyzer-mcp]
 versioned_files = ["crates/mcp/Cargo.toml"]
 changelog = "crates/mcp/CHANGELOG.md"
 assets = "artifacts/graphql-mcp-*"
 
-[packages.vscode]
+[packages.graphql-analyzer-vscode]
 versioned_files = ["editors/vscode/package.json"]
 changelog = "editors/vscode/CHANGELOG.md"
 assets = "artifacts/*.vsix"


### PR DESCRIPTION
## Summary

Updates all package identifiers across the project to use the `graphql-analyzer-` prefix for consistency and clarity. This affects the CLI, LSP, MCP, and VSCode packages, ensuring they are properly namespaced in release tags, changesets, and configuration files.

## Changes

- Updated `.changeset/README.md` to reflect new package names in documentation and examples
- Modified `knope.toml` to use `graphql-analyzer-cli`, `graphql-analyzer-lsp`, `graphql-analyzer-mcp`, and `graphql-analyzer-vscode` as package identifiers
- Updated `.github/workflows/release.yml` to use new package names when creating release tags
- Updated all changeset format examples to use the new prefixed package names

## Consulted SME Agents

-

## Manual Testing Plan

- Create a new changeset file using the updated format with `graphql-analyzer-cli: patch` and verify it's recognized by the changeset tooling
- Verify that the release workflow correctly generates tags with the new naming scheme (e.g., `graphql-analyzer-cli/v1.0.0`)
- Confirm that the knope configuration properly maps the new package names to their respective versioned files and changelogs

## Related Issues

https://claude.ai/code/session_01WVAbzMvbikfZu6YdvLmDF8