### PR TITLE
chore: fix changeset PR links and missing package bumps

### DIFF
--- a/.changeset/add-oneof-schema-builtins.md
+++ b/.changeset/add-oneof-schema-builtins.md
@@ -5,4 +5,4 @@ graphql-analyzer-mcp: patch
 graphql-analyzer-vscode: patch
 ---
 
-Add @oneOf directive to schema builtins so it is recognized in all schemas without being explicitly defined
+Add @oneOf directive to schema builtins so it is recognized in all schemas without being explicitly defined ([#621](https://github.com/trevor-scheer/graphql-analyzer/pull/621))

--- a/.changeset/configurable-client-directives.md
+++ b/.changeset/configurable-client-directives.md
@@ -1,5 +1,7 @@
 ---
 graphql-analyzer-cli: minor
+graphql-analyzer-lsp: minor
+graphql-analyzer-mcp: minor
 graphql-analyzer-vscode: minor
 ---
 

--- a/.changeset/fix-grammar-bodyless-extensions.md
+++ b/.changeset/fix-grammar-bodyless-extensions.md
@@ -2,4 +2,4 @@
 graphql-analyzer-vscode: patch
 ---
 
-Fix TextMate grammar for body-less type extensions (e.g. `extend type User implements Node`) breaking syntax highlighting on subsequent lines
+Fix TextMate grammar for body-less type extensions (e.g. `extend type User implements Node`) breaking syntax highlighting on subsequent lines ([#638](https://github.com/trevor-scheer/graphql-analyzer/pull/638))

--- a/.changeset/fix-vscode-packaging.md
+++ b/.changeset/fix-vscode-packaging.md
@@ -2,4 +2,4 @@
 graphql-analyzer-vscode: patch
 ---
 
-Fix VSIX packaging including entire monorepo due to npm workspace dependency resolution
+Fix VSIX packaging including entire monorepo due to npm workspace dependency resolution ([#638](https://github.com/trevor-scheer/graphql-analyzer/pull/638))

--- a/.changeset/support-relative-server-path.md
+++ b/.changeset/support-relative-server-path.md
@@ -2,4 +2,4 @@
 graphql-analyzer-vscode: patch
 ---
 
-Support relative paths in `graphql-analyzer.server.path` setting, resolved against the workspace folder
+Support relative paths in `graphql-analyzer.server.path` setting, resolved against the workspace folder ([#620](https://github.com/trevor-scheer/graphql-analyzer/pull/620))


### PR DESCRIPTION
## Summary

- Add missing PR links to 4 changesets (`add-oneof-schema-builtins`, `support-relative-server-path`, `fix-grammar-bodyless-extensions`, `fix-vscode-packaging`)
- Add missing `graphql-analyzer-lsp: minor` and `graphql-analyzer-mcp: minor` bumps to `configurable-client-directives` changeset — both packages use `graphql-ide::Analysis` and gain client directive support

## Test plan

- [ ] Verify `knope document-change` still parses all changesets correctly
- [ ] Verify PR links resolve to the correct PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)