### PR TITLE
refactor(lsp): reduce .unwrap() usage and improve error messages

### DIFF
--- a/crates/lsp/src/conversions.rs
+++ b/crates/lsp/src/conversions.rs
@@ -191,9 +191,10 @@ pub fn convert_ide_code_lens_info(info: &graphql_ide::CodeLensInfo, uri: &Uri) -
             title,
             command: "graphql-analyzer.showReferences".to_string(),
             arguments: Some(vec![
-                serde_json::to_value(uri.to_string()).unwrap(),
-                serde_json::to_value(convert_ide_position(info.range.start)).unwrap(),
-                serde_json::to_value(lsp_locations).unwrap(),
+                serde_json::to_value(uri.to_string()).expect("String is always serializable"),
+                serde_json::to_value(convert_ide_position(info.range.start))
+                    .expect("Position is always serializable"),
+                serde_json::to_value(lsp_locations).expect("Vec<Location> is always serializable"),
             ]),
         })
     } else {
@@ -234,9 +235,10 @@ pub fn convert_ide_code_lens(
             title: lens.title.clone(),
             command: "graphql-analyzer.showReferences".to_string(),
             arguments: Some(vec![
-                serde_json::to_value(uri.to_string()).unwrap(),
-                serde_json::to_value(convert_ide_position(lens.range.start)).unwrap(),
-                serde_json::to_value(references).unwrap(),
+                serde_json::to_value(uri.to_string()).expect("String is always serializable"),
+                serde_json::to_value(convert_ide_position(lens.range.start))
+                    .expect("Position is always serializable"),
+                serde_json::to_value(references).expect("&[Location] is always serializable"),
             ]),
         })
     };

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -166,7 +166,7 @@ async fn load_workspaces_background(
         method: "workspace/didChangeWatchedFiles".to_string(),
         register_options: Some(
             serde_json::to_value(lsp_types::DidChangeWatchedFilesRegistrationOptions { watchers })
-                .unwrap(),
+                .expect("DidChangeWatchedFilesRegistrationOptions is always serializable"),
         ),
     };
 
@@ -1141,7 +1141,7 @@ documents: "**/*.graphql"
 
     /// Validate a file and publish diagnostics
     #[allow(clippy::too_many_lines)]
-    #[tracing::instrument(skip(self), fields(path = ?uri.to_file_path().unwrap()))]
+    #[tracing::instrument(skip(self), fields(path = %uri.as_str()))]
     async fn validate_file(&self, uri: Uri) {
         let Some((workspace_uri, project_name)) = self.workspace.find_workspace_and_project(&uri)
         else {
@@ -1179,7 +1179,7 @@ documents: "**/*.graphql"
     ///
     /// This variant avoids acquiring the host lock again when we already have a snapshot.
     /// Used by `did_change` after updating a file to avoid double-locking.
-    #[tracing::instrument(skip(self, snapshot), fields(path = ?uri.to_file_path().unwrap()))]
+    #[tracing::instrument(skip(self, snapshot), fields(path = %uri.as_str()))]
     async fn validate_file_with_snapshot(&self, uri: &Uri, snapshot: graphql_ide::Analysis) {
         let file_path = graphql_ide::FilePath::new(uri.as_str());
         let diagnostics = snapshot.diagnostics(&file_path);
@@ -1419,7 +1419,7 @@ impl LanguageServer for GraphQLLanguageServer {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, params), fields(path = ?params.text_document.uri.to_file_path().unwrap()))]
+    #[tracing::instrument(skip(self, params), fields(path = %params.text_document.uri.as_str()))]
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri;
         let content = params.text_document.text;
@@ -1475,7 +1475,7 @@ impl LanguageServer for GraphQLLanguageServer {
         }
     }
 
-    #[tracing::instrument(skip(self, params), fields(path = ?params.text_document.uri.to_file_path().unwrap()))]
+    #[tracing::instrument(skip(self, params), fields(path = %params.text_document.uri.as_str()))]
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         let version = params.text_document.version;
@@ -1524,7 +1524,7 @@ impl LanguageServer for GraphQLLanguageServer {
         }
     }
 
-    #[tracing::instrument(skip(self, params), fields(path = ?params.text_document.uri.to_file_path().unwrap()))]
+    #[tracing::instrument(skip(self, params), fields(path = %params.text_document.uri.as_str()))]
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         let uri = params.text_document.uri;
 


### PR DESCRIPTION
## Summary
Reduce `.unwrap()` usage in the LSP server to prevent potential panics in production.

## Changes

### Tracing Instruments
Replace `uri.to_file_path().unwrap()` with `uri.as_str()` in tracing field attributes:
- `validate_file`
- `validate_file_with_snapshot`
- `did_open`
- `did_change`
- `did_save`

**Before:** Could panic for non-file URIs (e.g., `untitled:` scheme)
**After:** Safely logs the URI string regardless of scheme

### Serialization
Replace `.unwrap()` with `.expect()` for `serde_json::to_value()` calls that serialize:
- `String` (always serializable)
- `Position` (simple struct with Serialize)
- `Vec<Location>` / `&[Location]` (always serializable)

These are technically infallible, but now have descriptive messages documenting why.

## Impact
This addresses the highest-risk `.unwrap()` calls in the LSP server. The remaining `.unwrap()` calls (272 total across the codebase) are mostly:
- In test code (acceptable)
- Writing to String buffers (infallible)
- Parsing known-valid data

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (fmt, clippy)

Partial fix for #540

https://claude.ai/code/session_01SAnuPxfVEJsVLQULkSSxWb