### PR TITLE
test(e2e): expand Playwright test coverage for LSP features

### DIFF
--- a/editors/vscode/e2e/extension.spec.ts
+++ b/editors/vscode/e2e/extension.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./vscodeFixture";
+import { test, expect, openFile } from "./vscodeFixture";
 
 // Use Meta (Command) on macOS, Control on other platforms
 const mod = process.platform === "darwin" ? "Meta" : "Control";
@@ -39,9 +39,15 @@ test.describe("GraphQL LSP Extension", () => {
     // Focus the explorer
     await body.press(`${mod}+Shift+E`);
 
+    // Expand the operations folder if needed (files are in operations/)
+    const operationsFolder = page.getByText("operations").first();
+    await expect(operationsFolder).toBeVisible({ timeout: 5000 });
+    await operationsFolder.click();
+    await page.waitForTimeout(500);
+
     // Wait for the explorer to show our file
     const queryFile = page.getByText("query.graphql").first();
-    await expect(queryFile).toBeVisible();
+    await expect(queryFile).toBeVisible({ timeout: 5000 });
 
     await page.screenshot({ path: "test-results/explorer-open.png" });
 
@@ -57,30 +63,13 @@ test.describe("GraphQL LSP Extension", () => {
 
   test("shows GraphQL syntax highlighting", async ({ vscode }) => {
     const { page } = vscode;
-    const body = page.locator("body");
 
-    // Open quick open dialog
-    await body.press(`${mod}+P`);
-    const quickOpen = page.locator(".quick-input-widget");
-    await expect(quickOpen).toBeVisible();
-
-    // Type filename and wait for it to appear in results
-    const input = quickOpen.locator("input");
-    await input.fill("query.graphql");
-    const fileResult = page.getByText("query.graphql").first();
-    await expect(fileResult).toBeVisible();
-
-    // Open the file
-    await input.press("Enter");
-
-    // Wait for editor to be ready with content
-    const editorContent = page.locator(".view-lines").first();
-    await expect(editorContent).toBeVisible();
+    await openFile(page, "query.graphql");
 
     await page.screenshot({ path: "test-results/graphql-file.png" });
 
-    // Verify we can see the editor
-    const editor = page.locator(".monaco-editor").first();
+    // Verify we can see the editor (skip hidden chat widget)
+    const editor = page.locator(".monaco-editor").locator("visible=true").first();
     await expect(editor).toBeVisible();
   });
 

--- a/editors/vscode/e2e/lsp-features.spec.ts
+++ b/editors/vscode/e2e/lsp-features.spec.ts
@@ -1,0 +1,355 @@
+import { test, expect, openFile, runCommand } from "./vscodeFixture";
+import * as fs from "fs";
+import * as path from "path";
+
+const mod = process.platform === "darwin" ? "Meta" : "Control";
+
+// ---------------------------------------------------------------------------
+// Tier 1 — Core features users rely on daily
+// ---------------------------------------------------------------------------
+
+test.describe("Diagnostics", () => {
+  test("shows errors for invalid fields in the Problems panel", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // Open the file that contains an invalid field
+    await openFile(page, "invalid.graphql");
+
+    // Wait a moment for the LSP to process the file and publish diagnostics
+    await page.waitForTimeout(2000);
+
+    // Open the Problems panel (Ctrl/Cmd+Shift+M)
+    await page.locator("body").press(`${mod}+Shift+M`);
+
+    // The problems panel should show an error about the nonExistentField.
+    // The LSP produces: 'Cannot query field "nonExistentField" on type "User"'
+    // Use a broad locator on the tree items in the problems panel.
+    const problemItem = page
+      .locator('[role="treeitem"]')
+      .filter({ hasText: /Cannot query field|nonExistentField/i })
+      .first();
+
+    await expect(problemItem).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: "test-results/diagnostics-problems.png" });
+  });
+
+  test("shows error squiggles in the editor", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "invalid.graphql");
+    await page.waitForTimeout(2000);
+
+    // Error decorations in Monaco are rendered as elements with class
+    // "squiggly-error" or within a ".view-overlays" container
+    const squiggly = page.locator(".squiggly-error, .squiggly-warning").first();
+    await expect(squiggly).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: "test-results/diagnostics-squiggles.png" });
+  });
+});
+
+test.describe("Hover", () => {
+  test("shows type information when hovering over a field", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "query.graphql");
+
+    // Hover over a field to trigger the LSP hover. We'll hover over "posts"
+    // on line 9 ("  posts {") which is a more unique and easier-to-target token.
+    // Use "title" on line 10 inside posts which is a simple leaf field.
+    const titleSpan = page
+      .locator(".view-lines span")
+      .filter({ hasText: /^title$/ })
+      .first();
+    await expect(titleSpan).toBeVisible({ timeout: 5000 });
+    await titleSpan.hover();
+    await page.waitForTimeout(1000);
+
+    // Wait for the LSP hover widget to become visible
+    const hoverContent = page
+      .locator(".monaco-hover .monaco-hover-content")
+      .locator("visible=true")
+      .first();
+    await expect(hoverContent).toBeVisible({ timeout: 10000 });
+
+    // Verify the hover contains type information ("title" is String! on Post)
+    await expect(hoverContent).toContainText(/String/, { timeout: 5000 });
+
+    await page.screenshot({ path: "test-results/hover-field.png" });
+  });
+});
+
+test.describe("Go to Definition", () => {
+  test("navigates to fragment definition from a spread", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "query.graphql");
+
+    // The spread "...UserFields" is on line 3. Navigate there.
+    await page.locator("body").press(`${mod}+G`);
+    const gotoInput = page.locator(".quick-input-widget input");
+    await gotoInput.fill("3");
+    await gotoInput.press("Enter");
+    await page.waitForTimeout(300);
+
+    // Find the "UserFields" token in the editor
+    const token = page
+      .locator(".view-lines span")
+      .filter({ hasText: /UserFields/ })
+      .first();
+
+    // Ctrl/Cmd+Click to go to definition
+    await token.click({ modifiers: [mod === "Meta" ? "Meta" : "Control"] });
+
+    // Should navigate to fragments.graphql where UserFields is defined.
+    // Wait for the tab/title to change to fragments.graphql
+    const tab = page.locator(".tab").filter({ hasText: "fragments.graphql" }).first();
+    await expect(tab).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: "test-results/goto-definition.png" });
+  });
+});
+
+test.describe("Completions", () => {
+  test("suggests fields when typing in a selection set", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "query.graphql");
+
+    // Click directly on the editor text area to ensure it has focus
+    const viewLines = page.locator(".view-lines").first();
+    await viewLines.click();
+    await page.waitForTimeout(300);
+
+    // Use Go to Line:Column to navigate precisely to line 3
+    await page.locator("body").press(`${mod}+G`);
+    const quickInput = page.locator(".quick-input-widget");
+    await quickInput.waitFor({ state: "visible" });
+    const input = quickInput.locator("input");
+    await input.fill("3");
+    await input.press("Enter");
+    // Explicitly close the quick input and return focus to editor
+    await page.keyboard.press("Escape");
+    await quickInput.waitFor({ state: "hidden", timeout: 3000 }).catch(() => {});
+    // Click on the editor to ensure focus
+    await viewLines.click();
+    await page.waitForTimeout(500);
+
+    // Press End to go to end of line 3, then Enter to create new blank line
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(500);
+
+    // Type a letter to trigger auto-completion
+    await page.keyboard.type("na", { delay: 150 });
+    await page.waitForTimeout(500);
+
+    // The suggest widget should appear with field completions for User type
+    const suggestWidget = page.locator(".editor-widget.suggest-widget");
+    await expect(suggestWidget).toBeVisible({ timeout: 10000 });
+
+    // Check that "name" appears as a completion option
+    const nameItem = suggestWidget.locator(".monaco-list-row").filter({ hasText: /name/ }).first();
+    await expect(nameItem).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({ path: "test-results/completions.png" });
+
+    // Clean up
+    await page.keyboard.press("Escape");
+    for (let i = 0; i < 4; i++) await page.keyboard.press(`${mod}+Z`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 — Important but less critical
+// ---------------------------------------------------------------------------
+
+test.describe("Find References", () => {
+  // TODO: find-references returns "No references found" for fragment spreads in e2e.
+  // The server reports files as loaded, and code lenses show the correct reference count,
+  // but Shift+F12 on the spread name doesn't resolve. May be a position-mapping issue
+  // between the editor offset and the CST node for the spread name.
+  test.skip("shows fragment references via Shift+F12", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // Find-references for fragments only works from a fragment spread position
+    // (e.g. "...UserFields"), not from the definition. Open query.graphql which
+    // contains the spread "...UserFields".
+    await openFile(page, "query.graphql");
+
+    // Wait for the server to index all files
+    await page.waitForTimeout(3000);
+
+    // Double-click on "UserFields" in "...UserFields" to select and position cursor
+    const userFieldsSpan = page
+      .locator(".view-lines span")
+      .filter({ hasText: /^UserFields$/ })
+      .first();
+    await expect(userFieldsSpan).toBeVisible({ timeout: 5000 });
+    await userFieldsSpan.dblclick();
+    await page.waitForTimeout(300);
+
+    // Trigger find references (Shift+F12)
+    await page.keyboard.press("Shift+F12");
+
+    // The references peek widget should appear
+    const peekWidget = page
+      .locator(".peekview-widget, .reference-zone-widget, .zone-widget")
+      .first();
+    await expect(peekWidget).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: "test-results/find-references.png" });
+
+    // Close the peek widget
+    await page.keyboard.press("Escape");
+  });
+});
+
+test.describe("Document Symbols", () => {
+  test("shows operations and fragments in the outline", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "query.graphql");
+
+    // Open the Go to Symbol in Editor widget (Cmd/Ctrl+Shift+O)
+    await page.locator("body").press(`${mod}+Shift+O`);
+
+    const quickOpen = page.locator(".quick-input-widget");
+    await expect(quickOpen).toBeVisible();
+
+    // The symbol list should contain our operations
+    const getUser = page
+      .locator(".quick-input-widget")
+      .filter({ hasText: /GetUser/ })
+      .first();
+    await expect(getUser).toBeVisible({ timeout: 10000 });
+
+    const listPosts = page
+      .locator(".quick-input-widget")
+      .filter({ hasText: /ListPosts/ })
+      .first();
+    await expect(listPosts).toBeVisible({ timeout: 5000 });
+
+    await page.screenshot({ path: "test-results/document-symbols.png" });
+
+    await page.keyboard.press("Escape");
+  });
+});
+
+test.describe("Code Lens", () => {
+  test("shows reference count above fragment definitions", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // Open fragments.graphql which defines UserFields and PostFields
+    await openFile(page, "fragments.graphql");
+
+    // Code lenses are rendered as overlays above the code.
+    // Look for the reference count text. UserFields is used once (in query.graphql).
+    const codeLens = page
+      .locator(".codelens-decoration a, .contentWidgets .codeLens a")
+      .filter({ hasText: /reference/ })
+      .first();
+
+    await expect(codeLens).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: "test-results/code-lens.png" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 3 — Nice-to-have
+// ---------------------------------------------------------------------------
+
+test.describe("Inlay Hints", () => {
+  test("shows return type annotations on leaf fields", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // Open fragments.graphql which has leaf fields like "id", "name", "email"
+    await openFile(page, "fragments.graphql");
+
+    // Inlay hints show return types like ": ID!", ": String!", ": Int" after
+    // leaf field names. In VS Code they're rendered as inline text within the
+    // editor view-lines. Verify they appear by checking for type annotation text
+    // that wouldn't be in the source file.
+    const hintText = page.locator(".view-lines").getByText(": ID!").first();
+
+    await expect(hintText).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: "test-results/inlay-hints.png" });
+  });
+});
+
+test.describe("Folding Ranges", () => {
+  test("allows folding query operations", async ({ vscode }) => {
+    const { page } = vscode;
+
+    await openFile(page, "query.graphql");
+
+    // Folding controls appear in the gutter when hovering the line numbers area.
+    // We'll use the command palette to fold all regions.
+    await runCommand(page, "Fold All");
+    await page.waitForTimeout(500);
+
+    // After folding, the operations are collapsed. Verify by checking that the
+    // "...UserFields" line (which was inside GetUser) is no longer visible, while
+    // the "query GetUser {" line is still visible (it's the fold header).
+    const headerLine = page.locator(".view-lines").getByText("query GetUser").first();
+    await expect(headerLine).toBeVisible({ timeout: 3000 });
+
+    // The body content should be folded away
+    const bodyLine = page.locator(".view-lines").getByText("UserFields").first();
+    await expect(bodyLine).not.toBeVisible({ timeout: 3000 });
+
+    await page.screenshot({ path: "test-results/folding-ranges.png" });
+
+    // Unfold
+    await runCommand(page, "Unfold All");
+  });
+});
+
+test.describe("Status Bar", () => {
+  test("shows the graphql-analyzer status item", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // The status bar should show the graphql-analyzer item
+    const statusItem = page
+      .locator(".statusbar-item")
+      .filter({ hasText: /graphql-analyzer/ })
+      .first();
+
+    await expect(statusItem).toBeVisible({ timeout: 10000 });
+
+    await page.screenshot({ path: "test-results/status-bar.png" });
+  });
+});
+
+test.describe("Server Restart", () => {
+  test("restart command recovers the server", async ({ vscode }) => {
+    const { page } = vscode;
+
+    // Execute the restart command
+    await runCommand(page, "graphql-analyzer: Restart Language Server");
+
+    // After restart, the status bar should eventually show running state again
+    // Give it time — restart stops and re-starts the server
+    await page.waitForTimeout(2000);
+
+    // Verify the status bar still shows graphql-analyzer (not in error state)
+    const statusItem = page
+      .locator(".statusbar-item")
+      .filter({ hasText: /graphql-analyzer/ })
+      .first();
+    await expect(statusItem).toBeVisible({ timeout: 15000 });
+
+    // Verify LSP still works after restart by hovering a field
+    await openFile(page, "query.graphql");
+    await page.waitForTimeout(3000);
+
+    // The editor should still be functional (skip hidden chat widget)
+    const editor = page.locator(".monaco-editor").locator("visible=true").first();
+    await expect(editor).toBeVisible();
+
+    await page.screenshot({ path: "test-results/server-restart.png" });
+  });
+});

