### PR TITLE
docs: decompose CLAUDE.md into directory-level files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # GraphQL Analyzer - Claude Guide
 
-**Last Updated**: February 2026
+**Last Updated**: March 2026
 
 Context and guidance for Claude when working with this codebase.
 
@@ -28,7 +28,7 @@ Context and guidance for Claude when working with this codebase.
 | Where to add a lint rule?  | `crates/linter/src/rules/` - use `/adding-lint-rules` skill |
 | Where to add validation?   | `crates/analysis/src/`                                      |
 | Where's schema loading?    | `crates/introspect/` (remote), `crates/config/` (local)     |
-| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`    |
+| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`   |
 
 ---
 
@@ -42,21 +42,7 @@ A GraphQL LSP implementation in Rust providing IDE features for `.graphql` files
 - Project-wide analysis with proper fragment resolution across files
 - Remote schema support via introspection
 
-### Protected Core Features
-
-These features must NOT be removed or degraded:
-
-| Feature                       | Why Critical                      | What Enables It                                        |
-| ----------------------------- | --------------------------------- | ------------------------------------------------------ |
-| **Embedded GraphQL in TS/JS** | Most users write queries in TS/JS | `documentSelector` includes TS/JS in VS Code extension |
-| **Real-time diagnostics**     | Users expect immediate feedback   | LSP `textDocument/didChange` notifications             |
-| **Project-wide fragments**    | Fragments span many files         | `all_fragments()` indexes entire project               |
-
-**Solve performance problems without removing features.** Use filtering, lazy evaluation, debouncing, or configuration options instead.
-
----
-
-## Architecture
+### Architecture
 
 ```
 graphql-lsp / graphql-cli / graphql-mcp
@@ -73,66 +59,7 @@ graphql-db (Salsa database, FileId, memoization)
 ```
 
 See `DEVELOPMENT.md` for project structure and detailed architecture.
-
----
-
-## Key Concepts
-
-### GraphQL Document Model
-
-**Fragment scope is project-wide**, not file-scoped:
-
-- Operations can reference fragments in other files
-- Fragment spreads can reference other fragments (transitive dependencies)
-- Fragment and operation names must be unique across the entire project
-
-**When validating operations**, you MUST:
-
-1. Include direct fragment dependencies
-2. Recurse through fragment dependencies
-3. Handle circular references
-4. Validate against schema for all fragments in the chain
-
-### Cache Invariants
-
-The Salsa architecture relies on these invariants for incremental computation:
-
-| Invariant                     | Meaning                                                       |
-| ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries      |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
-| **Index stability**           | Global indexes stay cached when edits don't change names      |
-| **Lazy evaluation**           | Body queries only run when results are needed                 |
-
-**Structure** = identity (names, types). **Body** = content (selection sets, directives).
-
-### VS Code Extension Architecture
-
-The extension has three separate systems - don't confuse them:
-
-| System             | Purpose                                     | Scope                                            |
-| ------------------ | ------------------------------------------- | ------------------------------------------------ |
-| `documentSelector` | LSP features (diagnostics, hover, goto def) | Controls which files get IDE features            |
-| Grammar injection  | Syntax highlighting only                    | Visual coloring, no semantic understanding       |
-| File watcher       | Disk events only                            | File create/delete/rename, NOT real-time editing |
-
-**Common mistake:** Thinking grammar injection provides embedded GraphQL support. It only provides colors. The `documentSelector` MUST include TS/JS for actual LSP features.
-
----
-
-## Configuration
-
-```yaml
-# .graphqlrc.yaml
-schema: "schema.graphql"
-documents: "src/**/*.{graphql,ts,tsx}"
-
-# Lint config uses extensions.lint with camelCase rule names
-extensions:
-  lint: recommended # Happy path - just use preset
-```
-
-See `crates/config/README.md` for multi-project and advanced configuration.
+See `crates/CLAUDE.md` for crate architecture details, key concepts, and cache invariants.
 
 ---
 
@@ -282,7 +209,3 @@ SME agents in `.claude/agents/` provide domain guidance. Use `/sme-consultation`
 | `/add-ide-feature`   | LSP features (hover, goto def)     |
 | `/debug-lsp`         | Troubleshooting LSP issues         |
 | `/review-pr`         | Reviewing pull requests            |
