### PR TITLE
refactor: add Display and Default trait implementations

### DIFF
--- a/crates/linter/src/config.rs
+++ b/crates/linter/src/config.rs
@@ -44,6 +44,16 @@ pub enum LintSeverity {
     Error,
 }
 
+impl std::fmt::Display for LintSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Off => write!(f, "off"),
+            Self::Warn => write!(f, "warn"),
+            Self::Error => write!(f, "error"),
+        }
+    }
+}
+
 /// Configuration for a single lint rule
 ///
 /// Supports multiple formats:

--- a/crates/linter/src/diagnostics.rs
+++ b/crates/linter/src/diagnostics.rs
@@ -201,10 +201,16 @@ impl LintDiagnostic {
 }
 
 /// Byte offset range in a file
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct OffsetRange {
     pub start: usize,
     pub end: usize,
+}
+
+impl std::fmt::Display for OffsetRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}..{}", self.start, self.end)
+    }
 }
 
 impl OffsetRange {
@@ -230,6 +236,16 @@ pub enum LintSeverity {
     Error,
     Warning,
     Info,
+}
+
+impl std::fmt::Display for LintSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Error => write!(f, "error"),
+            Self::Warning => write!(f, "warning"),
+            Self::Info => write!(f, "info"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -36,11 +36,17 @@ pub struct ParseError {
     pub offset: usize,
 }
 
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (at offset {})", self.message, self.offset)
+    }
+}
+
 /// Result of parsing a file
 ///
 /// All GraphQL content is represented uniformly as blocks. Pure GraphQL files
 /// have a single block at offset 0. Use `documents()` to iterate over blocks.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Parse {
     /// GraphQL blocks (always at least one for valid files)
     blocks: Vec<ExtractedBlock>,


### PR DESCRIPTION
## Summary
- Add `Display` impl for `LintSeverity` (both config and diagnostics versions)
- Add `Display` impl for `OffsetRange` (formats as "start..end")
- Add `Display` impl for `ParseError` (formats as "message (at offset N)")
- Add `Default` derive for `OffsetRange` and `Parse`

## Motivation
From Rust SME review: Public types should implement standard traits like `Display` and `Default` where appropriate for better ergonomics.

Benefits:
- `Display` enables direct use in format strings and logging
- `Default` enables easier test setup with `Type::default()`

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (fmt, clippy)

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb