### PR TITLE
chore: add changeset to trigger vscode publish

### DIFF
--- a/.changeset/trigger-vscode-publish.md
+++ b/.changeset/trigger-vscode-publish.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Add extension icon for VS Code Marketplace


### PR DESCRIPTION
## Summary

- Add changeset for vscode extension to trigger marketplace publishing

## Changes

- Added changeset for `graphql-analyzer-vscode` patch release
- This will trigger the release workflow to publish the extension to VS Code Marketplace

## Test Plan

1. Merge this PR
2. Wait for knope to create a release PR
3. Merge the release PR
4. Verify the extension is published to VS Code Marketplace