### PR TITLE
Improve Claude config: path-scoped rules, new hooks, enhanced frontmatter

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,14 +12,16 @@ Context and guidance for Claude when working with this codebase.
 
 ### Critical File Locations
 
-| Location          | Purpose                         |
-| ----------------- | ------------------------------- |
-| `.graphqlrc.yaml` | Project configuration           |
-| `crates/*/src/`   | Crate sources                   |
-| `editors/vscode/` | VS Code extension               |
-| `.claude/agents/` | SME agents for consultation     |
-| `.claude/skills/` | Workflow guidance               |
-| `DEVELOPMENT.md`  | Build, test, and debug commands |
+| Location          | Purpose                              |
+| ----------------- | ------------------------------------ |
+| `.graphqlrc.yaml` | Project configuration                |
+| `crates/*/src/`   | Crate sources                        |
+| `editors/vscode/` | VS Code extension                    |
+| `.claude/agents/` | SME agents for consultation          |
+| `.claude/skills/` | Workflow guidance                    |
+| `.claude/rules/`  | Path-scoped context rules            |
+| `.claude/hooks/`  | Session, edit, and commit automation |
+| `DEVELOPMENT.md`  | Build, test, and debug commands      |
 
 ### Quick Answers
 
@@ -77,27 +79,11 @@ For build, test, and debug commands, see `DEVELOPMENT.md`.
 
 ---
 
-## Troubleshooting
-
-### "No project found" Error
-
-Ensure `.graphqlrc.yaml` exists. For multi-project configs, use `--project` flag.
-
-### LSP Not Responding
-
-1. Rebuild: `cargo build`
-2. Check VS Code logs: View → Output → GraphQL
-3. Enable debug logging: `RUST_LOG=debug`
-
-### Fragment Not Found Errors
-
-- Ensure fragment file is in `document_files()`
-- Check `all_fragments()` includes the file
-- Verify fragment name uniqueness
-
----
-
 ## Instructions for Claude
+
+> Path-scoped rules in `.claude/rules/` provide context-specific guidance
+> (Salsa patterns, LSP conventions, testing, linter patterns, etc.) that loads
+> automatically when working in relevant directories.
 
 ### Pre-Task Skill Check (REQUIRED)
 
