### PR TITLE
fix(vscode): correct marketplace publisher ID

### DIFF
--- a/.changeset/fix-publisher-id.md
+++ b/.changeset/fix-publisher-id.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Fix VS Code Marketplace publisher ID

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,7 +8,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "https://github.com/trevor-scheer/graphql-analyzer",
-  "publisher": "trevor-scheer",
+  "publisher": "graphql-analyzer",
   "icon": "icon.png",
   "main": "./out/extension.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Fix VS Code Marketplace publisher ID from `trevor-scheer` to `graphql-analyzer`

## Changes

- Updated `publisher` field in `editors/vscode/package.json`
- Added changeset to trigger a new release

## Test Plan

1. Merge this PR
2. Wait for knope to create a release PR
3. Merge the release PR
4. Verify the extension appears at https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer