### PR TITLE
fix(vscode): use dedicated jumpToLogs command for status bar item

### DIFF
--- a/.changeset/fix-checkstatus-command-conflict.md
+++ b/.changeset/fix-checkstatus-command-conflict.md
@@ -3,4 +3,4 @@ graphql-analyzer-vscode: patch
 graphql-analyzer-lsp: patch
 ---
 
-Fix extension crash on activation due to duplicate `checkStatus` command registration
+Fix extension crash on activation due to duplicate `checkStatus` command registration. The status bar item now uses a dedicated `jumpToLogs` command to avoid conflicting with the LSP server's `checkStatus` command.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -51,6 +51,11 @@
         "category": "graphql-analyzer"
       },
       {
+        "command": "graphql-analyzer.jumpToLogs",
+        "title": "Show Logs",
+        "category": "graphql-analyzer"
+      },
+      {
         "command": "graphql-analyzer.checkStatus",
         "title": "Check Status",
         "category": "graphql-analyzer"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -452,11 +452,17 @@ export async function activate(context: ExtensionContext) {
   outputChannel.appendLine("=== graphql-analyzer extension activating ===");
 
   statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-  statusBarItem.command = "graphql-analyzer.checkStatus";
+  statusBarItem.command = "graphql-analyzer.jumpToLogs";
   statusBarItem.text = "$(sync~spin) graphql-analyzer";
   statusBarItem.tooltip = "graphql-analyzer is starting...";
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
+
+  context.subscriptions.push(
+    commands.registerCommand("graphql-analyzer.jumpToLogs", () => {
+      outputChannel.show(true);
+    }),
+  );
 
   try {
     await startLanguageServer(context);


### PR DESCRIPTION
## Summary

Fixes the extension crash on activation introduced in v0.1.9:

```
[Error] Server initialization failed.
Error: command 'graphql-analyzer.checkStatus' already exists
```

**Root cause**: v0.1.9 added a manual `commands.registerCommand("graphql-analyzer.checkStatus", ...)` in `activate()` before starting the language client. The LSP server also advertises `checkStatus` in its `executeCommandProvider.commands`, so `vscode-languageclient` tries to register a proxy command for it during `initializeFeatures` — causing the duplicate registration crash.

**Fix**: Introduce a dedicated `jumpToLogs` command for the status bar item. This preserves the original intent (clicking the status bar shows logs even when the server fails to start) without colliding with the server-owned `checkStatus` command.

## Test plan

- [x] Extension activates without errors
- [x] Clicking the status bar item reveals the debug output channel
- [x] "Check Status" command palette entry still triggers the server's status report
- [ ] If the server fails to start, clicking the status bar still shows logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)