### PR TITLE
fix: use prefixItems for tuple validation in JSON Schema Draft 2020-12

### DIFF
--- a/crates/config/schema/graphqlrc.schema.json
+++ b/crates/config/schema/graphqlrc.schema.json
@@ -293,7 +293,7 @@
           "description": "ESLint-style array: [warn, { options }]",
           "minItems": 1,
           "maxItems": 2,
-          "items": [
+          "prefixItems": [
             {
               "$ref": "#/definitions/LintSeverity"
             },
@@ -301,7 +301,8 @@
               "type": "object",
               "description": "Rule-specific options"
             }
-          ]
+          ],
+          "items": false
         },
         {
           "type": "object",


### PR DESCRIPTION
## Summary

- Fixes JSON Schema validation error: "Incorrect type. Expected one of object, boolean"
- The schema declares Draft 2020-12, which requires `prefixItems` for tuple validation instead of array-style `items`

## Changes

- Changed `items: [...]` to `prefixItems: [...]` in `LintRuleConfig` definition
- Added `items: false` to disallow additional array elements beyond the tuple

## Test Plan

1. Open `.graphqlrc.yaml` in VS Code
2. Verify no schema validation errors appear
3. Test that lint rule configs like `[warn, { options }]` still validate correctly