### PR TITLE
refactor(linter): remove tool-specific lint configuration

### DIFF
--- a/crates/linter/README.md
+++ b/crates/linter/README.md
@@ -6,7 +6,6 @@ A flexible GraphQL linting engine with support for document-level and project-wi
 
 - **Multiple Linting Contexts**: Document-level, schema-only, and project-wide analysis
 - **Configurable Rules**: Enable/disable rules with custom severity levels
-- **Tool-Specific Config**: Different rule sets for LSP vs CLI
 - **Extensible**: Easy to add new custom rules
 - **Performance-Aware**: Separate fast and expensive rule categories
 
@@ -200,29 +199,6 @@ extensions:
     extends: [recommended]
     rules:
       unusedFields: warn
-```
-
-**Tool-specific overrides:**
-
-```yaml
-extensions:
-  # Base lint configuration
-  lint:
-    extends: recommended
-    rules:
-      noDeprecated: warn
-
-  # CLI-specific overrides
-  cli:
-    lint:
-      rules:
-        unusedFields: error # Enable expensive rule in CI
-
-  # LSP-specific overrides
-  lsp:
-    lint:
-      rules:
-        unusedFields: off # Disable expensive rule in editor
 ```
 
 ### Severity Levels
@@ -583,7 +559,6 @@ impl LintConfig {
     pub fn get_severity(&self, rule: &str) -> Option<LintSeverity>;
     pub fn is_enabled(&self, rule: &str) -> bool;
     pub fn validate(&self) -> Result<(), String>;
-    pub fn merge(&self, override_config: &Self) -> Self;
 }
 ```
 
@@ -624,26 +599,13 @@ let diagnostics = linter.lint_document(&ctx);
 // let diagnostics = linter.lint_project(&ctx);  // Too slow!
 ```
 
-Configure LSP to disable expensive rules:
-
-```yaml
-extensions:
-  lsp:
-    lint:
-      rules:
-        unused_fields: off
-```
-
 ### For CLI Integration
 
-Enable all rules including expensive project-wide analysis:
+Use project-wide analysis for comprehensive checks in CI:
 
-```yaml
-extensions:
-  cli:
-    lint:
-      rules:
-        unused_fields: error # Enable in CI
+```rust
+// Enable all rules including expensive project-wide analysis
+let diagnostics = linter.lint_project(&ctx);
 ```
 
 ## Examples

--- a/crates/linter/src/config.rs
+++ b/crates/linter/src/config.rs
@@ -388,55 +388,6 @@ impl LintConfig {
     pub fn recommended() -> Self {
         Self::Preset(ExtendsConfig::Single("recommended".to_string()))
     }
-
-    /// Merge another config into this one (tool-specific overrides)
-    #[must_use]
-    pub fn merge(&self, override_config: &Self) -> Self {
-        match (self, override_config) {
-            // If override is a preset, use it directly
-            (_, Self::Preset(name)) => Self::Preset(name.clone()),
-
-            // If override is empty Full config, keep base
-            (
-                base,
-                Self::Full(FullLintConfig {
-                    extends: None,
-                    rules,
-                }),
-            ) if rules.is_empty() => base.clone(),
-
-            // Merge Full configs
-            (
-                Self::Full(FullLintConfig {
-                    extends: base_ext,
-                    rules: base_rules,
-                }),
-                Self::Full(FullLintConfig {
-                    extends: override_ext,
-                    rules: override_rules,
-                }),
-            ) => {
-                let mut merged_rules = base_rules.clone();
-                merged_rules.extend(override_rules.clone());
-                Self::Full(FullLintConfig {
-                    extends: override_ext.clone().or_else(|| base_ext.clone()),
-                    rules: merged_rules,
-                })
-            }
-
-            // Preset + Full override: convert preset to extends and merge
-            (
-                Self::Preset(presets),
-                Self::Full(FullLintConfig {
-                    extends: override_ext,
-                    rules: override_rules,
-                }),
-            ) => Self::Full(FullLintConfig {
-                extends: override_ext.clone().or_else(|| Some(presets.clone())),
-                rules: override_rules.clone(),
-            }),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -537,40 +488,6 @@ rules:
             config.get_severity("no_deprecated"),
             Some(LintSeverity::Warn)
         );
-    }
-
-    #[test]
-    fn test_merge_preset_with_rules() {
-        let base = LintConfig::recommended();
-        let override_yaml = r"
-rules:
-  unusedFields: error
-";
-        let override_config: LintConfig = serde_yaml::from_str(override_yaml).unwrap();
-        let merged = base.merge(&override_config);
-
-        // unique_names is not in recommended (opinionated)
-        assert!(!merged.is_enabled("unique_names"));
-        assert!(merged.is_enabled("unused_fields"));
-    }
-
-    #[test]
-    fn test_merge_extends_override_severity() {
-        let base_yaml = r"
-extends: recommended
-";
-        let base: LintConfig = serde_yaml::from_str(base_yaml).unwrap();
-
-        let override_yaml = r"
-rules:
-  noDeprecated: off
-";
-        let override_config: LintConfig = serde_yaml::from_str(override_yaml).unwrap();
-        let merged = base.merge(&override_config);
-
-        // unique_names is not in recommended (opinionated)
-        assert!(!merged.is_enabled("unique_names"));
-        assert!(!merged.is_enabled("no_deprecated"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remove the partially-implemented tool-specific lint configuration infrastructure. The project-level `extensions.lint` is sufficient; allowing different behavior between LSP and CLI adds unnecessary complexity without clear benefit.

## Changes

- Remove `LintConfig::merge()` method that was designed for merging base config with tool-specific overrides
- Remove merge-related tests (`test_merge_preset_with_rules`, `test_merge_extends_override_severity`)
- Remove "Tool-Specific Config" from README features list
- Remove tool-specific YAML config examples from README (the `cli:` and `lsp:` extension paths)
- Simplify Performance Considerations section to remove tool-specific config guidance
- Remove `merge()` from API Reference documentation

## Consulted SME Agents

N/A - straightforward code removal

## Manual Testing Plan

N/A - internal refactoring with no behavioral changes

## Related Issues

https://claude.ai/code/session_01V1L2JnvxXx13RxeM3jbq7B