### PR TITLE
chore: add .editorconfig, .gitattributes, and Volta config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Context and guidance for Claude when working with this codebase.
 | Where to add a lint rule?  | `crates/linter/src/rules/` - use `/adding-lint-rules` skill |
 | Where to add validation?   | `crates/analysis/src/`                                      |
 | Where's schema loading?    | `crates/introspect/` (remote), `crates/config/` (local)     |
-| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`   |
+| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`    |
 
 ---
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Rust
+*.rs text eol=lf
+*.toml text eol=lf
+
+# TypeScript / JavaScript
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+
+# Config / docs
+*.yaml text eol=lf
+*.yml text eol=lf
+*.md text eol=lf
+*.graphql text eol=lf
+
+# Lock files - text but skip diffs
+Cargo.lock text eol=lf -diff
+package-lock.json text eol=lf -diff
+
+# Binary files
+*.png binary
+*.ico binary
+*.wasm binary

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -22,24 +22,24 @@ graphql-db           (Salsa database, FileId, memoization)
 
 ### Crate Purposes
 
-| Crate         | Purpose                                    |
-| ------------- | ------------------------------------------ |
-| `base-db`     | Salsa database foundation, FileId          |
-| `syntax`      | GraphQL parser, TS/JS extraction           |
-| `hir`         | Semantic layer, structure/body separation  |
-| `analysis`    | Validation and diagnostics                 |
-| `ide-db`      | IDE-specific database queries              |
-| `ide`         | IDE features (hover, completion, goto-def) |
-| `linter`      | Lint rules and configuration               |
-| `lsp`         | Language Server Protocol implementation    |
-| `cli`         | Command-line interface                     |
-| `mcp`         | Model Context Protocol server              |
-| `config`      | Project configuration (.graphqlrc.yaml)    |
-| `introspect`  | Remote schema introspection via HTTP       |
-| `extract`     | GraphQL extraction from TS/JS files        |
-| `apollo-ext`  | Apollo-specific extensions                 |
-| `types`       | Shared type definitions                    |
-| `test-utils`  | Testing utilities and fixtures             |
+| Crate        | Purpose                                    |
+| ------------ | ------------------------------------------ |
+| `base-db`    | Salsa database foundation, FileId          |
+| `syntax`     | GraphQL parser, TS/JS extraction           |
+| `hir`        | Semantic layer, structure/body separation  |
+| `analysis`   | Validation and diagnostics                 |
+| `ide-db`     | IDE-specific database queries              |
+| `ide`        | IDE features (hover, completion, goto-def) |
+| `linter`     | Lint rules and configuration               |
+| `lsp`        | Language Server Protocol implementation    |
+| `cli`        | Command-line interface                     |
+| `mcp`        | Model Context Protocol server              |
+| `config`     | Project configuration (.graphqlrc.yaml)    |
+| `introspect` | Remote schema introspection via HTTP       |
+| `extract`    | GraphQL extraction from TS/JS files        |
+| `apollo-ext` | Apollo-specific extensions                 |
+| `types`      | Shared type definitions                    |
+| `test-utils` | Testing utilities and fixtures             |
 
 ---
 
@@ -66,10 +66,10 @@ The Salsa architecture relies on these invariants for incremental computation:
 
 | Invariant                     | Meaning                                                       |
 | ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries       |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B  |
-| **Index stability**           | Global indexes stay cached when edits don't change names       |
-| **Lazy evaluation**           | Body queries only run when results are needed                  |
+| **Structure/Body separation** | Editing body content never invalidates structure queries      |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
+| **Index stability**           | Global indexes stay cached when edits don't change names      |
+| **Lazy evaluation**           | Body queries only run when results are needed                 |
 
 **Structure** = identity (names, types). **Body** = content (selection sets, directives).
 

--- a/crates/config/CLAUDE.md
+++ b/crates/config/CLAUDE.md
@@ -21,7 +21,7 @@ See `README.md` in this crate for multi-project and advanced configuration.
 
 ## Schema Loading
 
-| Source | Crate          |
-| ------ | -------------- |
-| Local  | `config`       |
-| Remote | `introspect`   |
+| Source | Crate        |
+| ------ | ------------ |
+| Local  | `config`     |
+| Remote | `introspect` |

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -27,10 +27,10 @@ The extension has three separate systems - don't confuse them:
 
 ## Key Files
 
-| File                  | Purpose                      |
-| --------------------- | ---------------------------- |
-| `src/extension.ts`    | Extension entry point        |
-| `src/binaryManager.ts`| LSP binary lifecycle         |
-| `syntaxes/`           | TextMate grammars            |
-| `package.json`        | Extension manifest           |
-| `e2e/`                | Playwright end-to-end tests  |
+| File                   | Purpose                     |
+| ---------------------- | --------------------------- |
+| `src/extension.ts`     | Extension entry point       |
+| `src/binaryManager.ts` | LSP binary lifecycle        |
+| `syntaxes/`            | TextMate grammars           |
+| `package.json`         | Extension manifest          |
+| `e2e/`                 | Playwright end-to-end tests |

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "devDependencies": {
     "oxfmt": "^0.35.0"
+  },
+  "volta": {
+    "node": "24.13.1"
   }
 }


### PR DESCRIPTION
## Summary
- Add `.editorconfig` for consistent formatting across editors (LF line endings, UTF-8, 2-space indent for most files, 4-space for Rust)
- Add `.gitattributes` to enforce LF line endings across platforms and skip diffs for lock files
- Add Volta config in root `package.json` to pin Node.js 24.13.1 for consistent toolchain management
- Fix pre-existing oxfmt formatting issues in CLAUDE.md files

## Test plan
- [ ] Verify `.editorconfig` is picked up by VS Code and other editors
- [ ] Verify `git diff` no longer shows lock file changes
- [ ] Verify `volta install` works with the pinned Node version

https://claude.ai/code/session_0126zsN38YJhNJ3hAsEiMgBr