### PR TITLE
fix(changeset): use correct package name for CLI

### DIFF
--- a/.changeset/cli-watch-mode.md
+++ b/.changeset/cli-watch-mode.md
@@ -1,5 +1,5 @@
 ---
-graphql-cli: minor
+graphql-analyzer-cli: minor
 ---
 
 Add `--watch` flag to validate, lint, and check commands for continuous validation during development


### PR DESCRIPTION
## Summary

- Fixes the changeset package name from `graphql-cli` to `graphql-analyzer-cli`
- This mismatch caused knope to skip the CLI version bump in release PR #535

## Test plan

- [ ] Re-run `knope prepare-release` workflow and verify CLI version is bumped
- [ ] Verify `crates/cli/CHANGELOG.md` is updated

https://claude.ai/code/session_013R41f4jTEE6rQgNps8Dpro