### PR TITLE
fix: include implicit field-traversal type deps in schema-diff filtering

### DIFF
--- a/.changeset/schema-save-perf.md
+++ b/.changeset/schema-save-perf.md
@@ -1,0 +1,7 @@
+---
+graphql-analyzer-lsp: patch
+graphql-analyzer-cli: patch
+graphql-analyzer-mcp: patch
+---
+
+Improve schema save performance by enabling Salsa backdating for unchanged schemas ([#745](https://github.com/trevor-scheer/graphql-analyzer/issues/745))

--- a/crates/analysis/src/merged_schema.rs
+++ b/crates/analysis/src/merged_schema.rs
@@ -3,19 +3,58 @@ use apollo_compiler::diagnostic::ToCliReport;
 use apollo_compiler::parser::{Parser, SourceOffset};
 use apollo_compiler::validation::DiagnosticList;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 /// Diagnostics grouped by file URI
 pub type DiagnosticsByFile = Arc<HashMap<Arc<str>, Vec<Diagnostic>>>;
 
-/// Result of merging schema files - includes both the schema (if valid) and any diagnostics
-#[derive(Clone, Debug, PartialEq)]
+/// Result of merging schema files - includes both the schema (if valid) and any diagnostics.
+///
+/// Uses SDL-based equality so Salsa can backdate unchanged results. Without this,
+/// every schema rebuild produces a new `Arc<Schema>` pointer, which Salsa treats as
+/// "changed" even if the schema is structurally identical. That cascades into
+/// re-validating every document file unnecessarily.
+#[derive(Clone, Debug)]
 pub struct MergedSchemaResult {
     /// The merged schema, if validation succeeded
     pub schema: Option<Arc<apollo_compiler::Schema>>,
     /// Validation diagnostics grouped by file URI
     pub diagnostics_by_file: DiagnosticsByFile,
+    /// Hash of the serialized SDL, used for semantic equality comparison.
+    /// Two schemas that produce the same SDL are considered equal regardless
+    /// of Arc pointer identity.
+    schema_sdl_hash: u64,
 }
+
+impl MergedSchemaResult {
+    fn new(
+        schema: Option<Arc<apollo_compiler::Schema>>,
+        diagnostics_by_file: DiagnosticsByFile,
+    ) -> Self {
+        let schema_sdl_hash = schema.as_ref().map_or(0, |s| {
+            let sdl = s.serialize().to_string();
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            sdl.hash(&mut hasher);
+            hasher.finish()
+        });
+
+        Self {
+            schema,
+            diagnostics_by_file,
+            schema_sdl_hash,
+        }
+    }
+}
+
+impl PartialEq for MergedSchemaResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema_sdl_hash == other.schema_sdl_hash
+            && self.diagnostics_by_file == other.diagnostics_by_file
+    }
+}
+
+impl Eq for MergedSchemaResult {}
 
 /// Convert apollo-compiler diagnostics to our diagnostic format, grouped by file URI.
 ///
@@ -104,10 +143,7 @@ pub fn merged_schema_with_diagnostics(
 
     if !has_user_schema {
         tracing::debug!("No user schema files found in project - returning empty result");
-        return MergedSchemaResult {
-            schema: None,
-            diagnostics_by_file: Arc::new(HashMap::new()),
-        };
+        return MergedSchemaResult::new(None, Arc::new(HashMap::new()));
     }
 
     let mut builder = apollo_compiler::schema::SchemaBuilder::new();
@@ -160,10 +196,10 @@ pub fn merged_schema_with_diagnostics(
                         type_count = valid_schema.types.len(),
                         "Successfully merged and validated schema"
                     );
-                    MergedSchemaResult {
-                        schema: Some(Arc::new(valid_schema.into_inner())),
-                        diagnostics_by_file: Arc::new(HashMap::new()),
-                    }
+                    MergedSchemaResult::new(
+                        Some(Arc::new(valid_schema.into_inner())),
+                        Arc::new(HashMap::new()),
+                    )
                 }
                 Err(with_errors) => {
                     tracing::warn!(
@@ -174,10 +210,10 @@ pub fn merged_schema_with_diagnostics(
                         tracing::debug!(error = %apollo_diag.error, "Schema validation error");
                     }
                     let diagnostics_by_file = collect_apollo_diagnostics(&with_errors.errors);
-                    MergedSchemaResult {
-                        schema: Some(Arc::new(with_errors.partial)),
-                        diagnostics_by_file: Arc::new(diagnostics_by_file),
-                    }
+                    MergedSchemaResult::new(
+                        Some(Arc::new(with_errors.partial)),
+                        Arc::new(diagnostics_by_file),
+                    )
                 }
             }
         }