@@ -138,12 +124,6 @@ Fix argument parsing bug ([#123](https://github.com/trevor-scheer/graphql-analyz
 - Features, bug fixes, breaking changes → YES
 - Internal refactoring, CI changes, test-only → NO
 
-### Code Style
-
-- No emoji in code or commits
-- Follow Rust conventions: `snake_case` functions, `CamelCase` types
-- Comments explain **why**, not **what**
-
 ### GitHub CLI Usage
 
 Always use `--repo` flag (git remote uses a local proxy):
@@ -155,12 +135,14 @@ gh issue view 123 --repo trevor-scheer/graphql-analyzer
 
 ### Things to Never Do
 
+> Some of these are enforced by hooks (PermissionRequest guard) and deny rules.
+
 - Don't remove TS/JS from VS Code `documentSelector`
 - Don't solve performance problems by removing features
 - Don't mention CI status in PR descriptions
 - Don't add features not requested
 - Don't create markdown files unless asked
-- Don't manually edit `.github/workflows/release.yml`
+- Don't manually edit `.github/workflows/release.yml` (enforced by deny rule + hook)
 
 ### rust-analyzer LSP
 
@@ -186,19 +168,27 @@ The rust-analyzer LSP plugin is enabled for this project. Use it proactively:
 ## Expert Agents
 
 SME agents in `.claude/agents/` provide domain guidance. Use `/sme-consultation` skill.
+All agents have YAML frontmatter configuring model, tools, and turn limits.
 
-| Agent                 | Domain                                   |
-| --------------------- | ---------------------------------------- |
-| `graphql.md`          | GraphQL spec, validation rules           |
-| `rust-analyzer.md`    | Query-based architecture, Salsa patterns |
-| `salsa.md`            | Salsa framework, database design         |
-| `lsp.md`              | LSP specification, protocol messages     |
-| `apollo-rs.md`        | apollo-parser, apollo-compiler           |
-| `vscode-extension.md` | Extension development                    |
+| Agent                 | Domain                                        |
+| --------------------- | --------------------------------------------- |
+| `graphql.md`          | GraphQL spec, validation rules                |
+| `rust-analyzer.md`    | Query-based architecture, Salsa patterns      |
+| `salsa.md`            | Salsa framework, database design              |
+| `lsp.md`              | LSP specification, protocol messages          |
+| `apollo-rs.md`        | apollo-parser, apollo-compiler                |
+| `rust.md`             | Rust language, ownership, idioms              |
+| `apollo-client.md`    | Apollo Client patterns, fragment organization |
+| `graphql-cli.md`      | CLI tools, graphql-config, ecosystem          |
+| `graphiql.md`         | GraphiQL IDE, graphql-language-service        |
+| `vscode-extension.md` | VS Code extension development                 |
+| `playwright.md`       | E2E testing, Playwright, Electron             |
 
 ---
 
 ## Skills
+
+Skills have YAML frontmatter with `allowed-tools` (auto-permissions) and `argument-hint` (autocomplete).
 
 | Skill                | When to Use                        |
 | -------------------- | ---------------------------------- |
@@ -209,3 +199,5 @@ SME agents in `.claude/agents/` provide domain guidance. Use `/sme-consultation`
 | `/add-ide-feature`   | LSP features (hover, goto def)     |
 | `/debug-lsp`         | Troubleshooting LSP issues         |
 | `/review-pr`         | Reviewing pull requests            |
+| `/audit-tests`       | Self-review test organization      |
+| `/testing-patterns`  | Test infrastructure reference      |

--- a/.claude/agents/apollo-client.md
+++ b/.claude/agents/apollo-client.md
@@ -1,3 +1,11 @@
+---
+name: apollo-client
+description: Apollo Client GraphQL patterns, fragment organization, template literals, import patterns
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Apollo Client Expert
 
 You are a Subject Matter Expert (SME) on how GraphQL is written in Apollo Client projects. Your role is to ensure our language tooling correctly handles the full diversity of patterns found in real Apollo Client codebases. Your focus is:

--- a/.claude/agents/apollo-rs.md
+++ b/.claude/agents/apollo-rs.md
@@ -1,3 +1,11 @@
+---
+name: apollo-rs
+description: apollo-parser and apollo-compiler APIs, CST/AST, error-tolerant parsing, validation
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Apollo-rs Expert
 
 You are a Subject Matter Expert (SME) on Apollo-rs, the Rust GraphQL tooling ecosystem used by this project. You are highly opinionated about parser design and error-tolerant tooling. Your role is to:

--- a/.claude/agents/graphiql.md
+++ b/.claude/agents/graphiql.md
@@ -1,3 +1,11 @@
+---
+name: graphiql
+description: GraphiQL IDE features, graphql-language-service, IDE UX patterns
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # GraphiQL Expert
 
 You are a Subject Matter Expert (SME) on GraphiQL, the in-browser GraphQL IDE. You are highly opinionated about developer experience and IDE features. Your role is to:

--- a/.claude/agents/graphql-cli.md
+++ b/.claude/agents/graphql-cli.md
@@ -1,3 +1,11 @@
+---
+name: graphql-cli
+description: GraphQL CLI tools, graphql-config standard, codegen, ecosystem integration
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # GraphQL CLI Expert
 
 You are a Subject Matter Expert (SME) on GraphQL CLI tools and ecosystem. You are highly opinionated about CLI design and developer workflows. Your role is to:

--- a/.claude/agents/graphql.md
+++ b/.claude/agents/graphql.md
@@ -1,3 +1,11 @@
+---
+name: graphql-spec
+description: GraphQL specification, validation rules, type system, and language semantics
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # GraphQL Specification Expert
 
 You are a Subject Matter Expert (SME) on the GraphQL specification and language. You are highly opinionated about correctness and best practices. Your role is to:

--- a/.claude/agents/lsp.md
+++ b/.claude/agents/lsp.md
@@ -1,3 +1,11 @@
+---
+name: lsp
+description: LSP specification, protocol messages, document sync, diagnostics, and server capabilities
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Language Server Protocol Expert
 
 You are a Subject Matter Expert (SME) on the Language Server Protocol (LSP). You are highly opinionated about protocol correctness and user experience. Your role is to:

--- a/.claude/agents/playwright.md
+++ b/.claude/agents/playwright.md
@@ -1,3 +1,11 @@
+---
+name: playwright
+description: Playwright testing, Electron/VS Code e2e tests, locators, fixtures, CI configuration
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Playwright Testing Expert
 
 You are a Subject Matter Expert (SME) on Playwright testing, with deep expertise in testing Electron applications like VSCode extensions. You are highly opinionated about test reliability and maintainability. Your role is to:

--- a/.claude/agents/rust-analyzer.md
+++ b/.claude/agents/rust-analyzer.md
@@ -1,3 +1,11 @@
+---
+name: rust-analyzer
+description: Query-based incremental architecture, AnalysisHost pattern, cache invariants, HIR design
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # rust-analyzer Expert
 
 You are a Subject Matter Expert (SME) on rust-analyzer, the Rust language server. This project draws significant architectural inspiration from rust-analyzer. You are highly opinionated about query-based, incremental architecture. Your role is to:

--- a/.claude/agents/rust.md
+++ b/.claude/agents/rust.md
@@ -1,3 +1,11 @@
+---
+name: rust
+description: Rust language, ownership, lifetimes, concurrency, error handling, idiomatic patterns
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Rust Expert
 
 You are a Subject Matter Expert (SME) on the Rust programming language. You are highly opinionated about idiomatic Rust and correctness. Your role is to:

--- a/.claude/agents/salsa.md
+++ b/.claude/agents/salsa.md
@@ -1,3 +1,11 @@
+---
+name: salsa
+description: Salsa incremental computation framework, database design, query patterns, snapshot isolation
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # Salsa Expert
 
 You are a Subject Matter Expert (SME) on Salsa, the incremental computation framework used by rust-analyzer and this GraphQL LSP. You are highly opinionated about correct usage of Salsa's APIs and patterns. Your role is to:

--- a/.claude/agents/vscode-extension.md
+++ b/.claude/agents/vscode-extension.md
@@ -1,3 +1,11 @@
+---
+name: vscode-extension
+description: VS Code extension development, activation, language server client integration
+model: sonnet
+tools: Read, Grep, Glob, WebSearch, WebFetch
+maxTurns: 10
+---
+
 # VSCode Extension Expert
 
 You are a Subject Matter Expert (SME) on VSCode extension development. You are highly opinionated about extension quality and user experience. Your role is to:

--- a/.claude/hooks/permission-guard.sh
+++ b/.claude/hooks/permission-guard.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# PermissionRequest hook: enforces project guardrails programmatically.
+# Denies edits to protected files and blocks dangerous operations.
+
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+tool_input=$(echo "$input" | jq -r '.tool_input // empty' 2>/dev/null || true)
+
+# Guard: never edit release.yml
+if [[ "$tool_name" == "Edit" || "$tool_name" == "Write" ]]; then
+  file_path=$(echo "$tool_input" | jq -r '.file_path // empty' 2>/dev/null || true)
+  if [[ "$file_path" == *".github/workflows/release.yml"* ]]; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"deny","permissionDecisionReason":"release.yml is auto-managed. Do not edit manually."}}'
+    exit 0
+  fi
+fi
+
+# Guard: never force-push to main/master
+if [[ "$tool_name" == "Bash" ]]; then
+  command=$(echo "$tool_input" | jq -r '.command // empty' 2>/dev/null || true)
+  if echo "$command" | grep -qP 'git\s+push\s+.*--force.*\s+(main|master)'; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"deny","permissionDecisionReason":"Force-pushing to main/master is not allowed."}}'
+    exit 0
+  fi
+fi

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# PreCompact hook: injects critical context that must survive compaction.
+# Ensures important project state is preserved when the context window is compressed.
+
+branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+# Detect which crates have been modified in this session
+changed_crates=$(git diff --name-only HEAD 2>/dev/null | grep -oP 'crates/[^/]+' | sort -u | tr '\n' ', ' || echo "none")
+
+cat <<EOF
+{"additionalContext": "PRESERVE: Working on branch '$branch'. Modified crates: ${changed_crates:-none}. Key invariants: structure/body separation, file isolation, index stability. Use /skills for guided workflows. Always use --repo flag with gh CLI."}
+EOF

