### PR TITLE
fix: correct changeset package scoping and PR links

### DIFF
--- a/.changeset/fix-hover-field-usage-count.md
+++ b/.changeset/fix-hover-field-usage-count.md
@@ -2,6 +2,7 @@
 graphql-analyzer-lsp: patch
 graphql-analyzer-cli: patch
 graphql-analyzer-mcp: patch
+graphql-analyzer-vscode: patch
 ---
 
 Fix hover showing 0 usages for fields on nested types ([#742](https://github.com/trevor-scheer/graphql-analyzer/pull/742))

--- a/.changeset/fix-ts-generic-parse-error.md
+++ b/.changeset/fix-ts-generic-parse-error.md
@@ -1,6 +1,8 @@
 ---
 graphql-analyzer-lsp: patch
 graphql-analyzer-cli: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-vscode: patch
 ---
 
-Fix SWC parse error on `.ts` files containing generic arrow functions ([#755](https://github.com/trevor-scheer/graphql-analyzer/pull/765))
+Fix SWC parse error on `.ts` files containing generic arrow functions ([#765](https://github.com/trevor-scheer/graphql-analyzer/pull/765))

--- a/.changeset/mcp-lsp-plugin-tools.md
+++ b/.changeset/mcp-lsp-plugin-tools.md
@@ -2,4 +2,4 @@
 graphql-analyzer-mcp: minor
 ---
 
-Add LSP plugin-style code intelligence tools: goto_definition, find_references, hover, document_symbols, workspace_symbols, get_completions, and get_file_diagnostics ([#742](https://github.com/trevor-scheer/graphql-analyzer/pull/742))
+Add LSP plugin-style code intelligence tools: goto_definition, find_references, hover, document_symbols, workspace_symbols, get_completions, and get_file_diagnostics ([#748](https://github.com/trevor-scheer/graphql-analyzer/pull/748))

--- a/.changeset/schema-merge-debug-logging.md
+++ b/.changeset/schema-merge-debug-logging.md
@@ -2,6 +2,7 @@
 graphql-analyzer-lsp: patch
 graphql-analyzer-cli: patch
 graphql-analyzer-mcp: patch
+graphql-analyzer-vscode: patch
 ---
 
 Add debug logging for schema merge error details ([#737](https://github.com/trevor-scheer/graphql-analyzer/pull/737))

--- a/.changeset/skip-files-without-graphql.md
+++ b/.changeset/skip-files-without-graphql.md
@@ -3,4 +3,4 @@ graphql-analyzer-lsp: patch
 graphql-analyzer-vscode: patch
 ---
 
-Only count and load files that contain GraphQL content during project initialization, reducing noise in the file count for projects with many TS/JS files. Remove the "maybe slow" warning popup for large file counts. Clicking the status bar item now opens the debug output channel.
+Only count and load files that contain GraphQL content during project initialization, reducing noise in the file count for projects with many TS/JS files. Remove the "maybe slow" warning popup for large file counts. Clicking the status bar item now opens the debug output channel. ([#759](https://github.com/trevor-scheer/graphql-analyzer/pull/759))

--- a/.changeset/swc-parser-error-paths.md
+++ b/.changeset/swc-parser-error-paths.md
@@ -1,6 +1,8 @@
 ---
 graphql-analyzer-lsp: patch
 graphql-analyzer-cli: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-vscode: patch
 ---
 
 Include file path in SWC parser error messages instead of "input" ([#736](https://github.com/trevor-scheer/graphql-analyzer/pull/736))


### PR DESCRIPTION
## Summary

Audit and fix all pending changesets for accurate package scoping and PR references before the next release.

## Changes

- **Add missing `graphql-analyzer-vscode`** to 4 changesets where LSP is bumped (vscode bundles the LSP binary)
- **Add missing `graphql-analyzer-mcp`** to 2 extract-related changesets (MCP depends on extract via ide)
- **Fix wrong PR link** in mcp-lsp-plugin-tools (#742 → #748)
- **Fix wrong PR link** in fix-ts-generic-parse-error (#755 → #765)
- **Add missing PR link** to skip-files-without-graphql (#759)

| Changeset | Fix |
|-----------|-----|
| fix-hover-field-usage-count | + vscode |
| schema-merge-debug-logging | + vscode |
| swc-parser-error-paths | + mcp, vscode |
| fix-ts-generic-parse-error | + mcp, vscode; fix PR link |
| mcp-lsp-plugin-tools | fix PR link #742 → #748 |
| skip-files-without-graphql | add PR link #759 |

## Consulted SME Agents

- N/A

## Manual Testing Plan

- N/A (changeset metadata only)

## Related Issues

N/A