### PR TITLE
Add tsgo-lsp Claude Code plugin for TypeScript diagnostics

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "project-tools",
+  "owner": {
+    "name": "graphql-analyzer"
+  },
+  "metadata": {
+    "description": "Project-local Claude Code plugins for graphql-analyzer development"
+  },
+  "plugins": [
+    {
+      "name": "tsgo-lsp",
+      "source": "./tsgo-lsp",
+      "description": "TypeScript diagnostics and code intelligence via tsgo native compiler LSP"
+    }
+  ]
+}

--- a/.claude/plugins/tsgo-lsp/.claude-plugin/plugin.json
+++ b/.claude/plugins/tsgo-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "tsgo-lsp",
+  "version": "1.0.0",
+  "description": "TypeScript diagnostics and code intelligence via tsgo native compiler LSP"
+}

--- a/.claude/plugins/tsgo-lsp/.lsp.json
+++ b/.claude/plugins/tsgo-lsp/.lsp.json
@@ -1,0 +1,12 @@
+{
+  "tsgo": {
+    "command": "npx",
+    "args": ["tsgo", "--lsp"],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact"
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "project-tools": {
+      "source": {
+        "source": "directory",
+        "path": ".claude/plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "tsgo-lsp@project-tools": true
+  },
   "permissions": {
     "allow": [
       "Bash(cargo clippy:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ node_modules/
 !.claude/hooks/
 !.claude/agents/
 !.claude/skills/
+!.claude/plugins/
 plan-dist-manifest.json


### PR DESCRIPTION
## Summary
- Adds a project-local Claude Code plugin that configures tsgo's native LSP server (`tsgo --lsp`)
- Gives Claude real-time TypeScript diagnostics, hover info, and code navigation while working on this codebase
- Uses the local marketplace pattern so the plugin activates automatically for anyone using Claude Code in this repo

## Details

Plugin structure:
```
.claude/plugins/
├── .claude-plugin/
│   └── marketplace.json          # Local marketplace catalog
└── tsgo-lsp/
    ├── .claude-plugin/
    │   └── plugin.json           # Plugin manifest
    └── .lsp.json                 # LSP server config (npx tsgo --lsp)
```

The `.lsp.json` configures `npx tsgo --lsp` as the language server for `.ts`, `.tsx`, `.js`, and `.jsx` files. The `extraKnownMarketplaces` and `enabledPlugins` entries in `.claude/settings.json` ensure the plugin is discovered and enabled at project scope.

## Test plan
- [ ] Start a fresh Claude Code session in this repo
- [ ] Verify the tsgo-lsp plugin loads (check `/plugin` UI)
- [ ] Edit a `.ts` file and confirm Claude receives TypeScript diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)