### PR TITLE
refactor(hir): add type aliases for complex HashMap types

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -12,6 +12,19 @@ mod structure;
 pub use body::*;
 pub use structure::*;
 
+// Type aliases for commonly used HashMap types.
+// These improve readability in function signatures and provide
+// a single point of change if the underlying type needs modification.
+
+/// Map from type name to type definition.
+pub type TypeDefMap = HashMap<Arc<str>, TypeDef>;
+
+/// Map from fragment name to fragment structure.
+pub type FragmentMap = HashMap<Arc<str>, FragmentStructure>;
+
+/// Map from name to count (used for uniqueness validation).
+pub type NameCountMap = HashMap<Arc<str>, usize>;
+
 /// Identifier for a GraphQL type in the schema
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeId(salsa::Id);
@@ -148,7 +161,7 @@ pub fn file_operations(
 pub fn schema_types(
     db: &dyn GraphQLHirDatabase,
     project_files: graphql_base_db::ProjectFiles,
-) -> HashMap<Arc<str>, TypeDef> {
+) -> TypeDefMap {
     let schema_ids = project_files.schema_file_ids(db).ids(db);
     let mut types = HashMap::new();
 
@@ -178,7 +191,7 @@ pub fn schema_types(
 pub fn all_fragments(
     db: &dyn GraphQLHirDatabase,
     project_files: graphql_base_db::ProjectFiles,
-) -> HashMap<Arc<str>, FragmentStructure> {
+) -> FragmentMap {
     let doc_ids = project_files.document_file_ids(db).ids(db);
     let mut fragments = HashMap::new();
 
@@ -720,8 +733,8 @@ pub fn file_schema_coordinates(
     struct CollectContext<'a> {
         db: &'a dyn GraphQLHirDatabase,
         project_files: graphql_base_db::ProjectFiles,
-        schema_types: &'a HashMap<Arc<str>, TypeDef>,
-        fragments: &'a HashMap<Arc<str>, FragmentStructure>,
+        schema_types: &'a TypeDefMap,
+        fragments: &'a FragmentMap,
         visited_fragments: std::collections::HashSet<Arc<str>>,
         coordinates: std::collections::HashSet<SchemaCoordinate>,
     }


### PR DESCRIPTION
## Summary
Add type aliases to the HIR crate for commonly used HashMap types.

## Changes
- Add `TypeDefMap` alias for `HashMap<Arc<str>, TypeDef>`
- Add `FragmentMap` alias for `HashMap<Arc<str>, FragmentStructure>`
- Add `NameCountMap` alias for `HashMap<Arc<str>, usize>`
- Update `schema_types()` return type to use `TypeDefMap`
- Update `all_fragments()` return type to use `FragmentMap`
- Update `CollectContext` struct fields to use type aliases

## Benefits
- Improved readability in function signatures
- Single point of change if underlying type needs modification
- Self-documenting code (type name conveys purpose)

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (fmt, clippy)

Closes #542

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb