### PR TITLE
refactor: migrate clippy config to workspace lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,21 +1,2 @@
 [alias]
 xtask = "run --package xtask --"
-
-[target.'cfg(all())']
-rustflags = [
-  "-Dwarnings",
-  "-Dclippy::all",
-  "-Dclippy::cargo",
-  "-Dclippy::correctness",
-  "-Dclippy::suspicious",
-  "-Dclippy::pedantic",
-  # Docs
-  "-Aclippy::missing_errors_doc",
-  "-Aclippy::missing_panics_doc",
-  # Cargo
-  "-Aclippy::multiple_crate_versions",
-  # Pedantic - not useful for this project
-  "-Aclippy::too_many_lines",
-  "-Aclippy::cast_possible_truncation",
-  "-Aclippy::similar_names",
-]

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Context and guidance for Claude when working with this codebase.
 | Where to add a lint rule?  | `crates/linter/src/rules/` - use `/adding-lint-rules` skill |
 | Where to add validation?   | `crates/analysis/src/`                                      |
 | Where's schema loading?    | `crates/introspect/` (remote), `crates/config/` (local)     |
-| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`   |
+| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`    |
 
 ---
 

--- a/.husky/Cargo.toml
+++ b/.husky/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 cargo-husky = { version = "1.5.0", default-features = false, features = [
   "user-hooks",
 ] }
+
+[lints]
+workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,25 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # Testing
 insta = { version = "1.40", features = ["yaml"] }
 
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+cargo = { level = "deny", priority = -1 }
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+# Docs
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+# Cargo
+multiple_crate_versions = "allow"
+# Pedantic - not useful for this project
+too_many_lines = "allow"
+cast_possible_truncation = "allow"
+similar_names = "allow"
+
+[workspace.lints.rust]
+warnings = "deny"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -20,3 +20,6 @@ graphql-analysis = { path = "../crates/analysis" }
 graphql-ide = { path = "../crates/ide" }
 criterion = { workspace = true }
 salsa = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -22,24 +22,24 @@ graphql-db           (Salsa database, FileId, memoization)
 
 ### Crate Purposes
 
-| Crate         | Purpose                                    |
-| ------------- | ------------------------------------------ |
-| `base-db`     | Salsa database foundation, FileId          |
-| `syntax`      | GraphQL parser, TS/JS extraction           |
-| `hir`         | Semantic layer, structure/body separation  |
-| `analysis`    | Validation and diagnostics                 |
-| `ide-db`      | IDE-specific database queries              |
-| `ide`         | IDE features (hover, completion, goto-def) |
-| `linter`      | Lint rules and configuration               |
-| `lsp`         | Language Server Protocol implementation    |
-| `cli`         | Command-line interface                     |
-| `mcp`         | Model Context Protocol server              |
-| `config`      | Project configuration (.graphqlrc.yaml)    |
-| `introspect`  | Remote schema introspection via HTTP       |
-| `extract`     | GraphQL extraction from TS/JS files        |
-| `apollo-ext`  | Apollo-specific extensions                 |
-| `types`       | Shared type definitions                    |
-| `test-utils`  | Testing utilities and fixtures             |
+| Crate        | Purpose                                    |
+| ------------ | ------------------------------------------ |
+| `base-db`    | Salsa database foundation, FileId          |
+| `syntax`     | GraphQL parser, TS/JS extraction           |
+| `hir`        | Semantic layer, structure/body separation  |
+| `analysis`   | Validation and diagnostics                 |
+| `ide-db`     | IDE-specific database queries              |
+| `ide`        | IDE features (hover, completion, goto-def) |
+| `linter`     | Lint rules and configuration               |
+| `lsp`        | Language Server Protocol implementation    |
+| `cli`        | Command-line interface                     |
+| `mcp`        | Model Context Protocol server              |
+| `config`     | Project configuration (.graphqlrc.yaml)    |
+| `introspect` | Remote schema introspection via HTTP       |
+| `extract`    | GraphQL extraction from TS/JS files        |
+| `apollo-ext` | Apollo-specific extensions                 |
+| `types`      | Shared type definitions                    |
+| `test-utils` | Testing utilities and fixtures             |
 
 ---
 
@@ -66,10 +66,10 @@ The Salsa architecture relies on these invariants for incremental computation:
 
 | Invariant                     | Meaning                                                       |
 | ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries       |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B  |
-| **Index stability**           | Global indexes stay cached when edits don't change names       |
-| **Lazy evaluation**           | Body queries only run when results are needed                  |
+| **Structure/Body separation** | Editing body content never invalidates structure queries      |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
+| **Index stability**           | Global indexes stay cached when edits don't change names      |
+| **Lazy evaluation**           | Body queries only run when results are needed                 |
 
 **Structure** = identity (names, types). **Body** = content (selection sets, directives).
 

--- a/crates/analysis/Cargo.toml
+++ b/crates/analysis/Cargo.toml
@@ -23,3 +23,6 @@ text-size = "1.1"
 
 [dev-dependencies]
 graphql-test-utils = { path = "../test-utils" }
+
+[lints]
+workspace = true

--- a/crates/apollo-ext/Cargo.toml
+++ b/crates/apollo-ext/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
 apollo-parser.workspace = true