--- a/.claude/hooks/prompt-context.sh
+++ b/.claude/hooks/prompt-context.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# UserPromptSubmit hook: injects branch context and issue details into every prompt.
+# Outputs JSON with additionalContext that Claude sees before processing the prompt.
+
+input=$(cat)
+
+context_parts=()
+
+# Add current branch info
+branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+if [[ "$branch" != "main" && "$branch" != "master" && "$branch" != "unknown" ]]; then
+  commit_count=$(git rev-list origin/main..HEAD --count 2>/dev/null || echo "0")
+  context_parts+=("Branch: $branch ($commit_count commits ahead of main)")
+fi
+
+# Detect issue references in the prompt (e.g., #123, issue 123)
+prompt_text=$(echo "$input" | jq -r '.prompt // empty' 2>/dev/null || true)
+issue_numbers=$(echo "$prompt_text" | grep -oP '(?:#|issue\s+)\K\d+' 2>/dev/null || true)
+
+for issue_num in $issue_numbers; do
+  issue_info=$(gh issue view "$issue_num" --repo trevor-scheer/graphql-analyzer --json title,body,labels --jq '"\(.title) [labels: \(.labels | map(.name) | join(", "))]"' 2>/dev/null || true)
+  if [[ -n "$issue_info" ]]; then
+    context_parts+=("Issue #$issue_num: $issue_info")
+  fi
+done
+
+# Output additional context if we have any
+if [[ ${#context_parts[@]} -gt 0 ]]; then
+  context=$(printf '%s\n' "${context_parts[@]}")
+  jq -n --arg ctx "$context" '{"additionalContext": $ctx}'
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -32,6 +32,11 @@ else
     export PATH="$LOCAL_BIN:$PATH"
   fi
 
+  # Persist PATH for all subsequent Bash calls in this session
+  if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+    echo "PATH=$LOCAL_BIN:\$PATH" >> "$CLAUDE_ENV_FILE"
+  fi
+
   echo "✓ gh CLI installed successfully: $($LOCAL_BIN/gh --version | head -1)"
 fi
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,13 @@
+---
+description: Global Rust code style conventions
+globs:
+  - "**/*.rs"
+---
+
+# Code Style
+
+- No emoji in code or commits
+- Follow Rust conventions: `snake_case` functions, `CamelCase` types
+- Comments explain **why**, not **what**
+- No unnecessary `pub` visibility - use the minimum required
+- Prefer `impl` blocks near the struct definition

--- a/.claude/rules/graphql-documents.md
+++ b/.claude/rules/graphql-documents.md
@@ -1,0 +1,28 @@
+---
+description: GraphQL document model - fragment scope and validation rules
+globs:
+  - "crates/graphql-hir/**"
+  - "crates/graphql-analysis/**"
+  - "crates/graphql-ide/**"
+---
+
+# GraphQL Document Model
+
+Fragment scope is **project-wide**, not file-scoped:
+
+- Operations can reference fragments in other files
+- Fragment spreads can reference other fragments (transitive dependencies)
+- Fragment and operation names must be unique across the entire project
+
+When validating operations, you MUST:
+
+1. Include direct fragment dependencies
+2. Recurse through fragment dependencies
+3. Handle circular references
+4. Validate against schema for all fragments in the chain
+
+## Common Pitfall: Fragment Not Found
+
+- Ensure fragment file is in `document_files()`
+- Check `all_fragments()` includes the file
+- Verify fragment name uniqueness

--- a/.claude/rules/linter-rules.md
+++ b/.claude/rules/linter-rules.md
@@ -1,0 +1,13 @@
+---
+description: Lint rule implementation patterns
+globs:
+  - "crates/graphql-linter/**"
+---
+
+# Lint Rule Patterns
+
+- Each rule goes in its own file under `crates/graphql-linter/src/rules/`
+- Use the `/adding-lint-rules` skill for the full implementation workflow
+- Rules must have a unique name, severity, and documentation
+- Always add both positive (should lint) and negative (should not lint) test cases
+- Rules operate on the HIR, not raw syntax

--- a/.claude/rules/lsp-handlers.md
+++ b/.claude/rules/lsp-handlers.md
@@ -1,0 +1,14 @@
+---
+description: LSP handler conventions and protocol compliance
+globs:
+  - "crates/graphql-lsp/**"
+---
+
+# LSP Handler Conventions
+
+- All request handlers go in `crates/graphql-lsp/src/handlers/`
+- Register new capabilities in the server initialization
+- Every handler must support cancellation via the LSP cancellation token
+- Return `None`/empty results rather than errors for graceful degradation
+- Prefer incremental document sync over full sync
+- Never block the main message loop with expensive computation

--- a/.claude/rules/protected-files.md
+++ b/.claude/rules/protected-files.md
@@ -1,0 +1,10 @@
+---
+description: Files and patterns that must never be modified without explicit permission
+globs:
+  - ".github/workflows/release.yml"
+---
+
+# Protected Files
+
+This file is auto-managed. Do NOT edit `.github/workflows/release.yml` manually.
+If release workflow changes are needed, discuss with the maintainer first.

--- a/.claude/rules/salsa-queries.md
+++ b/.claude/rules/salsa-queries.md
@@ -1,0 +1,28 @@
+---
+description: Salsa query patterns and cache invariants for the database layer
+globs:
+  - "crates/graphql-db/**"
+  - "crates/graphql-hir/**"
+---
+
+# Salsa Query Patterns
+
+## Cache Invariants
+
+These invariants MUST be preserved for incremental computation to work:
+
+| Invariant                     | Meaning                                                       |
+| ----------------------------- | ------------------------------------------------------------- |
+| **Structure/Body separation** | Editing body content never invalidates structure queries      |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
+| **Index stability**           | Global indexes stay cached when edits don't change names      |
+| **Lazy evaluation**           | Body queries only run when results are needed                 |
+
+**Structure** = identity (names, types). **Body** = content (selection sets, directives).
+
+## Query Design Rules
+
+- Never store `FileId` in a query result if the query doesn't depend on that file
+- Use `#[salsa::tracked]` for computed values that should be memoized
+- Use `#[salsa::input]` only for external data (file contents, config)
+- Prefer fine-grained queries over coarse ones to maximize cache reuse

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,17 @@
+---
+description: Test organization and TestDatabase patterns
+globs:
+  - "**/tests/**"
+  - "**/*_test.rs"
+  - "crates/graphql-test-utils/**"
+---
+
+# Testing Conventions
+
+- Use the `/testing-patterns` skill for detailed guidance
+- Unit tests go in the same file as the code (`#[cfg(test)]` module)
+- Integration tests go in `crates/<name>/tests/`
+- Use `TestDatabase` from `graphql-test-utils` for tests that need Salsa queries
+- Test names should describe the scenario: `test_fragment_spread_on_union_type`
+- Always test both the happy path and error cases
+- Run `/audit-tests` after writing new tests to self-review

--- a/.claude/rules/vscode-extension.md
+++ b/.claude/rules/vscode-extension.md
@@ -1,0 +1,12 @@
+---
+description: VS Code extension development rules
+globs:
+  - "editors/vscode/**"
+---
+
+# VS Code Extension Rules
+
+- NEVER remove TypeScript or JavaScript from the `documentSelector` - most users write GraphQL in TS/JS files
+- Test extension changes with the Playwright e2e test suite
+- Keep activation events minimal - lazy load where possible
+- All user-facing strings must be localizable

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,12 @@
       "Bash(git ls-files:*)",
       "Bash(git remote:*)",
       "Bash(git fetch:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh api:*)",
+      "Bash(knope:*)",
+      "Bash(npm ci:*)",
+      "Bash(npm run:*)",
       "Bash(ls:*)",
       "Bash(tree:*)",
       "Bash(find:*)",
@@ -41,7 +47,8 @@
       "mcp__ide__getHoverInfo",
       "mcp__ide__getDefinition",
       "mcp__ide__getReferences"
-    ]
+    ],
+    "deny": ["Edit(.github/workflows/release.yml)"]
   },
   "hooks": {
     "SessionStart": [
@@ -50,6 +57,17 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/prompt-context.sh",
+            "timeout": 15
           }
         ]
       }
