### PR TITLE
refactor: add #[non_exhaustive] to public error enums

### DIFF
--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, ConfigError>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ConfigError {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),

--- a/crates/extract/src/error.rs
+++ b/crates/extract/src/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, ExtractError>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ExtractError {
     #[error("IO error: {0}")]
     Io(#[from] io::Error),

--- a/crates/introspect/src/error.rs
+++ b/crates/introspect/src/error.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, IntrospectionError>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum IntrospectionError {
     #[error("Network error: {0}")]
     Network(String),


### PR DESCRIPTION
## Summary
- Add `#[non_exhaustive]` attribute to `ConfigError`, `ExtractError`, and `IntrospectionError` enums
- Improves API stability by allowing new error variants in minor versions without breaking downstream `match` statements

## Motivation
From Rust SME review: Public error enums should be marked `#[non_exhaustive]` to allow adding new error variants in minor versions without breaking downstream code that exhaustively matches on these enums.

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (fmt, clippy)

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb