### PR TITLE
chore: remove unused once_cell workspace dependency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Context and guidance for Claude when working with this codebase.
 | Where to add a lint rule?  | `crates/linter/src/rules/` - use `/adding-lint-rules` skill |
 | Where to add validation?   | `crates/analysis/src/`                                      |
 | Where's schema loading?    | `crates/introspect/` (remote), `crates/config/` (local)     |
-| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`   |
+| How does incremental work? | Salsa queries: `base-db` → `syntax` → `hir` → `analysis`    |
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ swc_common = "19.0"
 
 # Utilities
 dashmap = "6.1"
-once_cell = "1.21"
 parking_lot = "0.12"
 
 # Logging and Tracing

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -22,24 +22,24 @@ graphql-db           (Salsa database, FileId, memoization)
 
 ### Crate Purposes
 
-| Crate         | Purpose                                    |
-| ------------- | ------------------------------------------ |
-| `base-db`     | Salsa database foundation, FileId          |
-| `syntax`      | GraphQL parser, TS/JS extraction           |
-| `hir`         | Semantic layer, structure/body separation  |
-| `analysis`    | Validation and diagnostics                 |
-| `ide-db`      | IDE-specific database queries              |
-| `ide`         | IDE features (hover, completion, goto-def) |
-| `linter`      | Lint rules and configuration               |
-| `lsp`         | Language Server Protocol implementation    |
-| `cli`         | Command-line interface                     |
-| `mcp`         | Model Context Protocol server              |
-| `config`      | Project configuration (.graphqlrc.yaml)    |
-| `introspect`  | Remote schema introspection via HTTP       |
-| `extract`     | GraphQL extraction from TS/JS files        |
-| `apollo-ext`  | Apollo-specific extensions                 |
-| `types`       | Shared type definitions                    |
-| `test-utils`  | Testing utilities and fixtures             |
+| Crate        | Purpose                                    |
+| ------------ | ------------------------------------------ |
+| `base-db`    | Salsa database foundation, FileId          |
+| `syntax`     | GraphQL parser, TS/JS extraction           |
+| `hir`        | Semantic layer, structure/body separation  |
+| `analysis`   | Validation and diagnostics                 |
+| `ide-db`     | IDE-specific database queries              |
+| `ide`        | IDE features (hover, completion, goto-def) |
+| `linter`     | Lint rules and configuration               |
+| `lsp`        | Language Server Protocol implementation    |
+| `cli`        | Command-line interface                     |
+| `mcp`        | Model Context Protocol server              |
+| `config`     | Project configuration (.graphqlrc.yaml)    |
+| `introspect` | Remote schema introspection via HTTP       |
+| `extract`    | GraphQL extraction from TS/JS files        |
+| `apollo-ext` | Apollo-specific extensions                 |
+| `types`      | Shared type definitions                    |
+| `test-utils` | Testing utilities and fixtures             |
 
 ---
 
@@ -66,10 +66,10 @@ The Salsa architecture relies on these invariants for incremental computation:
 
 | Invariant                     | Meaning                                                       |
 | ----------------------------- | ------------------------------------------------------------- |
-| **Structure/Body separation** | Editing body content never invalidates structure queries       |
-| **File isolation**            | Editing file A never invalidates unrelated queries for file B  |
-| **Index stability**           | Global indexes stay cached when edits don't change names       |
-| **Lazy evaluation**           | Body queries only run when results are needed                  |
+| **Structure/Body separation** | Editing body content never invalidates structure queries      |
+| **File isolation**            | Editing file A never invalidates unrelated queries for file B |
+| **Index stability**           | Global indexes stay cached when edits don't change names      |
+| **Lazy evaluation**           | Body queries only run when results are needed                 |
 
 **Structure** = identity (names, types). **Body** = content (selection sets, directives).
 

--- a/crates/config/CLAUDE.md
+++ b/crates/config/CLAUDE.md
@@ -21,7 +21,7 @@ See `README.md` in this crate for multi-project and advanced configuration.
 
 ## Schema Loading
 
-| Source | Crate          |
-| ------ | -------------- |
-| Local  | `config`       |
-| Remote | `introspect`   |
+| Source | Crate        |
+| ------ | ------------ |
+| Local  | `config`     |
+| Remote | `introspect` |

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -27,10 +27,10 @@ The extension has three separate systems - don't confuse them:
 
 ## Key Files
 
-| File                  | Purpose                      |
-| --------------------- | ---------------------------- |
-| `src/extension.ts`    | Extension entry point        |
-| `src/binaryManager.ts`| LSP binary lifecycle         |
-| `syntaxes/`           | TextMate grammars            |
-| `package.json`        | Extension manifest           |
-| `e2e/`                | Playwright end-to-end tests  |
+| File                   | Purpose                     |
+| ---------------------- | --------------------------- |
+| `src/extension.ts`     | Extension entry point       |
+| `src/binaryManager.ts` | LSP binary lifecycle        |
+| `syntaxes/`            | TextMate grammars           |
+| `package.json`         | Extension manifest          |
+| `e2e/`                 | Playwright end-to-end tests |


### PR DESCRIPTION
## Summary
- Remove unused `once_cell = "1.21"` from `[workspace.dependencies]`

## Why
The `once_cell` crate is declared in workspace dependencies but **no workspace member imports or uses it**. The codebase already uses `std::sync::LazyLock` (stable since Rust 1.80) for lazy static initialization (see `crates/linter/src/registry.rs`).

`once_cell` remains in `Cargo.lock` as a transitive dependency of dashmap, tracing-core, swc, etc., but doesn't need an explicit workspace-level declaration.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets --all-features` passes
- [ ] CI passes

https://claude.ai/code/session_0126zsN38YJhNJ3hAsEiMgBr