@@ -65,6 +83,17 @@
         ]
       }
     ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/permission-guard.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -72,6 +101,17 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-format.sh"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.sh",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/skills/add-ide-feature/SKILL.md
+++ b/.claude/skills/add-ide-feature/SKILL.md
@@ -2,6 +2,8 @@
 name: add-ide-feature
 description: Add new IDE/LSP features like hover, goto definition, find references, or completion. Use when implementing editor features, LSP handlers, or IDE functionality.
 user-invocable: true
+argument-hint: "[feature name, e.g. hover, goto-def, completion]"
+allowed-tools: Bash(cargo test *), Bash(cargo clippy *), Bash(cargo fmt *), Bash(cargo check *), Read, Edit, Write, Grep, Glob
 ---
 
 # Adding IDE Features

--- a/.claude/skills/adding-lint-rules/SKILL.md
+++ b/.claude/skills/adding-lint-rules/SKILL.md
@@ -2,6 +2,8 @@
 name: adding-lint-rules
 description: Add new GraphQL lint rules following project patterns. Use when implementing a lint rule, adding validation logic, or extending the linter with new checks.
 user-invocable: true
+argument-hint: "[rule name or description]"
+allowed-tools: Bash(cargo test *), Bash(cargo clippy *), Bash(cargo fmt *), Bash(cargo check *), Read, Edit, Write, Grep, Glob
 ---
 
 # Adding Lint Rules

