### PR TITLE
docs: add VS Code Marketplace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This project draws heavy inspiration from [rust-analyzer](https://rust-analyzer.
 
 ### 1. Install the VS Code Extension
 
+Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer): search for "graphql-analyzer" in the Extensions view, or run:
+
+```bash
+code --install-extension graphql-analyzer.graphql-analyzer
+```
+
+**Alternative: install from GitHub Release**
+
+<details>
+<summary>macOS / Linux / Windows scripts</summary>
+
 **macOS / Linux:**
 
 ```sh
@@ -25,6 +36,8 @@ irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/script
 ```
 
 Or download the `.vsix` from the [releases page](https://github.com/trevor-scheer/graphql-analyzer/releases) and install via `code --install-extension <file>.vsix`.
+
+</details>
 
 ### 2. Configure Your Project
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -41,7 +41,11 @@ A VS Code extension that provides comprehensive GraphQL language support includi
 
 ### From VS Code Marketplace
 
-Coming soon - this extension will be published to the VS Code Marketplace.
+Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer): search for "graphql-analyzer" in the Extensions view, or run:
+
+```bash
+code --install-extension graphql-analyzer.graphql-analyzer
+```
 
 ### From GitHub Release
 


### PR DESCRIPTION
## Summary
- Add VS Code Marketplace as the primary installation method in both the root README and extension README
- Move script-based installation to a collapsible "Alternative" section in root README
- Replace "Coming soon" placeholder with actual marketplace link and `code --install-extension` command

## Test plan
- [ ] Verify marketplace link resolves: https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer
- [ ] Verify `code --install-extension graphql-analyzer.graphql-analyzer` works

https://claude.ai/code/session_01TjgHJ8vgLiUUjr4uA2jtFc