### PR TITLE
docs: require PR links in changeset entries

### DIFF
--- a/.changeset/README
+++ b/.changeset/README
@@ -7,6 +7,8 @@ This directory contains changeset files that document changes for the changelog.
 ```bash
 # After making changes, create a changeset
 knope document-change
+
+# Then edit the generated file to add a PR link (see format below)
 ```
 
 That's it! When your PR is merged to main, CI will automatically:
@@ -36,10 +38,16 @@ graphql-analyzer-cli: patch
 graphql-analyzer-lsp: minor
 ---
 
-Add new feature to CLI and LSP
+Add new feature to CLI and LSP ([#123](https://github.com/trevor-scheer/graphql-analyzer/pull/123))
 ```
 
 List the packages affected and their bump type. Only include packages that have changes.
+
+**Important:** Always include a link to the PR that implements the change at the end of the first line. This helps users trace changelog entries back to the implementation details.
+
+**Workflow tip:** Since you won't have a PR number when creating the changeset, either:
+1. Create the PR first, note the number, then add the changeset with the link
+2. Create the changeset, push, create the PR, then amend your commit to add the PR link
 
 ### Version Bump Types
 
@@ -56,7 +64,7 @@ List the packages affected and their bump type. Only include packages that have 
 graphql-analyzer-cli: patch
 ---
 
-Fix argument parsing bug
+Fix argument parsing bug ([#456](https://github.com/trevor-scheer/graphql-analyzer/pull/456))
 ```
 
 **Change affecting multiple packages:**
@@ -68,7 +76,7 @@ graphql-analyzer-lsp: minor
 graphql-analyzer-mcp: minor
 ---
 
-Add support for new GraphQL directive
+Add support for new GraphQL directive ([#789](https://github.com/trevor-scheer/graphql-analyzer/pull/789))
 ```
 
 **VSCode extension update:**
@@ -78,7 +86,7 @@ Add support for new GraphQL directive
 graphql-analyzer-vscode: patch
 ---
 
-Fix syntax highlighting for fragments
+Fix syntax highlighting for fragments ([#234](https://github.com/trevor-scheer/graphql-analyzer/pull/234))
 ```
 
 ## When to Create a Changeset

--- a/.changeset/cli-watch-mode.md
+++ b/.changeset/cli-watch-mode.md
@@ -2,7 +2,7 @@
 graphql-analyzer-cli: minor
 ---
 
-Add `--watch` flag to validate, lint, and check commands for continuous validation during development
+Add `--watch` flag to validate, lint, and check commands for continuous validation during development ([#467](https://github.com/trevor-scheer/graphql-analyzer/pull/467))
 
 - `graphql validate --watch`: Watch mode for GraphQL spec validation
 - `graphql lint --watch`: Watch mode for custom lint rules

--- a/.changeset/fix-multiline-gql-tags.md
+++ b/.changeset/fix-multiline-gql-tags.md
@@ -2,4 +2,4 @@
 graphql-analyzer-vscode: patch
 ---
 
-Fix syntax highlighting for gql tags with backtick on separate line
+Fix syntax highlighting for gql tags with backtick on separate line ([#529](https://github.com/trevor-scheer/graphql-analyzer/pull/529))

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -196,6 +196,16 @@ Skills enforce important workflows. Skipping them leads to incomplete work.
 3. Review changes: `git diff main...HEAD`
 4. Use the `/create-pr` skill for guidance
 
+**Changeset format:** Always include a PR link at the end of the first line:
+
+```markdown
+---
+graphql-analyzer-cli: patch
+---
+
+Fix argument parsing bug ([#123](https://github.com/trevor-scheer/graphql-analyzer/pull/123))
+```
+
 **When to create a changeset:**
 
 - Features, bug fixes, breaking changes → YES

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -26,6 +26,18 @@ For user-facing changes (features, bug fixes, breaking changes), create a change
 knope document-change
 ```
 
+**Important:** After creating the changeset file, edit it to include a PR link at the end of the first line. Since you're creating a PR, use the PR number you expect (or update after PR is created):
+
+```markdown
+---
+graphql-analyzer-cli: patch
+---
+
+Fix argument parsing bug ([#123](https://github.com/trevor-scheer/graphql-analyzer/pull/123))
+```
+
+The PR link helps users trace changelog entries back to implementation details.
+
 **Skip changesets for:** internal refactoring, CI changes, test-only changes, documentation updates.
 
 ### 4. Review Your Changes
@@ -115,7 +127,7 @@ EOF
 - [ ] All tests pass locally
 - [ ] Clippy is clean
 - [ ] Code is formatted
-- [ ] Changeset created (if user-facing changes)
+- [ ] Changeset created with PR link (if user-facing changes)
 - [ ] Commits follow conventional format
 - [ ] PR title is descriptive (no emoji)
 - [ ] PR body follows `.github/PULL_REQUEST_TEMPLATE.md` structure


### PR DESCRIPTION
## Summary

Adds PR link requirement to changeset documentation and updates existing changesets with their PR links. This ensures changelog entries can be traced back to their implementation PRs.

## Changes

- Add PR links to existing changesets (`cli-watch-mode.md` → #467, `fix-multiline-gql-tags.md` → #529)
- Update `.changeset/README` with PR link format requirement and workflow tips
- Update `CLAUDE.md` with changeset format guidelines
- Update `create-pr` skill with PR link instructions and checklist item

## Consulted SME Agents

N/A - documentation-only changes

## Manual Testing Plan

N/A - documentation changes only

## Related Issues

https://claude.ai/code/session_016NnLorriZMaNN3xxsDfoAJ