### PR TITLE
chore: replace cargo-audit with cargo-deny

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Context and guidance for Claude when working with this codebase.
 | Where to add a lint rule?  | `crates/linter/src/rules/` - use `/adding-lint-rules` skill |
 | Where to add validation?   | `crates/analysis/src/`                                      |
 | Where's schema loading?    | `crates/introspect/` (remote), `crates/config/` (local)     |
-| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`   |
+| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`    |
 
 ---
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,4 +1,4 @@
-name: Security Audit
+name: Security & License Audit
 
 on:
   schedule:
@@ -8,27 +8,25 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
   pull_request:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "deny.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  audit:
-    name: Cargo Audit
+  cargo-deny:
+    name: cargo deny
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-
-      - name: Run cargo audit
-        run: cargo audit
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -22,24 +22,24 @@ graphql-db           (Salsa database, FileId, memoization)
 
 ### Crate Purposes
 
-| Crate         | Purpose                                    |
-| ------------- | ------------------------------------------ |
-| `base-db`     | Salsa database foundation, FileId          |
-| `syntax`      | GraphQL parser, TS/JS extraction           |
-| `hir`         | Semantic layer, structure/body separation  |
-| `analysis`    | Validation and diagnostics                 |
-| `ide-db`      | IDE-specific database queries              |
-| `ide`         | IDE features (hover, completion, goto-def) |
-| `linter`      | Lint rules and configuration               |
-| `lsp`         | Language Server Protocol implementation    |
-| `cli`         | Command-line interface                     |
-| `mcp`         | Model Context Protocol server              |
-| `config`      | Project configuration (.graphqlrc.yaml)    |
-| `introspect`  | Remote schema introspection via HTTP       |
-| `extract`     | GraphQL extraction from TS/JS files        |
-| `apollo-ext`  | Apollo-specific extensions                 |
-| `types`       | Shared type definitions                    |
-| `test-utils`  | Testing utilities and fixtures             |
+| Crate        | Purpose                                    |
+| ------------ | ------------------------------------------ |
+| `base-db`    | Salsa database foundation, FileId          |
+| `syntax`     | GraphQL parser, TS/JS extraction           |
+| `hir`        | Semantic layer, structure/body separation  |
+| `analysis`   | Validation and diagnostics                 |
+| `ide-db`     | IDE-specific database queries              |
+| `ide`        | IDE features (hover, completion, goto-def) |
+| `linter`     | Lint rules and configuration               |
+| `lsp`        | Language Server Protocol implementation    |
+| `cli`        | Command-line interface                     |
+| `mcp`        | Model Context Protocol server              |
+| `config`     | Project configuration (.graphqlrc.yaml)    |
+| `introspect` | Remote schema introspection via HTTP       |
+| `extract`    | GraphQL extraction from TS/JS files        |
+| `apollo-ext` | Apollo-specific extensions                 |
+| `types`      | Shared type definitions                    |
+| `test-utils` | Testing utilities and fixtures             |
 
 ---
 
@@ -66,10 +66,10 @@ The Salsa architecture relies on these invariants for incremental computation:
 
 | Invariant                     | Meaning                                                       |
 | ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries       |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B  |
-| **Index stability**           | Global indexes stay cached when edits don't change names       |
-| **Lazy evaluation**           | Body queries only run when results are needed                  |
+| **Structure/Body separation** | Editing body content never invalidates structure queries      |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
+| **Index stability**           | Global indexes stay cached when edits don't change names      |
+| **Lazy evaluation**           | Body queries only run when results are needed                 |
 
 **Structure** = identity (names, types). **Body** = content (selection sets, directives).
 

--- a/crates/config/CLAUDE.md
+++ b/crates/config/CLAUDE.md
@@ -21,7 +21,7 @@ See `README.md` in this crate for multi-project and advanced configuration.
 
 ## Schema Loading
 
-| Source | Crate          |
-| ------ | -------------- |
-| Local  | `config`       |
-| Remote | `introspect`   |
+| Source | Crate        |
+| ------ | ------------ |
+| Local  | `config`     |
+| Remote | `introspect` |

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+# cargo-deny configuration
+# https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+]
+
+# Lint unauthorized licenses
+[licenses]
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT-0",
+  "MPL-2.0",
+  "OpenSSL",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = true
+
+# Lint banned crates and duplicate versions
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+# Lint known security vulnerabilities
+[advisories]
+ignore = []
+
+# Lint allowed sources
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+  # Fork of apollo-rs with parse_with_offset branch
+  # Tracking issue: https://github.com/trevor-scheer/graphql-analyzer/issues/274
+  "https://github.com/trevor-scheer/apollo-rs.git",
+]

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -27,10 +27,10 @@ The extension has three separate systems - don't confuse them:
 
 ## Key Files
 
-| File                  | Purpose                      |
-| --------------------- | ---------------------------- |
-| `src/extension.ts`    | Extension entry point        |
-| `src/binaryManager.ts`| LSP binary lifecycle         |
-| `syntaxes/`           | TextMate grammars            |
-| `package.json`        | Extension manifest           |
-| `e2e/`                | Playwright end-to-end tests  |
+| File                   | Purpose                     |
+| ---------------------- | --------------------------- |
+| `src/extension.ts`     | Extension entry point       |
+| `src/binaryManager.ts` | LSP binary lifecycle        |
+| `syntaxes/`            | TextMate grammars           |
+| `package.json`         | Extension manifest          |
+| `e2e/`                 | Playwright end-to-end tests |


### PR DESCRIPTION
## Summary
- Replace `cargo audit` with `cargo-deny` for comprehensive supply chain checks
- Add `deny.toml` covering licenses, bans, advisories, and source verification
- Replace the workflow's manual `cargo install cargo-audit` with the official `EmbarkStudios/cargo-deny-action@v2`
- cargo-deny is a superset of cargo-audit: it checks licenses, banned/duplicate crates, advisories, and allowed sources in one pass

## Details
- License allowlist covers all permissive licenses found in the dependency tree (MIT, Apache-2.0, BSD, ISC, Unicode, Zlib, etc.)
- Source verification ensures only crates.io and the known apollo-rs fork are allowed
- Unpublished workspace crates (xtask, husky-hooks) are excluded from license checks
- Duplicate dependency warnings are non-blocking (warn level)

## Test plan
- [x] `cargo deny check` passes locally (warnings only for expected duplicate transitive deps)
- [ ] CI workflow runs successfully with `EmbarkStudios/cargo-deny-action@v2`

https://claude.ai/code/session_0126zsN38YJhNJ3hAsEiMgBr