### PR TITLE
feat(ide): variable completions after $

### DIFF
--- a/crates/ide/src/completion.rs
+++ b/crates/ide/src/completion.rs
@@ -10,7 +10,8 @@
 
 use crate::helpers::{
     find_argument_context_at_offset, find_block_for_position,
-    find_directive_argument_context_at_offset, format_type_ref, position_to_offset,
+    find_directive_argument_context_at_offset, find_operation_variables_at_offset, format_type_ref,
+    position_to_offset,
 };
 use crate::symbol::{
     find_parent_type_at_offset, find_symbol_at_offset, is_in_selection_set, Symbol,
@@ -59,6 +60,11 @@ pub fn completions(
         try_directive_argument_completions(db, project_files, block_context.tree, offset)
     {
         return Some(items);
+    }
+
+    // Check if cursor follows `$` - offer variable completions
+    if is_after_dollar_sign(block_context.block_source, offset) {
+        return Some(variable_completions(block_context.tree, offset));
     }
 
     // Check if cursor is inside a field's arguments list
@@ -246,6 +252,28 @@ fn is_after_at_sign(source: &str, offset: usize) -> bool {
     source.as_bytes().get(offset - 1) == Some(&b'@')
 }
 
+/// Check if the cursor immediately follows a `$` sign.
+fn is_after_dollar_sign(source: &str, offset: usize) -> bool {
+    if offset == 0 {
+        return false;
+    }
+    source.as_bytes().get(offset - 1) == Some(&b'$')
+}
+
+/// Generate completion items for variables defined on the current operation.
+fn variable_completions(tree: &apollo_parser::SyntaxTree, offset: usize) -> Vec<CompletionItem> {
+    let Some(variables) = find_operation_variables_at_offset(tree, offset) else {
+        return Vec::new();
+    };
+
+    variables
+        .into_iter()
+        .map(|(name, type_str)| {
+            CompletionItem::new(name, CompletionKind::Variable).with_detail(type_str)
+        })
+        .collect()
+}
+
 /// Determine which directive locations are valid at the cursor position.
 fn directive_locations_at_offset(
     tree: &apollo_parser::SyntaxTree,
@@ -261,7 +289,6 @@ fn directive_locations_at_offset(
             cst::Definition::OperationDefinition(op) => {
                 let op_range = op.syntax().text_range();
                 if offset >= op_range.start().into() && offset <= op_range.end().into() {
-                    // Check if inside a selection set (field, fragment spread, inline fragment)
                     if is_in_selection_set(tree, offset) {
                         return vec![
                             DirectiveLocationKind::Field,
@@ -269,7 +296,6 @@ fn directive_locations_at_offset(
                             DirectiveLocationKind::InlineFragment,
                         ];
                     }
-                    // On the operation itself
                     let loc = match op.operation_type() {
                         Some(op_type) if op_type.mutation_token().is_some() => {
                             DirectiveLocationKind::Mutation
@@ -299,7 +325,6 @@ fn directive_locations_at_offset(
         }
     }
 
-    // Fallback: show all executable directives
     vec![
         DirectiveLocationKind::Query,
         DirectiveLocationKind::Mutation,

--- a/crates/ide/src/helpers.rs
+++ b/crates/ide/src/helpers.rs
@@ -802,6 +802,43 @@ pub fn find_directive_argument_context_at_offset(
     None
 }
 
+/// Find variable definitions from the operation that contains the given offset.
+///
+/// Returns variable names and their types for completions.
+pub fn find_operation_variables_at_offset(
+    tree: &apollo_parser::SyntaxTree,
+    byte_offset: usize,
+) -> Option<Vec<(String, String)>> {
+    use apollo_parser::cst::{CstNode, Definition};
+
+    let doc = tree.document();
+    for definition in doc.definitions() {
+        if let Definition::OperationDefinition(op) = definition {
+            let range = op.syntax().text_range();
+            let start: usize = range.start().into();
+            let end: usize = range.end().into();
+            if byte_offset >= start && byte_offset <= end {
+                let mut variables = Vec::new();
+                if let Some(var_defs) = op.variable_definitions() {
+                    for var_def in var_defs.variable_definitions() {
+                        if let Some(variable) = var_def.variable() {
+                            if let Some(name) = variable.name() {
+                                let type_str = var_def
+                                    .ty()
+                                    .map(|t| t.syntax().to_string())
+                                    .unwrap_or_default();
+                                variables.push((name.text().to_string(), type_str));
+                            }
+                        }
+                    }
+                }
+                return Some(variables);
+            }
+        }
+    }
+    None
+}
+
 /// Unwrap a `TypeRef` to get just the base type name (without List or `NonNull` wrappers)
 #[must_use]
 pub fn unwrap_type_to_name(type_ref: &graphql_hir::TypeRef) -> String {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -5273,6 +5273,65 @@ query GetUser {
     }
 
     #[test]
+    fn test_completions_for_variables_after_dollar() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "type Query { user(id: ID!): User } type User { id: ID! name: String! }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        // Cursor right after $: user(id: $|)
+        let (graphql, pos) = extract_cursor(
+            r#"
+query GetUser($userId: ID!, $includeEmail: Boolean!) {
+    user(id: $*) {
+        name
+    }
+}
+"#,
+        );
+        let path = FilePath::new("file:///test.graphql");
+        host.add_file(&path, &graphql, Language::GraphQL, DocumentKind::Executable);
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let items = snapshot.completions(&path, pos).unwrap_or_default();
+        let labels: Vec<_> = items.iter().map(|i| i.label.as_str()).collect();
+
+        assert!(
+            labels.contains(&"userId"),
+            "Should suggest 'userId' variable: got {labels:?}"
+        );
+        assert!(
+            labels.contains(&"includeEmail"),
+            "Should suggest 'includeEmail' variable: got {labels:?}"
+        );
+        assert_eq!(
+            items.len(),
+            2,
+            "Should suggest exactly 2 variables: got {labels:?}"
+        );
+
+        // All completions should be Variable kind
+        for item in &items {
+            assert_eq!(
+                item.kind,
+                CompletionKind::Variable,
+                "Expected Variable completion kind for '{}', got {:?}",
+                item.label,
+                item.kind
+            );
+        }
+
+        // Check type details
+        let user_id = items.iter().find(|i| i.label == "userId").unwrap();
+        assert_eq!(user_id.detail, Some("ID!".to_string()));
+    }
+
+    #[test]
     fn test_completions_for_field_arguments_on_nested_field() {
         let schema = r#"
 type Query { user: User }

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -1700,6 +1700,7 @@ impl LanguageServer for GraphQLLanguageServer {
                         "{".to_string(),
                         "@".to_string(),
                         "(".to_string(),
+                        "$".to_string(),
                     ]),
                     ..Default::default()
                 }),


### PR DESCRIPTION
## Summary
- Add autocomplete for variables when typing after `$`
- Suggest variables defined in the enclosing operation's variable definitions
- Add `$` as a completion trigger character

## Test plan
- [x] `test_completions_for_variables_after_dollar` - verifies variable suggestions from operation definition

> **Stack**: 4/7 - depends on #675

https://claude.ai/code/session_01RC3GMp8EysB2auvTRZmrSB