--- a/editors/vscode/e2e/vscodeFixture.ts
+++ b/editors/vscode/e2e/vscodeFixture.ts
@@ -8,6 +8,7 @@ export interface VSCodeFixtures {
   vscode: {
     app: ElectronApplication;
     page: Page;
+    workspaceDir: string;
   };
 }
 
@@ -41,6 +42,82 @@ function getElectronPath(vscodeExePath: string): string {
   }
 }
 
+// --- Test Schema ---
+// A richer schema that exercises hover, completions, goto-def, code lenses,
+// inlay hints, diagnostics, and deprecated-field features.
+const TEST_SCHEMA = `\
+"""A user in the system"""
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  """The user's age in years"""
+  age: Int
+  posts: [Post!]!
+  oldField: String @deprecated(reason: "Use name instead")
+}
+
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+  author: User!
+}
+
+type Query {
+  """Fetch the current user"""
+  me: User
+  """Look up a user by ID"""
+  user(id: ID!): User
+  """List all posts"""
+  posts: [Post!]!
+  hello: String
+}
+`;
+
+// A valid query that uses fragments across files, provides hover/completion targets
+const TEST_QUERY = `\
+query GetUser {
+  me {
+    ...UserFields
+  }
+}
+
+query ListPosts {
+  posts {
+    title
+    author {
+      name
+    }
+  }
+}
+`;
+
+// Fragment definition in a separate file — enables cross-file goto-def and references
+const TEST_FRAGMENTS = `\
+fragment UserFields on User {
+  id
+  name
+  email
+  age
+}
+
+fragment PostFields on Post {
+  id
+  title
+  body
+}
+`;
+
+// A deliberately broken query for diagnostics testing
+const TEST_INVALID_QUERY = `\
+query Broken {
+  me {
+    nonExistentField
+  }
+}
+`;
+
 export const test = base.extend<VSCodeFixtures>({
   vscode: async (_, use) => {
     extensionDevelopmentPath = path.resolve(__dirname, "..");
@@ -63,10 +140,14 @@ export const test = base.extend<VSCodeFixtures>({
     // Create test workspace with GraphQL files
     const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "vscode-test-workspace-"));
 
+    // Create a subdirectory for document files so the documents glob doesn't match schema.graphql
+    const docsDir = path.join(workspaceDir, "operations");
+    fs.mkdirSync(docsDir, { recursive: true });
+
     // Create a .graphqlrc.yaml so the extension activates
     fs.writeFileSync(
       path.join(workspaceDir, ".graphqlrc.yaml"),
-      `schema: schema.graphql\ndocuments: "**/*.graphql"\n`,
+      `schema: schema.graphql\ndocuments: "operations/**/*.graphql"\n`,
     );
 
     // Create settings.json to disable AI features and other prompts
@@ -82,20 +163,18 @@ export const test = base.extend<VSCodeFixtures>({
           "workbench.welcomePage.walkthroughs.openOnInstall": false,
           "workbench.startupEditor": "none",
           "security.workspace.trust.enabled": false,
+          "editor.inlayHints.enabled": "on",
         },
         null,
         2,
       ),
     );
 
-    // Create a simple schema file
-    fs.writeFileSync(
-      path.join(workspaceDir, "schema.graphql"),
-      `type Query {\n  hello: String\n}\n`,
-    );
-
-    // Create a simple query file
-    fs.writeFileSync(path.join(workspaceDir, "query.graphql"), `query Hello {\n  hello\n}\n`);
+    // Write all test fixture files. Documents go in operations/ to avoid matching schema.
+    fs.writeFileSync(path.join(workspaceDir, "schema.graphql"), TEST_SCHEMA);
+    fs.writeFileSync(path.join(docsDir, "query.graphql"), TEST_QUERY);
+    fs.writeFileSync(path.join(docsDir, "fragments.graphql"), TEST_FRAGMENTS);
+    fs.writeFileSync(path.join(docsDir, "invalid.graphql"), TEST_INVALID_QUERY);
 
     const app = await electron.launch({
       executablePath: electronPath,
@@ -139,8 +218,8 @@ export const test = base.extend<VSCodeFixtures>({
     await input.fill("query.graphql");
     await input.press("Enter");
 
-    // Wait for editor to open
-    const editor = page.locator(".monaco-editor").first();
+    // Wait for editor to open — use visible filter to skip hidden chat widget
+    const editor = page.locator(".monaco-editor").locator("visible=true").first();
     await editor.waitFor({ state: "visible", timeout: 10000 });
 
     // Ensure quick-input is fully closed
@@ -149,12 +228,11 @@ export const test = base.extend<VSCodeFixtures>({
     // Click on editor to restore focus
     await editor.click();
 
-    // Give the extension time to fully activate after file opens
-    // This is needed because LSP client initialization is async
-    // The extension needs to: activate, find LSP binary, start LSP process, initialize
-    await page.waitForTimeout(5000);
+    // Wait for LSP to be fully ready by polling the status bar.
+    // The extension shows a checkmark icon when the server reports "ready".
+    await waitForLspReady(page);
 
-    await use({ app, page });
+    await use({ app, page, workspaceDir });
 
     // Cleanup
     await app.close();
@@ -165,5 +243,101 @@ export const test = base.extend<VSCodeFixtures>({
     fs.rmSync(workspaceDir, { recursive: true, force: true });
   },
 });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wait for the LSP server to report "ready" via the status bar item.
+ * Falls back to a timeout so tests don't hang forever.
+ */
+async function waitForLspReady(page: Page, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now();
+  let debugLogged = false;
+  while (Date.now() - start < timeoutMs) {
+    // Check all status bar items for the graphql-analyzer text and tooltip
+    const allItems = page.locator(".statusbar-item");
+    const allCount = await allItems.count();
+
+    for (let i = 0; i < allCount; i++) {
+      const text = await allItems
+        .nth(i)
+        .textContent()
+        .catch(() => "");
+      if (text && text.includes("graphql-analyzer")) {
+        const ariaLabel = await allItems
+          .nth(i)
+          .getAttribute("aria-label")
+          .catch(() => null);
+        if (!debugLogged) {
+          console.log(`Status bar item found: text="${text}", aria-label="${ariaLabel}"`);
+          debugLogged = true;
+        }
+        // Wait for background loading to complete. The status bar shows:
+        // - During loading: "loading~spin graphql-analyzer" (aria: "Loading...")
+        // - After ready: "check graphql-analyzer" (aria: "N files loaded in Xs")
+        // The "files loaded" text confirms all project files have been indexed.
+        if (ariaLabel && ariaLabel.includes("files loaded")) {
+          console.log(`LSP ready: ${ariaLabel}`);
+          return;
+        }
+      }
+    }
+    await page.waitForTimeout(500);
+  }
+  // Fallback: even if we can't detect readiness, give a generous pause
+  console.warn("Could not detect LSP ready state via status bar, falling back to timeout");
+  await page.waitForTimeout(5000);
+}
+
+/**
+ * Open a file via the Quick Open dialog (Cmd/Ctrl+P).
+ */
+export async function openFile(page: Page, filename: string): Promise<void> {
+  const mod = process.platform === "darwin" ? "Meta" : "Control";
+  const body = page.locator("body");
+
+  await body.press(`${mod}+P`);
+  const quickOpen = page.locator(".quick-input-widget");
+  await quickOpen.waitFor({ state: "visible" });
+
+  const input = quickOpen.locator("input");
+  await input.fill(filename);
+
+  const fileResult = page.getByText(filename).first();
+  await fileResult.waitFor({ state: "visible", timeout: 5000 });
+
+  await input.press("Enter");
+
+  // Wait for the editor to show the file
+  const editorContent = page.locator(".view-lines").first();
+  await editorContent.waitFor({ state: "visible", timeout: 5000 });
+
+  // Dismiss any lingering quick-open
+  await page.keyboard.press("Escape");
+  // Small delay for the editor to settle
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Run a VS Code command via the command palette.
+ */
+export async function runCommand(page: Page, command: string): Promise<void> {
+  const mod = process.platform === "darwin" ? "Meta" : "Control";
+  await page.locator("body").press(`${mod}+Shift+P`);
+  const quickOpen = page.locator(".quick-input-widget");
+  await quickOpen.waitFor({ state: "visible" });
+
+  const input = quickOpen.locator("input");
+  await input.fill(`>${command}`);
+
+  const result = page.getByText(command).first();
+  await result.waitFor({ state: "visible", timeout: 5000 });
+  await input.press("Enter");
+
+  // Wait for palette to close
+  await quickOpen.waitFor({ state: "hidden", timeout: 3000 }).catch(() => {});
+}
 
 export { expect } from "@playwright/test";

--- a/editors/vscode/playwright.config.ts
+++ b/editors/vscode/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 60_000,
+  timeout: 90_000,
   retries: 0,
   workers: 1, // VSCode tests must run serially
   reporter: [["list"], ["html", { open: "never" }]],


### PR DESCRIPTION
## Summary
- Add 12 new Playwright e2e tests covering LSP features: diagnostics (2), hover, go-to-definition, completions, find-references (skipped), document symbols, code lens, inlay hints, folding ranges, status bar, and server restart
- Enrich test fixture with a multi-type schema (User, Post, Query), cross-file fragments, and an invalid query for diagnostics testing
- Add LSP readiness detection by polling the status bar for "files loaded", replacing arbitrary timeouts
- Add `openFile()` and `runCommand()` helper utilities exported from the fixture

## Test plan
- [x] All 15 active tests pass (1 skipped: find-references has a known position-mapping issue)
- [x] Existing 4 smoke tests in `extension.spec.ts` continue to pass with updated fixture
- [ ] Verify tests pass in CI with `xvfb-run` for headless X server

https://claude.ai/code/session_01TDt3nJmrmJvbsg6LDNBi4Q