+
+[lints]
+workspace = true

--- a/crates/base-db/Cargo.toml
+++ b/crates/base-db/Cargo.toml
@@ -12,3 +12,6 @@ categories = ["development-tools"]
 [dependencies]
 graphql-types = { path = "../types" }
 salsa = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -72,3 +72,6 @@ otel = [
 
 [dev-dependencies]
 tempfile = "3.25.0"
+
+[lints]
+workspace = true

--- a/crates/config/CLAUDE.md
+++ b/crates/config/CLAUDE.md
@@ -21,7 +21,7 @@ See `README.md` in this crate for multi-project and advanced configuration.
 
 ## Schema Loading
 
-| Source | Crate          |
-| ------ | -------------- |
-| Local  | `config`       |
-| Remote | `introspect`   |
+| Source | Crate        |
+| ------ | ------------ |
+| Local  | `config`     |
+| Remote | `introspect` |

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,3 +21,6 @@ tracing = "0.1"
 anyhow = { workspace = true }
 tempfile = "3.0"
 jsonschema = "0.43"
+
+[lints]
+workspace = true

--- a/crates/extract/Cargo.toml
+++ b/crates/extract/Cargo.toml
@@ -23,3 +23,6 @@ serde = { workspace = true }
 tracing = "0.1"
 
 [dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -19,3 +19,6 @@ text-size = "1.1"
 
 [dev-dependencies]
 graphql-test-utils = { path = "../test-utils" }
+
+[lints]
+workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -22,3 +22,6 @@ graphql-extract = { path = "../extract" }
 
 # Salsa for incremental computation
 salsa = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -43,3 +43,6 @@ graphql-extract = { path = "../extract" }
 tempfile = "3.0"
 serde_json = { workspace = true }
 graphql-ide-db = { path = "../ide-db" }
+
+[lints]
+workspace = true

--- a/crates/introspect/Cargo.toml
+++ b/crates/introspect/Cargo.toml
@@ -19,3 +19,6 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }
+
+[lints]
+workspace = true

--- a/crates/linter/Cargo.toml
+++ b/crates/linter/Cargo.toml
@@ -31,3 +31,6 @@ tracing = "0.1"
 serde_yaml = { workspace = true }
 insta = { workspace = true }
 graphql-ide-db = { path = "../ide-db" }
+
+[lints]
+workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -63,3 +63,6 @@ vergen-git2 = { version = "9.1", features = ["build", "cargo"] }
 [features]
 default = []
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp"]
+
+[lints]
+workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -42,3 +42,6 @@ glob = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -17,3 +17,6 @@ salsa = { workspace = true }
 apollo-parser = { workspace = true }
 apollo-compiler = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -21,3 +21,6 @@ graphql-analysis = { path = "../analysis" }
 graphql-ide-db = { path = "../ide-db" }
 salsa = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -15,3 +15,6 @@ dist = false
 
 # Zero external dependencies - this is a foundation crate
 [dependencies]
+
+[lints]
+workspace = true

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -27,10 +27,10 @@ The extension has three separate systems - don't confuse them:
 
 ## Key Files
 
-| File                  | Purpose                      |
-| --------------------- | ---------------------------- |
-| `src/extension.ts`    | Extension entry point        |
-| `src/binaryManager.ts`| LSP binary lifecycle         |
-| `syntaxes/`           | TextMate grammars            |
-| `package.json`        | Extension manifest           |
-| `e2e/`                | Playwright end-to-end tests  |
+| File                   | Purpose                     |
+| ---------------------- | --------------------------- |
+| `src/extension.ts`     | Extension entry point       |
+| `src/binaryManager.ts` | LSP binary lifecycle        |
+| `syntaxes/`            | TextMate grammars           |
+| `package.json`         | Extension manifest          |
+| `e2e/`                 | Playwright end-to-end tests |

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,3 +9,6 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6.0"
 toml = "1.0"
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary
- Migrate clippy lint configuration from `.cargo/config.toml` rustflags to the idiomatic `[workspace.lints]` in `Cargo.toml`
- Add `[lints] workspace = true` to all 19 workspace member crates
- Remove `rustflags` from `.cargo/config.toml` (keep only the `xtask` alias)

## Why
The `rustflags` approach in `.cargo/config.toml` is non-standard and has issues:
- Not all IDEs/tools parse rustflags correctly
- Cannot do per-crate lint overrides
- Conflicts with other rustflags (e.g., linker flags for faster builds)

`[workspace.lints]` is the modern Cargo convention (stable since Rust 1.74) and is what rust-analyzer, Cargo itself, and other major Rust projects use.

## Changes
Lint behavior is preserved identically:
- **deny**: `clippy::all`, `clippy::cargo`, `clippy::correctness`, `clippy::suspicious`, `clippy::pedantic`, `rust::warnings`
- **allow**: `missing_errors_doc`, `missing_panics_doc`, `multiple_crate_versions`, `too_many_lines`, `cast_possible_truncation`, `similar_names`

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features` passes cleanly
- [x] `cargo fmt --all -- --check` passes
- [ ] CI passes with identical lint enforcement

https://claude.ai/code/session_0126zsN38YJhNJ3hAsEiMgBr