### PR TITLE
Fix rules frontmatter: use `paths` instead of `globs`

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,6 +1,6 @@
 ---
 description: Global Rust code style conventions
-globs:
+paths:
   - "**/*.rs"
 ---
 

--- a/.claude/rules/graphql-documents.md
+++ b/.claude/rules/graphql-documents.md
@@ -1,6 +1,6 @@
 ---
 description: GraphQL document model - fragment scope and validation rules
-globs:
+paths:
   - "crates/graphql-hir/**"
   - "crates/graphql-analysis/**"
   - "crates/graphql-ide/**"

--- a/.claude/rules/linter-rules.md
+++ b/.claude/rules/linter-rules.md
@@ -1,6 +1,6 @@
 ---
 description: Lint rule implementation patterns
-globs:
+paths:
   - "crates/graphql-linter/**"
 ---
 

--- a/.claude/rules/lsp-handlers.md
+++ b/.claude/rules/lsp-handlers.md
@@ -1,6 +1,6 @@
 ---
 description: LSP handler conventions and protocol compliance
-globs:
+paths:
   - "crates/graphql-lsp/**"
 ---
 

--- a/.claude/rules/protected-files.md
+++ b/.claude/rules/protected-files.md
@@ -1,6 +1,6 @@
 ---
 description: Files and patterns that must never be modified without explicit permission
-globs:
+paths:
   - ".github/workflows/release.yml"
 ---
 

--- a/.claude/rules/salsa-queries.md
+++ b/.claude/rules/salsa-queries.md
@@ -1,6 +1,6 @@
 ---
 description: Salsa query patterns and cache invariants for the database layer
-globs:
+paths:
   - "crates/graphql-db/**"
   - "crates/graphql-hir/**"
 ---

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 ---
 description: Test organization and TestDatabase patterns
-globs:
+paths:
   - "**/tests/**"
   - "**/*_test.rs"
   - "crates/graphql-test-utils/**"

--- a/.claude/rules/vscode-extension.md
+++ b/.claude/rules/vscode-extension.md
@@ -1,6 +1,6 @@
 ---
 description: VS Code extension development rules
-globs:
+paths:
   - "editors/vscode/**"
 ---
 


### PR DESCRIPTION
## Summary
- Replace invalid `globs` frontmatter key with `paths` in all 8 `.claude/rules/` files
- `globs` is not a recognized key; `paths` is the correct one for path-scoped rules

## Test plan
- [x] Verify rules files load correctly with `paths` key


🤖 Generated with [Claude Code](https://claude.com/claude-code)