--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-tests
 description: Audit test organization and patterns. Use PROACTIVELY after writing new tests to self-review, or when reviewing test changes in PRs. Checks unit vs integration test placement, TestDatabase patterns, and caching verification.
 user-invocable: true
+allowed-tools: Bash(cargo test *), Read, Grep, Glob
 ---
 
 # Audit Tests

--- a/.claude/skills/bug-fix-workflow/SKILL.md
+++ b/.claude/skills/bug-fix-workflow/SKILL.md
@@ -2,6 +2,8 @@
 name: bug-fix-workflow
 description: Fix bugs using the two-commit structure with failing test first. Use when fixing bugs, addressing issues, or correcting incorrect behavior.
 user-invocable: true
+argument-hint: "[issue number or bug description]"
+allowed-tools: Bash(cargo test *), Bash(cargo clippy *), Bash(cargo fmt *), Bash(cargo check *), Bash(git add *), Bash(git commit *), Read, Edit, Write, Grep, Glob
 ---
 
 # Bug Fix Workflow

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: create-pr
 description: Create pull requests following project standards. Use when opening a PR, preparing changes for review, or running gh pr create.
 user-invocable: true
+allowed-tools: Bash(gh *), Bash(git *), Bash(cargo fmt *), Bash(cargo clippy *), Bash(cargo test *), Bash(knope *), Read, Edit, Write, Grep, Glob
 ---
 
 # Creating Pull Requests

