### PR TITLE
chore: schedule Renovate to run weekly on Sundays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:weekly"
+  ],
+  "schedule": [
+    "before 9am on Sunday"
   ],
   "ignorePaths": [
     "test-workspace/**"


### PR DESCRIPTION
## Summary
- Adds `schedule:weekly` preset and a `"before 9am on Sunday"` schedule to `renovate.json`
- Reduces Renovate noise by batching dependency update PRs to once per week

## Test plan
- Verify Renovate respects the new schedule on next run (no PRs created outside Sunday window)

https://claude.ai/code/session_01K7BPfbB23JiTgbeHshDKnp