@@ -190,10 +226,7 @@ pub fn merged_schema_with_diagnostics(
                 tracing::debug!(error = %apollo_diag.error, "Schema build error");
             }
             let diagnostics_by_file = collect_apollo_diagnostics(&with_errors.errors);
-            MergedSchemaResult {
-                schema: None,
-                diagnostics_by_file: Arc::new(diagnostics_by_file),
-            }
+            MergedSchemaResult::new(None, Arc::new(diagnostics_by_file))
         }
     }
 }
@@ -221,10 +254,7 @@ mod tests {
 
     #[test]
     fn test_merged_schema_result_default_values() {
-        let result = MergedSchemaResult {
-            schema: None,
-            diagnostics_by_file: Arc::new(HashMap::new()),
-        };
+        let result = MergedSchemaResult::new(None, Arc::new(HashMap::new()));
         assert!(result.schema.is_none());
         assert!(result.diagnostics_by_file.is_empty());
     }
@@ -236,10 +266,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result = MergedSchemaResult {
-            schema: Some(Arc::new(schema)),
-            diagnostics_by_file: Arc::new(HashMap::new()),
-        };
+        let result = MergedSchemaResult::new(Some(Arc::new(schema)), Arc::new(HashMap::new()));
         assert!(result.schema.is_some());
         assert!(result.diagnostics_by_file.is_empty());
     }
@@ -258,25 +285,57 @@ mod tests {
             }],
         );
 
-        let result = MergedSchemaResult {
-            schema: None,
-            diagnostics_by_file: Arc::new(diagnostics),
-        };
+        let result = MergedSchemaResult::new(None, Arc::new(diagnostics));
         assert!(result.schema.is_none());
         assert_eq!(result.diagnostics_by_file.len(), 1);
     }
 
     #[test]
     fn test_merged_schema_result_equality() {
-        let result1 = MergedSchemaResult {
-            schema: None,
-            diagnostics_by_file: Arc::new(HashMap::new()),
-        };
-        let result2 = MergedSchemaResult {
-            schema: None,
-            diagnostics_by_file: Arc::new(HashMap::new()),
-        };
+        let result1 = MergedSchemaResult::new(None, Arc::new(HashMap::new()));
+        let result2 = MergedSchemaResult::new(None, Arc::new(HashMap::new()));
         assert_eq!(result1, result2);
+    }
+
+    #[test]
+    fn test_merged_schema_result_semantic_equality() {
+        // Two independently-built schemas with identical SDL should be equal
+        // even though they have different Arc pointers
+        let schema1 = apollo_compiler::Schema::builder()
+            .parse("type Query { hello: String }", "schema.graphql")
+            .build()
+            .unwrap();
+        let schema2 = apollo_compiler::Schema::builder()
+            .parse("type Query { hello: String }", "schema.graphql")
+            .build()
+            .unwrap();
+
+        let result1 = MergedSchemaResult::new(Some(Arc::new(schema1)), Arc::new(HashMap::new()));
+        let result2 = MergedSchemaResult::new(Some(Arc::new(schema2)), Arc::new(HashMap::new()));
+
+        // Different Arc pointers, but same SDL hash
+        assert!(!Arc::ptr_eq(
+            result1.schema.as_ref().unwrap(),
+            result2.schema.as_ref().unwrap()
+        ));
+        assert_eq!(result1, result2);
+    }
+
+    #[test]
+    fn test_merged_schema_result_different_schemas_not_equal() {
+        let schema1 = apollo_compiler::Schema::builder()
+            .parse("type Query { hello: String }", "schema.graphql")
+            .build()
+            .unwrap();
+        let schema2 = apollo_compiler::Schema::builder()
+            .parse("type Query { goodbye: Int }", "schema.graphql")
+            .build()
+            .unwrap();
+
+        let result1 = MergedSchemaResult::new(Some(Arc::new(schema1)), Arc::new(HashMap::new()));
+        let result2 = MergedSchemaResult::new(Some(Arc::new(schema2)), Arc::new(HashMap::new()));
+
+        assert_ne!(result1, result2);
     }
 
     #[test]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -4,6 +4,7 @@
 
 use graphql_base_db::FileId;
 use std::collections::HashMap;
