### PR TITLE
fix(cli): validate command now reports document file errors

### DIFF
--- a/.changeset/fix-cli-validate-documents.md
+++ b/.changeset/fix-cli-validate-documents.md
@@ -1,0 +1,8 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-mcp: patch
+---
+
+Fix validate command not reporting errors from document files ([#617](https://github.com/trevor-scheer/graphql-analyzer/pull/617))
+
+The CLI and MCP validate commands were silently ignoring validation errors from document files (TypeScript, JavaScript, GraphQL) due to a path format mismatch. Files were registered with raw filesystem paths but looked up with file:// URIs, causing lookups to fail.

--- a/crates/mcp/src/service.rs
+++ b/crates/mcp/src/service.rs
@@ -150,8 +150,7 @@ impl McpService {
                         for entry in paths.flatten() {
                             if entry.is_file() {
                                 if let Ok(content) = std::fs::read_to_string(&entry) {
-                                    let file_path =
-                                        FilePath::new(entry.to_string_lossy().to_string());
+                                    let file_path = FilePath::from_path(&entry);
                                     let (language, document_kind) =
                                         match entry.extension().and_then(|e| e.to_str()) {
                                             Some("ts" | "tsx") => {
@@ -340,7 +339,7 @@ impl McpService {
                     for entry in paths.flatten() {
                         if entry.is_file() {
                             if let Ok(content) = std::fs::read_to_string(&entry) {
-                                let file_path = FilePath::new(entry.to_string_lossy().to_string());
+                                let file_path = FilePath::from_path(&entry);
                                 let (language, document_kind) =
                                     match entry.extension().and_then(|e| e.to_str()) {
                                         Some("ts" | "tsx") => {


### PR DESCRIPTION
## Summary

- Fixed CLI validate command not reporting validation errors from document files
- Root cause: path format mismatch between file registration (raw paths) and lookup (file:// URIs)
- Fix: added `FilePath::from_path()` to canonically convert filesystem paths to file:// URIs

## Changes

- Added `FilePath::from_path()` constructor in `crates/ide/src/types.rs`
- Updated `graphql-cli` to use `FilePath::from_path()` for all file operations
- Updated `graphql-mcp` to use `FilePath::from_path()` for all file operations  
- Added regression test `test_cli_validates_document_files`

## Test Plan

1. Create a test project with a schema requiring non-nullable ID:
   ```graphql
   # schema.graphql
   type Query { user(id: ID!): User }
   type User { id: ID! name: String! }
   ```
2. Create a TypeScript file with a validation error:
   ```typescript
   // query.ts
   const GET_USER = gql`
     query GetUser($id: ID) {
       user(id: $id) { id name }
     }
   `;
   ```
3. Run `graphql validate` - should now report the validation error