--- a/.claude/skills/debug-lsp/SKILL.md
+++ b/.claude/skills/debug-lsp/SKILL.md
@@ -2,6 +2,8 @@
 name: debug-lsp
 description: Debug LSP server issues including hangs, incorrect responses, performance problems, or crashes. Use when troubleshooting the language server.
 user-invocable: true
+argument-hint: "[symptom description]"
+allowed-tools: Bash(cargo build *), Bash(cargo test *), Bash(cargo run *), Bash(RUST_LOG=*), Read, Grep, Glob
 ---
 
 # Debugging the LSP Server

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -2,6 +2,8 @@
 name: review-pr
 description: Review pull requests against project standards. Use when reviewing PRs, checking code quality, or providing feedback on changes.
 user-invocable: true
+argument-hint: "[PR number or URL]"
+allowed-tools: Bash(gh *), Bash(git diff *), Bash(git log *), Bash(cargo test *), Bash(cargo clippy *), Read, Grep, Glob
 ---
 
 # Reviewing Pull Requests

--- a/.claude/skills/sme-consultation/SKILL.md
+++ b/.claude/skills/sme-consultation/SKILL.md
@@ -2,6 +2,7 @@
 name: sme-consultation
 description: Consult SME agents before implementing features, fixing bugs, or making architecture changes. Use when working on LSP features, GraphQL validation, lint rules, VSCode extension, Salsa queries, CLI changes, or Rust API design.
 user-invocable: true