+use std::hash::Hasher;
 use std::sync::Arc;
 
 mod body;
@@ -333,6 +334,30 @@ pub fn schema_directives(
     }
 
     directives
+}
+
+/// Per-type fingerprints for the merged schema.
+///
+/// Returns a hash for each type name. When a schema file changes, only
+/// types actually modified will have different fingerprints. This enables
+/// the IDE layer to diff old vs new and skip re-validating operations
+/// that don't reference any changed types.
+#[salsa::tracked(returns(ref))]
+pub fn schema_type_fingerprints(
+    db: &dyn GraphQLHirDatabase,
+    project_files: graphql_base_db::ProjectFiles,
+) -> HashMap<Arc<str>, u64> {
+    let types = schema_types(db, project_files);
+    let mut fingerprints = HashMap::with_capacity(types.len());
+    for (name, type_def) in types {
+        let mut hasher = std::hash::DefaultHasher::new();
+        // Use semantic_hash to ignore positional data (ranges, file IDs).
+        // This way, shifting text positions from unrelated edits in the
+        // same file don't cause false "type changed" signals.
+        type_def.semantic_hash(&mut hasher);
+        fingerprints.insert(name.clone(), hasher.finish());
+    }
+    fingerprints
 }
 
 /// Get all fragments in the project

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -1,6 +1,7 @@
 use apollo_compiler::ast;
 use apollo_compiler::Node;
 use graphql_base_db::FileId;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 pub use text_size::{TextRange, TextSize};
 