-
----
-
-**End of Guide**

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,0 +1,88 @@
+# Crates - Claude Guide
+
+Architecture, key concepts, and invariants for the Rust crate workspace.
+
+---
+
+## Crate Dependency Graph
+
+```
+graphql-lsp / graphql-cli / graphql-mcp    (entrypoints)
+    ↓
+graphql-ide          (Editor API, POD types)
+    ↓
+graphql-analysis     (Validation + Linting)
+    ↓
+graphql-hir          (Semantic layer, structure/body separation)
+    ↓
+graphql-syntax       (Parsing, TS/JS extraction)
+    ↓
+graphql-db           (Salsa database, FileId, memoization)
+```
+
+### Crate Purposes
+
+| Crate         | Purpose                                    |
+| ------------- | ------------------------------------------ |
+| `base-db`     | Salsa database foundation, FileId          |
+| `syntax`      | GraphQL parser, TS/JS extraction           |
+| `hir`         | Semantic layer, structure/body separation  |
+| `analysis`    | Validation and diagnostics                 |
+| `ide-db`      | IDE-specific database queries              |
+| `ide`         | IDE features (hover, completion, goto-def) |
+| `linter`      | Lint rules and configuration               |
+| `lsp`         | Language Server Protocol implementation    |
+| `cli`         | Command-line interface                     |
+| `mcp`         | Model Context Protocol server              |
+| `config`      | Project configuration (.graphqlrc.yaml)    |
+| `introspect`  | Remote schema introspection via HTTP       |
+| `extract`     | GraphQL extraction from TS/JS files        |
+| `apollo-ext`  | Apollo-specific extensions                 |
+| `types`       | Shared type definitions                    |
+| `test-utils`  | Testing utilities and fixtures             |
+
+---
+
+## GraphQL Document Model
+
+**Fragment scope is project-wide**, not file-scoped:
+
+- Operations can reference fragments in other files
+- Fragment spreads can reference other fragments (transitive dependencies)
+- Fragment and operation names must be unique across the entire project
+
+**When validating operations**, you MUST:
+
+1. Include direct fragment dependencies
+2. Recurse through fragment dependencies
+3. Handle circular references
+4. Validate against schema for all fragments in the chain
+
+---
+
+## Cache Invariants
+
+The Salsa architecture relies on these invariants for incremental computation:
+
+| Invariant                     | Meaning                                                       |
+| ----------------------------- | ------------------------------------------------------------- |
+| **Structure/Body separation** | Editing body content never invalidates structure queries       |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B  |
+| **Index stability**           | Global indexes stay cached when edits don't change names       |
+| **Lazy evaluation**           | Body queries only run when results are needed                  |
+
+**Structure** = identity (names, types). **Body** = content (selection sets, directives).
+
+---
+
+## Protected Core Features
+
+These features must NOT be removed or degraded:
+
+| Feature                       | Why Critical                      | What Enables It                                        |
+| ----------------------------- | --------------------------------- | ------------------------------------------------------ |
+| **Embedded GraphQL in TS/JS** | Most users write queries in TS/JS | `documentSelector` includes TS/JS in VS Code extension |
+| **Real-time diagnostics**     | Users expect immediate feedback   | LSP `textDocument/didChange` notifications             |
+| **Project-wide fragments**    | Fragments span many files         | `all_fragments()` indexes entire project               |
+
+**Solve performance problems without removing features.** Use filtering, lazy evaluation, debouncing, or configuration options instead.

--- a/crates/analysis/CLAUDE.md
+++ b/crates/analysis/CLAUDE.md
@@ -1,0 +1,24 @@
+# Analysis Crate - Claude Guide
+
+Guidance for working with the validation and diagnostics engine.
+
+---
+
+## Validation Requirements
+
+When validating operations, you MUST:
+
+1. Include direct fragment dependencies
+2. Recurse through fragment dependencies
+3. Handle circular references
+4. Validate against schema for all fragments in the chain
+
+Fragment scope is **project-wide** - operations can reference fragments defined in other files.
+
+---
+
+## Adding Validation
+
+New validation logic goes in `src/`. Follow existing patterns for producing diagnostics.
+
+See the `graphql.md` SME agent (`.claude/agents/graphql.md`) for GraphQL spec validation rules.