+argument-hint: "[topic or question for SME agents]"
 ---
 
 # SME Agent Consultation

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ node_modules/
 !.claude/hooks/
 !.claude/agents/
 !.claude/skills/
+!.claude/rules/
 plan-dist-manifest.json

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -43,37 +43,8 @@ graphql-db           (Salsa database, FileId, memoization)
 
 ---
 
-## GraphQL Document Model
-
-**Fragment scope is project-wide**, not file-scoped:
-
-- Operations can reference fragments in other files
-- Fragment spreads can reference other fragments (transitive dependencies)
-- Fragment and operation names must be unique across the entire project
-
-**When validating operations**, you MUST:
-
-1. Include direct fragment dependencies
-2. Recurse through fragment dependencies
-3. Handle circular references
-4. Validate against schema for all fragments in the chain
-
----
-
-## Cache Invariants
-
-The Salsa architecture relies on these invariants for incremental computation:
-
-| Invariant                     | Meaning                                                       |
-| ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries      |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
-| **Index stability**           | Global indexes stay cached when edits don't change names      |
-| **Lazy evaluation**           | Body queries only run when results are needed                 |
-
-**Structure** = identity (names, types). **Body** = content (selection sets, directives).
-
----
+> Detailed rules for Salsa queries, GraphQL document model, and cache invariants
+> are in `.claude/rules/` (loaded automatically when working in relevant crates).
 
 ## Protected Core Features
 


### PR DESCRIPTION
## Summary

Comprehensive improvement to the project's Claude Code configuration, adding features that were previously unused and consolidating existing config for efficiency.

- **8 path-scoped rule files** (`.claude/rules/`): Context-specific guidance for Salsa queries, LSP handlers, linter patterns, testing, code style, VS Code extension, GraphQL documents, and protected files. Rules load automatically only when working in relevant directories, reducing context noise.
- **Agent frontmatter** on all 11 SME agents: Configures `model: sonnet` (faster/cheaper for consultations), `tools` (read-only for advisory agents), and `maxTurns: 10` (prevents runaway agents).
- **Enhanced skill frontmatter** on 8 skills: `allowed-tools` pre-approves common commands (e.g., `cargo test` during `/bug-fix-workflow`) to reduce permission prompts. `argument-hint` adds autocomplete hints (e.g., `/review-pr [PR number]`).
- **3 new hooks**:
  - `UserPromptSubmit`: Auto-injects branch context and fetches GitHub issue details when issue numbers appear in prompts.
  - `PermissionRequest`: Programmatically denies edits to `release.yml` and force-pushes to main/master (enforces "Things to Never Do").
  - `PreCompact`: Preserves critical state (branch, modified crates, key invariants) when the context window gets compacted during long sessions.
- **Permission improvements**: Added `deny` rule for `release.yml` edits, pre-approved `gh`, `knope`, and `npm` commands.
- **Web session fix**: `session-start.sh` now persists PATH via `$CLAUDE_ENV_FILE` so tools installed during session start remain available.
- **CLAUDE.md consolidation**: Extracted duplicated content (troubleshooting, cache invariants, document model) into path-scoped rules, keeping CLAUDE.md focused on quick reference and behavioral instructions.

## Test plan

- [ ] Verify `settings.json` is valid JSON (validated in commit)
- [ ] Verify hook scripts have valid bash syntax (validated in commit)
- [ ] Test `UserPromptSubmit` hook by mentioning an issue number in a prompt
- [ ] Test `PermissionRequest` hook by attempting to edit `release.yml`
- [ ] Verify path-scoped rules load when working in relevant directories
- [ ] Verify agent frontmatter is respected (model selection, tool restrictions)
- [ ] Verify skill `allowed-tools` reduce permission prompts during skill execution
- [ ] Test session-start.sh `CLAUDE_ENV_FILE` persistence in a web session

https://claude.ai/code/session_018f2WzasaqV3YapMb34iVej