@@ -26,6 +27,63 @@ pub struct TypeDef {
     pub definition_range: TextRange,
     /// Whether this type was extracted from a type extension (extend type)
     pub is_extension: bool,
+}
+
+impl TypeDef {
+    /// Hash only semantic content, excluding positional data (ranges, file IDs).
+    /// Two type defs with the same schema meaning but different source positions
+    /// will produce the same hash.
+    pub fn semantic_hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.kind.hash(state);
+        self.is_extension.hash(state);
+        self.description.hash(state);
+
+        self.fields.len().hash(state);
+        for field in &self.fields {
+            field.semantic_hash(state);
+        }
+
+        self.implements.hash(state);
+        self.union_members.hash(state);
+
+        self.enum_values.len().hash(state);
+        for ev in &self.enum_values {
+            ev.hash(state);
+        }
+
+        self.directives.hash(state);
+    }
+}
+
+impl FieldSignature {
+    /// Hash only semantic content, excluding positional data.
+    pub fn semantic_hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.type_ref.hash(state);
+        self.description.hash(state);
+        self.is_deprecated.hash(state);
+        self.deprecation_reason.hash(state);
+        self.directives.hash(state);
+
+        self.arguments.len().hash(state);
+        for arg in &self.arguments {
+            arg.semantic_hash(state);
+        }
+    }
+}
+
+impl ArgumentDef {
+    /// Hash only semantic content, excluding positional data.
+    pub fn semantic_hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.type_ref.hash(state);
+        self.default_value.hash(state);
+        self.description.hash(state);
+        self.is_deprecated.hash(state);
+        self.deprecation_reason.hash(state);
+        self.directives.hash(state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ide/src/diagnostics_for_change_tests.rs
+++ b/crates/ide/src/diagnostics_for_change_tests.rs
@@ -1,5 +1,16 @@
 use super::{AnalysisHost, DiagnosticSeverity, DocumentKind, FilePath, Language};
 
+/// Helper to set up a host with fingerprints initialized.
+/// This mirrors what the LSP does: load files, rebuild, capture fingerprints.
+fn setup_host_with_fingerprints(
+    schema: &str,
+    files: &[(&str, &str, DocumentKind)],
+) -> (AnalysisHost, FilePath, Vec<FilePath>) {
+    let (mut host, schema_path, file_paths) = setup_host(schema, files);
+    host.update_schema_fingerprints();
+    (host, schema_path, file_paths)
+}
+
 /// Helper to set up a host with schema + document files and rebuild project files
 fn setup_host(
     schema: &str,
@@ -270,5 +281,300 @@ fn document_change_without_fragments_or_ops_is_self_only() {
         let result = snapshot.diagnostics_for_change(anon_path);
         assert!(result.contains_key(anon_path));
         assert!(!result.contains_key(other_path));
+    }
+}
+
+// ============================================================================
+// Schema-diff filtering tests
+// ============================================================================
+
+#[test]
+fn schema_diff_skips_unrelated_type_change() {
+    // Two operations reference different types via fragments.
+    // Changing only one type should only re-validate the operation
+    // that references it (via fragment type condition).
+    let (mut host, schema_path, file_paths) = setup_host_with_fingerprints(
+        "type Query { user: User\npost: Post }\ntype User { name: String }\ntype Post { title: String }",
+        &[
+            (
+                "user_query.graphql",
+                "fragment UserFields on User { name }\nquery { user { ...UserFields } }",
+                DocumentKind::Executable,
+            ),
+            (
+                "post_query.graphql",
+                "fragment PostFields on Post { title }\nquery { post { ...PostFields } }",
+                DocumentKind::Executable,
+            ),
+        ],
+    );
+    let user_query = &file_paths[0];
+    let post_query = &file_paths[1];
+
+    // Initial: no errors
+    {
+        let snapshot = host.snapshot();
+        assert!(!has_error(&snapshot.diagnostics(user_query)));
+        assert!(!has_error(&snapshot.diagnostics(post_query)));
+    }
+
+    // Change only the User type (add a field)
+    host.add_file(
+        &schema_path,
+        "type Query { user: User\npost: Post }\ntype User { name: String\nemail: String }\ntype Post { title: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // user_query references User so it SHOULD be re-validated
+        assert!(
+            result.contains_key(user_query),
+            "user_query should be re-validated (references changed User type)"
+        );
+
+        // post_query only references Post which didn't change - should be skipped
+        assert!(
+            !result.contains_key(post_query),
+            "post_query should be skipped (Post type unchanged)"
+        );
+    }
+}
+
+#[test]
+fn schema_diff_revalidates_all_when_query_type_changes() {
+    // When the Query root type changes, all operations must be re-validated
+    // because operations implicitly depend on their root type.
+    let (mut host, schema_path, file_paths) = setup_host_with_fingerprints(
+        "type Query { hero: String\nvillain: String }",
+        &[
+            (
+                "hero_query.graphql",
+                "query { hero }",
+                DocumentKind::Executable,
+            ),
+            (
+                "villain_query.graphql",
+                "query { villain }",
+                DocumentKind::Executable,
+            ),
+        ],
+    );
+    let hero_path = &file_paths[0];
+    let villain_path = &file_paths[1];
+
+    // Add a new field to Query type
+    host.add_file(
+        &schema_path,
+        "type Query { hero: String\nvillain: String\nsidekick: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // Both should be re-validated when Query type changes
+        assert!(
+            result.contains_key(hero_path),
+            "hero_query should be re-validated (Query type changed)"
+        );
+        assert!(
+            result.contains_key(villain_path),
+            "villain_query should be re-validated (Query type changed)"
+        );
+    }
+}
+
+#[test]
+fn schema_diff_skips_all_when_no_types_changed() {
+    // If a schema file changes but no type definitions actually changed
+    // (e.g., whitespace or comment change), all document files should be skipped.
+    let (mut host, schema_path, file_paths) = setup_host_with_fingerprints(
+        "type Query { hero: String }",
+        &[("query.graphql", "query { hero }", DocumentKind::Executable)],
+    );
+    let query_path = &file_paths[0];
+
+    // Initial: no errors
+    {
+        let snapshot = host.snapshot();
+        assert!(!has_error(&snapshot.diagnostics(query_path)));
+    }
+
+    // "Change" the schema by adding a description (which changes the SDL
+    // but might or might not change type fingerprints depending on whether
+    // descriptions are part of TypeDef). Even if it does change, the key
+    // test is that the diffing mechanism works.
+    //
+    // Use exact same content to test the "no types changed" path.
+    host.add_file(
+        &schema_path,
+        "type Query { hero: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // Only the schema file itself should be in the result
+        assert!(result.contains_key(&schema_path));
+        assert!(
+            !result.contains_key(query_path),
+            "query.graphql should be skipped (no types changed)"
+        );
+    }
+}
+
+#[test]
+fn schema_diff_handles_type_removal() {
+    // When a type is removed from the schema, operations referencing it
+    // should be re-validated.
+    let (mut host, schema_path, file_paths) = setup_host_with_fingerprints(
+        "type Query { user: User }\ntype User { name: String }\ntype Post { title: String }",
+        &[
+            (
+                "user_frag.graphql",
+                "fragment F on User { name }",
+                DocumentKind::Executable,
+            ),
+            (
+                "post_frag.graphql",
+                "fragment P on Post { title }",
+                DocumentKind::Executable,
+            ),
+        ],
+    );
+    let user_frag = &file_paths[0];
+    let post_frag = &file_paths[1];
+
+    // Remove the Post type
+    host.add_file(
+        &schema_path,
+        "type Query { user: User }\ntype User { name: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // post_frag references Post which was removed - should be re-validated
+        assert!(
+            result.contains_key(post_frag),
+            "post_frag should be re-validated (Post type removed)"
+        );
+
+        // user_frag references User which didn't change - should be skipped
+        assert!(
+            !result.contains_key(user_frag),
+            "user_frag should be skipped (User type unchanged)"
+        );
+    }
+}
+
+#[test]
+fn schema_diff_with_variable_type_reference() {
+    // Operations reference types via variables. Changing a variable's input type
+    // should cause that operation to be re-validated.
+    let (mut host, schema_path, file_paths) = setup_host_with_fingerprints(
+        "type Query { user(id: ID!): User }\ntype User { name: String }\ninput UserInput { name: String }",
+        &[
+            (
+                "simple_query.graphql",
+                "query { user(id: \"1\") { name } }",
+                DocumentKind::Executable,
+            ),
+            (
+                "input_query.graphql",
+                "query CreateUser($input: UserInput!) { user(id: \"1\") { name } }",
+                DocumentKind::Executable,
+            ),
+        ],
+    );
+    let simple_query = &file_paths[0];
+    let input_query = &file_paths[1];
+
+    // Change UserInput type
+    host.add_file(
+        &schema_path,
+        "type Query { user(id: ID!): User }\ntype User { name: String }\ninput UserInput { name: String\nemail: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // input_query references UserInput via variable - should be re-validated
+        assert!(
+            result.contains_key(input_query),
+            "input_query should be re-validated (UserInput type changed)"
+        );
+
+        // simple_query doesn't reference UserInput - should be skipped
+        // (Query type didn't change in terms of fields, but its field arg type
+        // didn't change since we didn't modify ID or User)
+        // Actually: Query type DID change because user field's return type User didn't change,
+        // but Query type itself didn't change structurally. Let's verify.
+        // Query type hash: same fields {user(id: ID!): User} - unchanged.
+        assert!(
+            !result.contains_key(simple_query),
+            "simple_query should be skipped (doesn't reference UserInput)"
+        );
+    }
+}
+
+#[test]
+fn first_schema_change_without_fingerprints_validates_all() {
+    // Without calling update_schema_fingerprints, the first schema change
+    // should fall back to validating all document files (no previous baseline).
+    let (mut host, schema_path, file_paths) = setup_host(
+        "type Query { hero: String }\ntype User { name: String }",
+        &[
+            (
+                "hero_query.graphql",
+                "query { hero }",
+                DocumentKind::Executable,
+            ),
+            (
+                "user_frag.graphql",
+                "fragment F on User { name }",
+                DocumentKind::Executable,
+            ),
+        ],
+    );
+    let hero_path = &file_paths[0];
+    let user_frag = &file_paths[1];
+
+    // Change User type without having called update_schema_fingerprints
+    host.add_file(
+        &schema_path,
+        "type Query { hero: String }\ntype User { name: String\nemail: String }",
+        Language::GraphQL,
+        DocumentKind::Schema,
+    );
+
+    {
+        let snapshot = host.snapshot();
+        let result = snapshot.diagnostics_for_change(&schema_path);
+
+        // Both files should be re-validated (no fingerprint baseline)
+        assert!(
+            result.contains_key(hero_path),
+            "hero_query should be re-validated (no fingerprint baseline)"
+        );
+        assert!(
+            result.contains_key(user_frag),
+            "user_frag should be re-validated (no fingerprint baseline)"
+        );
     }
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -829,6 +829,11 @@ pub struct AnalysisHost {
     /// File registry for mapping paths to file IDs
     /// Wrapped in Arc<RwLock> so snapshots can share it
     registry: Arc<RwLock<FileRegistry>>,
+    /// Previous schema type fingerprints for diff-based filtering.
+    /// When a schema file changes, we compare old vs new fingerprints
+    /// to determine which types actually changed, and only re-validate
+    /// document files that reference those changed types.
+    previous_schema_fingerprints: Arc<HashMap<Arc<str>, u64>>,
 }
 
 impl AnalysisHost {
@@ -838,6 +843,7 @@ impl AnalysisHost {
         Self {
             db: IdeDatabase::default(),
             registry: Arc::new(RwLock::new(FileRegistry::new())),
+            previous_schema_fingerprints: Arc::new(HashMap::new()),
         }
     }
 
@@ -985,6 +991,7 @@ impl AnalysisHost {
             db: self.db.clone(),
             registry: Arc::clone(&self.registry),
             project_files,
+            previous_schema_fingerprints: Arc::clone(&self.previous_schema_fingerprints),
         };
 
         (is_new, snapshot)
@@ -1500,6 +1507,16 @@ impl AnalysisHost {
             db: self.db.clone(),
             registry: Arc::clone(&self.registry),
             project_files,
+            previous_schema_fingerprints: Arc::clone(&self.previous_schema_fingerprints),
+        }
+    }
+
+    /// Update stored schema fingerprints after a schema change has been processed.
+    /// Call this after `diagnostics_for_change` to keep fingerprints in sync.
+    pub fn update_schema_fingerprints(&mut self) {
+        if let Some(pf) = self.db.project_files_input {
+            let fingerprints = graphql_hir::schema_type_fingerprints(&self.db, pf);
+            self.previous_schema_fingerprints = Arc::new(fingerprints.clone());
         }
     }
 }
@@ -1528,6 +1545,10 @@ pub struct Analysis {
     /// Cached `ProjectFiles` for HIR queries
     /// This is fetched from the registry when the snapshot is created
     project_files: Option<graphql_base_db::ProjectFiles>,
+    /// Schema type fingerprints from before the current change.
+    /// Used to diff which types actually changed and skip re-validating
+    /// document files that don't reference any changed types.
+    previous_schema_fingerprints: Arc<HashMap<Arc<str>, u64>>,
 }
 
 impl Analysis {
@@ -1565,14 +1586,16 @@ impl Analysis {
     /// Get diagnostics for all files affected by a change to `changed_file`.
     ///
     /// Always includes diagnostics for the changed file itself. Additionally:
-    /// - If the changed file is a **schema** file, re-validates all document files
-    ///   (every operation/fragment validates against the schema).
+    /// - If the changed file is a **schema** file, uses schema-diff filtering
+    ///   to only re-validate document files that reference changed types.
     /// - If the changed file is a **document** file containing fragments,
     ///   re-validates files that spread those fragments.
     /// - If the changed file has named operations, re-validates files with
     ///   same-named operations (uniqueness checks).
     ///
-    /// Salsa memoization ensures unaffected files return cached results instantly.
+    /// Schema-diff filtering compares per-type fingerprints before and after the
+    /// change. Document files that don't reference any changed type names are
+    /// skipped entirely, leaving their Salsa queries dirty but unexecuted.
     pub fn diagnostics_for_change(
         &self,
         changed_file: &FilePath,
@@ -1602,26 +1625,7 @@ impl Analysis {
         };
 
         if is_schema {
-            // Schema change: re-validate all document files
-            let document_files: Vec<FilePath> = {
-                let registry = self.registry.read();
-                registry
-                    .all_file_ids()
-                    .into_iter()
-                    .filter(|&id| {
-                        registry
-                            .get_metadata(id)
-                            .is_some_and(|m| m.is_document(&self.db))
-                    })
-                    .filter_map(|id| registry.get_path(id))
-                    .collect()
-            };
-
-            for doc_file in document_files {
-                if doc_file != *changed_file {
-                    result.insert(doc_file.clone(), self.diagnostics(&doc_file));
-                }
-            }
+            self.schema_change_diagnostics(project_files, changed_file, &mut result);
         } else if is_document {
             // Document file change: find affected files via fragment/operation dependencies
             let affected = self.find_affected_document_files(changed_file_id, project_files);
@@ -1633,6 +1637,143 @@ impl Analysis {
         }
 
         result
+    }
+
+    /// Handle schema file changes with diff-based filtering.
+    ///
+    /// Compares per-type fingerprints to the previous snapshot. Only re-validates
+    /// document files whose type references intersect with changed types.
+    /// Falls back to full re-validation when fingerprints are unavailable
+    /// (first change after startup) or when root operation types changed.
+    fn schema_change_diagnostics(
+        &self,
+        project_files: graphql_base_db::ProjectFiles,
+        changed_file: &FilePath,
+        result: &mut HashMap<FilePath, Vec<Diagnostic>>,
+    ) {
+        let document_files: Vec<(graphql_base_db::FileId, FilePath)> = {
+            let registry = self.registry.read();
+            registry
+                .all_file_ids()
+                .into_iter()
+                .filter(|&id| {
+                    registry
+                        .get_metadata(id)
+                        .is_some_and(|m| m.is_document(&self.db))
+                })
+                .filter_map(|id| registry.get_path(id).map(|p| (id, p)))
+                .collect()
+        };
+
+        let changed_types = self.changed_schema_type_names(project_files);
+
+        if let Some(ref changed) = changed_types {
+            tracing::debug!(
+                changed_count = changed.len(),
+                "Schema diff: {} type(s) changed",
+                changed.len()
+            );
+        }
+
+        let mut skipped = 0usize;
+        for (file_id, doc_file) in &document_files {
+            if *doc_file == *changed_file {
+                continue;
+            }
+
+            if let Some(ref changed) = changed_types {
+                if changed.is_empty() {
+                    // No types actually changed - skip all document files.
+                    // (D/Salsa backdating handles this at the query level too,
+                    // but skipping here avoids even calling into Salsa.)
+                    skipped += 1;
+                    continue;
+                }
+
+                if self.can_skip_document_file(*file_id, project_files, changed) {
+                    skipped += 1;
+                    continue;
+                }
+            }
+
+            result.insert(doc_file.clone(), self.diagnostics(doc_file));
+        }
+
+        if skipped > 0 {
+            tracing::debug!(
+                skipped,
+                total = document_files.len(),
+                "Schema diff filtering: skipped {}/{} document files",
+                skipped,
+                document_files.len()
+            );
+        }
+    }
+
+    /// Compute which schema type names changed compared to previous fingerprints.
+    /// Returns `None` if no previous fingerprints are available (first schema change).
+    fn changed_schema_type_names(
+        &self,
+        project_files: graphql_base_db::ProjectFiles,
+    ) -> Option<std::collections::HashSet<Arc<str>>> {
+        if self.previous_schema_fingerprints.is_empty() {
+            return None;
+        }
+
+        let current = graphql_hir::schema_type_fingerprints(&self.db, project_files);
+        let previous = &*self.previous_schema_fingerprints;
+        let mut changed = std::collections::HashSet::new();
+
+        // Types that are new or modified
+        for (name, hash) in current {
+            match previous.get(name) {
+                Some(prev_hash) if *prev_hash == *hash => {}
+                _ => {
+                    changed.insert(name.clone());
+                }
+            }
+        }
+
+        // Types that were removed
+        for name in previous.keys() {
+            if !current.contains_key(name) {
+                changed.insert(name.clone());
+            }
+        }
+
+        Some(changed)
+    }
+
+    /// Check whether a document file can be safely skipped during schema
+    /// change re-validation, based on its type references.
+    fn can_skip_document_file(
+        &self,
+        file_id: graphql_base_db::FileId,
+        project_files: graphql_base_db::ProjectFiles,
+        changed_types: &std::collections::HashSet<Arc<str>>,
+    ) -> bool {
+        // If root operation types changed, operations of that kind need re-validation.
+        // Since file_type_name_references doesn't capture implicit root type deps,
+        // we check if any root type changed and conservatively include all files.
+        let root_type_changed = changed_types.contains("Query")
+            || changed_types.contains("Mutation")
+            || changed_types.contains("Subscription");
+
+        if root_type_changed {
+            return false;
+        }
+
+        let Some((content, metadata)) =
+            graphql_base_db::file_lookup(&self.db, project_files, file_id)
+        else {
+            return true;
+        };
+
+        let type_refs =
+            graphql_hir::file_type_name_references(&self.db, file_id, content, metadata);
+
+        // Skip if none of the file's referenced types are in the changed set
+        !type_refs.iter().any(|name| changed_types.contains(name))
     }
 
     /// Get all diagnostics (per-file + project-wide lints) for files affected by a change.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -1772,8 +1772,19 @@ impl Analysis {
         let type_refs =
             graphql_hir::file_type_name_references(&self.db, file_id, content, metadata);
 
-        // Skip if none of the file's referenced types are in the changed set
-        !type_refs.iter().any(|name| changed_types.contains(name))
+        if type_refs.iter().any(|name| changed_types.contains(name)) {
+            return false;
+        }
+
+        // file_type_name_references only captures explicit type names (variable types,
+        // fragment type conditions). It misses implicit dependencies from field selections
+        // like `query { user { name } }` where `User` is only reachable via schema traversal.
+        // file_schema_coordinates walks the selection set through the schema and captures
+        // all type names that the file's selections pass through.
+        let coords =
+            graphql_hir::file_schema_coordinates(&self.db, file_id, content, metadata, project_files);
+
+        !coords.iter().any(|c| changed_types.contains(&c.type_name))
     }
 
     /// Get all diagnostics (per-file + project-wide lints) for files affected by a change.

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -691,9 +691,12 @@ async fn load_all_project_files_background(
             );
         }
 
-        // Rebuild project files index (brief lock)
-        host.with_write(graphql_ide::AnalysisHost::rebuild_project_files)
-            .await;
+        // Rebuild project files index and capture initial schema fingerprints (brief lock)
+        host.with_write(|h| {
+            h.rebuild_project_files();
+            h.update_schema_fingerprints();
+        })
+        .await;
 
         // Compute and publish diagnostics
         // Use try_snapshot since this is a background task - if we can't get the lock, just skip diagnostics
@@ -2095,6 +2098,11 @@ impl LanguageServer for GraphQLLanguageServer {
             .instrument(tracing::info_span!("publish_diagnostics", file_count))
             .await;
         }
+
+        // Update schema fingerprints so the next schema change can diff against them.
+        // This must happen after diagnostics are published (which used the old fingerprints).
+        host.with_write(graphql_ide::AnalysisHost::update_schema_fingerprints)
+            .await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {


### PR DESCRIPTION
## Problem

After a schema save, `can_skip_document_file()` uses `file_type_name_references()` to decide whether a document needs re-validation. That function only captures **explicit** type names from the file's structure layer:

- Variable type annotations: `$id: UserID!` → captures `UserID`
- Named fragment type conditions: `fragment F on User` → captures `User`

It does **not** capture types that are only reachable via field selection traversal. For a query like:

```graphql
query GetUser {
  user {
    name   # ← field removed from schema type
  }
}
```

`file_type_name_references()` returns `{}` (empty). When `User.name` is removed from the schema:

1. `changed_types = {"User"}`
2. Root type check: `"User"` is not `Query/Mutation/Subscription` → no short-circuit
3. `type_refs ∩ changed_types = {} ∩ {"User"} = {}` → **file incorrectly skipped**
4. No re-validation → no diagnostics published

**Symptoms observed:**
- After saving a schema change that removes/modifies a field on a non-root type, affected operations show no diagnostics
- Hover returns `null` for the now-invalid field (correct — field gone from schema), but no error is shown to explain why
- Inlay type hints disappear for that specific field

## Fix

In `can_skip_document_file()`, add a second check using `file_schema_coordinates()`. This function walks the selection set recursively through the schema, recording `{type_name, field_name}` pairs for every field accessed. Extracting the `type_name` values gives the complete set of types the document implicitly depends on.

```rust
// Before: only explicit type refs
!type_refs.iter().any(|name| changed_types.contains(name))

// After: also check implicit deps from field traversal
if type_refs.iter().any(|name| changed_types.contains(name)) {
    return false; // don't skip
}
let coords = file_schema_coordinates(..., project_files);
!coords.iter().any(|c| changed_types.contains(&c.type_name))
```

**Why this is correct even for removed fields:** `file_schema_coordinates` records coordinates from the AST before the schema lookup used for recursion. So `{User, name}` is recorded even when `name` no longer exists in the updated `User` type — the coordinate still carries `type_name = "User"`, which intersects with `changed_types`.

## Scope

This fix only affects the **schema-change diff filtering path** (`did_save` → `schema_change_diagnostics`). It has no effect on:
- `did_change` (always validates the changed file directly)
- Document-change propagation (uses fragment dependency tracking, unrelated)
- The root type fast path (Query/Mutation/Subscription handled before this check)

## Performance note

`file_schema_coordinates` depends on `schema_types`, so it's invalidated when the schema changes. This means filtering now recomputes coordinates for each document file after a schema change. However, `all_used_schema_coordinates` already does this project-wide for other features, so the work is within the established performance envelope. If this proves expensive on very large projects, the coordinate type-name projection could be cached separately.

## Still open

This fix is **blocked on** the document validation issue (#758). Until document validation runs at all, this fix cannot be verified end-to-end in the test project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)