--- a/crates/config/CLAUDE.md
+++ b/crates/config/CLAUDE.md
@@ -1,0 +1,27 @@
+# Config Crate - Claude Guide
+
+Guidance for working with project configuration.
+
+---
+
+## Configuration Format
+
+```yaml
+# .graphqlrc.yaml
+schema: "schema.graphql"
+documents: "src/**/*.{graphql,ts,tsx}"
+
+extensions:
+  lint: recommended
+```
+
+See `README.md` in this crate for multi-project and advanced configuration.
+
+---
+
+## Schema Loading
+
+| Source | Crate          |
+| ------ | -------------- |
+| Local  | `config`       |
+| Remote | `introspect`   |

--- a/crates/linter/CLAUDE.md
+++ b/crates/linter/CLAUDE.md
@@ -1,0 +1,31 @@
+# Linter Crate - Claude Guide
+
+Guidance for working with the lint rules system.
+
+---
+
+## Adding Lint Rules
+
+Use the `/adding-lint-rules` skill for the full guided workflow.
+
+Rules live in `src/rules/`. Each rule is a separate module.
+
+---
+
+## Configuration
+
+Lint config uses `extensions.lint` in `.graphqlrc.yaml` with camelCase rule names:
+
+```yaml
+extensions:
+  lint: recommended # Happy path - just use preset
+```
+
+Or configure individual rules:
+
+```yaml
+extensions:
+  lint:
+    noAnonymousOperations: error
+    noDeprecated: warn
+```

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -1,0 +1,36 @@
+# VS Code Extension - Claude Guide
+
+Architecture and guidance for the VS Code extension.
+
+---
+
+## Extension Architecture
+
+The extension has three separate systems - don't confuse them:
+
+| System             | Purpose                                     | Scope                                            |
+| ------------------ | ------------------------------------------- | ------------------------------------------------ |
+| `documentSelector` | LSP features (diagnostics, hover, goto def) | Controls which files get IDE features            |
+| Grammar injection  | Syntax highlighting only                    | Visual coloring, no semantic understanding       |
+| File watcher       | Disk events only                            | File create/delete/rename, NOT real-time editing |
+
+**Common mistake:** Thinking grammar injection provides embedded GraphQL support. It only provides colors. The `documentSelector` MUST include TS/JS for actual LSP features.
+
+---
+
+## Protected Features
+
+- **NEVER** remove TS/JS from `documentSelector` - most users write queries in TS/JS files
+- **NEVER** solve performance problems by removing language support from the selector
+
+---
+
+## Key Files
+
+| File                  | Purpose                      |
+| --------------------- | ---------------------------- |
+| `src/extension.ts`    | Extension entry point        |
+| `src/binaryManager.ts`| LSP binary lifecycle         |
+| `syntaxes/`           | TextMate grammars            |
+| `package.json`        | Extension manifest           |
+| `e2e/`                | Playwright end-to-end tests  |


### PR DESCRIPTION
## Summary

Decompose the monolithic root `.claude/CLAUDE.md` into focused files at each relevant directory level so Claude picks up only context relevant to the directory being worked in.

## Changes

- Slim down `.claude/CLAUDE.md` to retain only global concerns: project overview, high-level architecture, Claude behavioral instructions, skills/agents references, and troubleshooting
- Add `crates/CLAUDE.md` with crate architecture, dependency graph, cache invariants, GraphQL document model, and protected core features
- Add `editors/vscode/CLAUDE.md` with extension architecture (3 systems), common mistakes, and key files
- Add `crates/linter/CLAUDE.md` with lint rule location and configuration guidance
- Add `crates/analysis/CLAUDE.md` with validation requirements and fragment chain rules
- Add `crates/config/CLAUDE.md` with configuration format and schema loading sources

## Consulted SME Agents

N/A

## Manual Testing Plan

N/A - documentation only change

## Related Issues