### PR TITLE
feat(linter): add define_lint_rule! macro for boilerplate reduction

### DIFF
--- a/crates/linter/src/lib.rs
+++ b/crates/linter/src/lib.rs
@@ -7,6 +7,63 @@ mod rules;
 mod schema_utils;
 mod traits;
 
+/// Macro to reduce boilerplate when defining lint rules.
+///
+/// This macro generates the struct definition and `LintRule` trait implementation
+/// for a lint rule, reducing repetitive code across rule implementations.
+///
+/// # Example
+///
+/// ```ignore
+/// define_lint_rule! {
+///     /// Documentation for the rule
+///     pub struct MyRuleImpl;
+///     name = "my_rule",
+///     description = "Description of what this rule checks",
+///     severity = Warning,
+/// }
+/// ```
+///
+/// This expands to:
+///
+/// ```ignore
+/// /// Documentation for the rule
+/// pub struct MyRuleImpl;
+///
+/// impl LintRule for MyRuleImpl {
+///     fn name(&self) -> &'static str { "my_rule" }
+///     fn description(&self) -> &'static str { "Description of what this rule checks" }
+///     fn default_severity(&self) -> LintSeverity { LintSeverity::Warning }
+/// }
+/// ```
+#[macro_export]
+macro_rules! define_lint_rule {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+        name = $rule_name:literal,
+        description = $desc:literal,
+        severity = $severity:ident $(,)?
+    ) => {
+        $(#[$meta])*
+        $vis struct $name;
+
+        impl $crate::traits::LintRule for $name {
+            fn name(&self) -> &'static str {
+                $rule_name
+            }
+
+            fn description(&self) -> &'static str {
+                $desc
+            }
+
+            fn default_severity(&self) -> $crate::diagnostics::LintSeverity {
+                $crate::diagnostics::LintSeverity::$severity
+            }
+        }
+    };
+}
+
 pub use config::{LintConfig, LintRuleConfig, LintSeverity};
 
 // New architecture exports

--- a/crates/linter/src/rules/no_anonymous_operations.rs
+++ b/crates/linter/src/rules/no_anonymous_operations.rs
@@ -1,49 +1,40 @@
 use crate::diagnostics::{LintDiagnostic, LintSeverity};
-use crate::traits::{LintRule, StandaloneDocumentLintRule};
+use crate::traits::StandaloneDocumentLintRule;
 use apollo_parser::cst::{self, CstNode};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
 
-/// Lint rule that requires all GraphQL operations to have explicit names
-///
-/// Anonymous operations are allowed by the GraphQL specification but are
-/// discouraged in production code. Named operations provide several benefits:
-/// - Better monitoring and debugging (operation names appear in logs and APM tools)
-/// - Improved caching strategies in GraphQL clients
-/// - Self-documenting code that describes what each operation does
-/// - Easier security auditing and operation tracking
-///
-/// Example:
-/// ```graphql
-/// # Bad - anonymous operation
-/// query {
-///   user {
-///     id
-///     name
-///   }
-/// }
-///
-/// # Good - named operation
-/// query GetUser {
-///   user {
-///     id
-///     name
-///   }
-/// }
-/// ```
-pub struct NoAnonymousOperationsRuleImpl;
-
-impl LintRule for NoAnonymousOperationsRuleImpl {
-    fn name(&self) -> &'static str {
-        "no_anonymous_operations"
-    }
-
-    fn description(&self) -> &'static str {
-        "Requires all operations to have explicit names for better monitoring and debugging"
-    }
-
-    fn default_severity(&self) -> LintSeverity {
-        LintSeverity::Error
-    }
+crate::define_lint_rule! {
+    /// Lint rule that requires all GraphQL operations to have explicit names
+    ///
+    /// Anonymous operations are allowed by the GraphQL specification but are
+    /// discouraged in production code. Named operations provide several benefits:
+    /// - Better monitoring and debugging (operation names appear in logs and APM tools)
+    /// - Improved caching strategies in GraphQL clients
+    /// - Self-documenting code that describes what each operation does
+    /// - Easier security auditing and operation tracking
+    ///
+    /// Example:
+    /// ```graphql
+    /// # Bad - anonymous operation
+    /// query {
+    ///   user {
+    ///     id
+    ///     name
+    ///   }
+    /// }
+    ///
+    /// # Good - named operation
+    /// query GetUser {
+    ///   user {
+    ///     id
+    ///     name
+    ///   }
+    /// }
+    /// ```
+    pub struct NoAnonymousOperationsRuleImpl;
+    name = "no_anonymous_operations",
+    description = "Requires all operations to have explicit names for better monitoring and debugging",
+    severity = Error,
 }
 
 impl StandaloneDocumentLintRule for NoAnonymousOperationsRuleImpl {


### PR DESCRIPTION
## Summary
- Add `define_lint_rule!` declarative macro that generates lint rule boilerplate
- Update `no_anonymous_operations` rule to demonstrate macro usage
- Reduces per-rule boilerplate from ~15 lines to ~5 lines

## Motivation
From Rust SME review: Every lint rule has identical boilerplate for the `LintRule` trait implementation. A macro reduces repetition and ensures consistency.

## Usage

```rust
crate::define_lint_rule! {
    /// Documentation for the rule
    pub struct MyRuleImpl;
    name = "my_rule",
    description = "What this rule checks",
    severity = Warning,
}

// Then implement the specific rule trait:
impl StandaloneDocumentLintRule for MyRuleImpl {
    fn check(&self, ...) -> Vec<LintDiagnostic> { ... }
}
```

## Features
- Accepts doc comments and visibility modifiers
- Generates struct definition and `LintRule` impl
- Uses fully-qualified paths (`$crate::`) for proper macro hygiene
- Supports all severity levels: `Error`, `Warning`, `Info`

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --package graphql-linter no_anonymous` passes (13 tests)
- [x] Pre-commit hooks pass (fmt, clippy)

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb