### PR TITLE
feat(linter): add prelude module for common imports

### DIFF
--- a/crates/linter/src/lib.rs
+++ b/crates/linter/src/lib.rs
@@ -18,3 +18,19 @@ pub use traits::{
     DocumentSchemaLintRule, LintRule, ProjectLintRule, StandaloneDocumentLintRule,
     StandaloneSchemaLintRule,
 };
+
+/// Prelude module for convenient imports.
+///
+/// This module re-exports the most commonly used types for working with
+/// the linter. Import with:
+///
+/// ```rust,ignore
+/// use graphql_linter::prelude::*;
+/// ```
+pub mod prelude {
+    pub use crate::config::{LintConfig, LintSeverity};
+    pub use crate::diagnostics::{LintDiagnostic, LintSeverity as DiagnosticSeverity, OffsetRange};
+    pub use crate::traits::{
+        DocumentSchemaLintRule, LintRule, ProjectLintRule, StandaloneDocumentLintRule,
+    };
+}


### PR DESCRIPTION
## Summary
Add a prelude module to the linter crate for convenient imports of commonly used types.

## Changes
- Add `prelude` module to `graphql-linter`
- Re-exports: `LintConfig`, `LintSeverity`, `LintDiagnostic`, `DiagnosticSeverity`, `OffsetRange`, `LintRule`, `DocumentSchemaLintRule`, `ProjectLintRule`, `StandaloneDocumentLintRule`

## Usage
```rust
use graphql_linter::prelude::*;
```

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (fmt, clippy)

Closes #543

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb