### PR TITLE
fix: pass ProjectFiles as parameter to tracked functions for proper caching

### DIFF
--- a/crates/analysis/src/document_validation.rs
+++ b/crates/analysis/src/document_validation.rs
@@ -44,13 +44,10 @@ pub fn validate_document_file(
     db: &dyn GraphQLAnalysisDatabase,
     content: FileContent,
     metadata: FileMetadata,
+    project_files: graphql_base_db::ProjectFiles,
 ) -> Arc<Vec<Diagnostic>> {
     let structure = graphql_hir::file_structure(db, metadata.file_id(db), content, metadata);
     let mut diagnostics = Vec::new();
-
-    let project_files = db
-        .project_files()
-        .expect("project files must be set for validation");
     let schema = graphql_hir::schema_types(db, project_files);
 
     // Use the operation name index for O(1) lookup instead of iterating all operations

--- a/crates/analysis/tests/analysis_tests.rs
+++ b/crates/analysis/tests/analysis_tests.rs
@@ -408,7 +408,7 @@ fn test_unknown_variable_type() {
     let project_files = create_project_files(&mut db, &[], &[(file_id, content, metadata)]);
     db.set_project_files(Some(project_files));
 
-    let diagnostics = validate_document_file(&db, content, metadata);
+    let diagnostics = validate_document_file(&db, content, metadata, project_files);
 
     let unknown_type_error = diagnostics
         .iter()
@@ -436,7 +436,7 @@ fn test_fragment_unknown_type_condition() {
     let project_files = create_project_files(&mut db, &[], &[(file_id, content, metadata)]);
     db.set_project_files(Some(project_files));
 
-    let diagnostics = validate_document_file(&db, content, metadata);
+    let diagnostics = validate_document_file(&db, content, metadata, project_files);
 
     let unknown_type_error = diagnostics
         .iter()
@@ -464,7 +464,7 @@ fn test_missing_root_type() {
     let project_files = create_project_files(&mut db, &[], &[(file_id, content, metadata)]);
     db.set_project_files(Some(project_files));
 
-    let diagnostics = validate_document_file(&db, content, metadata);
+    let diagnostics = validate_document_file(&db, content, metadata, project_files);
 
     let missing_root_error = diagnostics
         .iter()
@@ -515,7 +515,7 @@ fn test_valid_document() {
     );
     db.set_project_files(Some(project_files));
 
-    let diagnostics = validate_document_file(&db, doc_fc, doc_metadata);
+    let diagnostics = validate_document_file(&db, doc_fc, doc_metadata, project_files);
 
     assert_eq!(diagnostics.len(), 0, "Expected no validation errors");
 }
@@ -982,7 +982,7 @@ fn test_analyze_field_usage_basic() {
 
     db.set_project_files(Some(project_files));
 
-    let coverage = analyze_field_usage(&db);
+    let coverage = analyze_field_usage(&db, project_files);
 
     assert_eq!(coverage.total_fields, 4); // Query.user, User.id, User.name, User.email
     assert_eq!(coverage.used_fields, 3); // Query.user, User.id, User.name
@@ -1063,7 +1063,7 @@ fn test_analyze_field_usage_multiple_operations() {
 
     db.set_project_files(Some(project_files));
 
-    let coverage = analyze_field_usage(&db);
+    let coverage = analyze_field_usage(&db, project_files);
 
     let user_name = coverage
         .field_usages
@@ -1140,7 +1140,7 @@ fn test_analyze_field_usage_with_fragments() {
 
     db.set_project_files(Some(project_files));
 
-    let coverage = analyze_field_usage(&db);
+    let coverage = analyze_field_usage(&db, project_files);
 
     let user_email = coverage
         .field_usages

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -91,7 +91,7 @@ pub fn hover(
             let field_type = format_type_ref(&field.type_ref);
             write!(hover_text, "**Type:** `{field_type}`\n\n").ok();
 
-            let coverage = graphql_analysis::analyze_field_usage(db);
+            let coverage = graphql_analysis::analyze_field_usage(db, project_files);
             let usage_key = (Arc::from(parent_type_name.as_str()), Arc::from(name));
             if let Some(usage) = coverage.field_usages.get(&usage_key) {
                 let op_count = usage.operations.len();

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -1625,9 +1625,9 @@ impl Analysis {
     /// detailed coverage statistics. This is useful for understanding
     /// schema usage patterns and finding unused fields.
     pub fn field_coverage(&self) -> Option<FieldCoverageReport> {
-        let _ = self.project_files?;
+        let pf = self.project_files?;
         Some(FieldCoverageReport::from(
-            graphql_analysis::analyze_field_usage(&self.db),
+            graphql_analysis::analyze_field_usage(&self.db, pf),
         ))
     }
 
@@ -1636,8 +1636,8 @@ impl Analysis {
     /// Returns usage information for a field if it exists in the schema.
     /// Useful for enhancing hover to show "Used in N operations".
     pub fn field_usage(&self, type_name: &str, field_name: &str) -> Option<FieldUsageInfo> {
-        let _ = self.project_files?;
-        let coverage = graphql_analysis::analyze_field_usage(&self.db);
+        let pf = self.project_files?;
+        let coverage = graphql_analysis::analyze_field_usage(&self.db, pf);
         let key = (
             std::sync::Arc::from(type_name),
             std::sync::Arc::from(field_name),

--- a/crates/test-utils/src/database.rs
+++ b/crates/test-utils/src/database.rs
@@ -36,10 +36,9 @@ pub type TestDatabase = RootDatabase;
 ///
 /// let db = TestDatabaseWithProject::default();
 /// let project_files = create_project_files(&db, &schemas, &docs);
-/// db.set_project_files(Some(project_files));
 ///
-/// // Now validation can access project context
-/// let diagnostics = validate_document_file(&db, content, metadata);
+/// // Pass project_files directly to validation functions
+/// let diagnostics = validate_document_file(&db, content, metadata, project_files);
 /// ```
 #[salsa::db]
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Follow-up to #544. Salsa-tracked functions use their parameters as cache keys. Previously, functions like `find_unused_fields(db)` only had `db` as their key, so Salsa couldn't invalidate the cache when project files changed.

By passing `ProjectFiles` as a parameter, the cache key now includes project files, ensuring proper invalidation when files are added/removed.

## Changes

Functions updated to accept `ProjectFiles` parameter:
- `find_unused_fields(db, project_files)`
- `find_unused_fragments(db, project_files)`
- `analyze_field_usage(db, project_files)`
- `validate_document_file(db, content, metadata, project_files)`

## Why this matters

```rust
// OLD: Only 'db' is the key - Salsa can't track project_files changes
#[salsa::tracked]
fn find_unused_fields(db: &dyn Database) -> ... {
    let project_files = db.project_files();  // Not tracked as dependency
}

// NEW: Both 'db' and 'project_files' are the key
#[salsa::tracked]
fn find_unused_fields(db: &dyn Database, project_files: ProjectFiles) -> ... {
    // Now Salsa recomputes when project_files changes
}
```

After #544, `db.project_files()` is a simple field access (not a Salsa-tracked query), so Salsa doesn't track it as a dependency. By making `project_files` an explicit parameter, Salsa properly invalidates cached results when project structure changes.

## Test plan

- All existing tests pass
- Verified with `cargo fmt && cargo clippy && cargo test`

---

Generated with [Claude Code](https://claude.ai/code)