### PR TITLE
fix: use project extract config during document discovery

### DIFF
--- a/crates/ide/src/discovery.rs
+++ b/crates/ide/src/discovery.rs
@@ -74,6 +74,7 @@ impl FileDiscoveryResult {
 pub fn discover_document_files(
     config: &graphql_config::ProjectConfig,
     workspace_path: &std::path::Path,
+    extract_config: &graphql_extract::ExtractConfig,
 ) -> FileDiscoveryResult {
     let Some(documents_config) = &config.documents else {
         return FileDiscoveryResult::default();
@@ -121,9 +122,11 @@ pub fn discover_document_files(
                                         // For TS/JS files, we need to extract GraphQL first
                                         let graphql_content = if language.requires_extraction() {
                                             // Extract and concatenate all GraphQL blocks
-                                            let config = graphql_extract::ExtractConfig::default();
                                             graphql_extract::extract_from_source(
-                                                &content, language, &config, &path_str,
+                                                &content,
+                                                language,
+                                                extract_config,
+                                                &path_str,
                                             )
                                             .unwrap_or_default()
                                             .iter()
@@ -304,7 +307,8 @@ export function add(a: number, b: number): number {
             extensions: None,
         };
 
-        let result = discover_document_files(&config, temp_dir.path());
+        let extract_config = graphql_extract::ExtractConfig::default();
+        let result = discover_document_files(&config, temp_dir.path(), &extract_config);
 
         // Should only discover files that actually contain GraphQL:
         // - with-graphql.ts (has gql tag)

--- a/crates/ide/src/host.rs
+++ b/crates/ide/src/host.rs
@@ -568,6 +568,7 @@ impl AnalysisHost {
         &mut self,
         config: &graphql_config::ProjectConfig,
         workspace_path: &std::path::Path,
+        extract_config: &graphql_extract::ExtractConfig,
     ) -> (Vec<LoadedFile>, DocumentLoadResult) {
         let Some(documents_config) = &config.documents else {
             return (Vec::new(), DocumentLoadResult::default());
@@ -614,10 +615,11 @@ impl AnalysisHost {
 
                                             // Skip files that require extraction but contain no GraphQL
                                             if language.requires_extraction() {
-                                                let config =
-                                                    graphql_extract::ExtractConfig::default();
                                                 let blocks = graphql_extract::extract_from_source(
-                                                    &content, language, &config, &path_str,
+                                                    &content,
+                                                    language,
+                                                    extract_config,
+                                                    &path_str,
                                                 )
                                                 .unwrap_or_default();
                                                 if blocks.is_empty() {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -5082,7 +5082,8 @@ export const RATE_LIMIT_QUERY = gql`
         // Load schema
         let _ = host.load_schemas_from_config(&config, temp_dir.path());
         // Load documents (including TS files)
-        let _ = host.load_documents_from_config(&config, temp_dir.path());
+        let extract_config = graphql_extract::ExtractConfig::default();
+        let _ = host.load_documents_from_config(&config, temp_dir.path(), &extract_config);
 
         // Rebuild project files to update indices (this happens in LSP initialization)
         host.rebuild_project_files();
@@ -5171,7 +5172,9 @@ export const RATE_LIMIT_QUERY = gql`
         // Load schema
         let _ = host.load_schemas_from_config(&config, temp_dir.path());
         // Load documents (including TS files)
-        let (loaded_docs, _doc_result) = host.load_documents_from_config(&config, temp_dir.path());
+        let extract_config = graphql_extract::ExtractConfig::default();
+        let (loaded_docs, _doc_result) =
+            host.load_documents_from_config(&config, temp_dir.path(), &extract_config);
 
         // Verify the TS file was loaded
         assert!(

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -532,7 +532,7 @@ async fn load_all_project_files_background(
         .await;
 
         // Load schemas
-        let (pending_introspections, no_user_schema, unmatched_patterns) = host
+        let (pending_introspections, no_user_schema, unmatched_patterns, schema_count) = host
             .with_write(
                 |h| match h.load_schemas_from_config(project_config, workspace_path) {
                     Ok(result) => {
@@ -542,6 +542,7 @@ async fn load_all_project_files_background(
                             result.pending_introspections.len()
                         );
                         let no_schema = result.has_no_user_schema();
+                        let count = result.loaded_count;
                         // Convert content mismatch errors to ConfigValidationError
                         for error in &result.content_errors {
                             tracing::warn!(
@@ -559,11 +560,11 @@ async fn load_all_project_files_background(
                                 },
                             );
                         }
-                        (result.pending_introspections, no_schema, result.unmatched_patterns)
+                        (result.pending_introspections, no_schema, result.unmatched_patterns, count)
                     }
                     Err(e) => {
                         tracing::error!("Failed to load schemas: {}", e);
-                        (vec![], true, vec![])
+                        (vec![], true, vec![], 0)
                     }
                 },
             )
@@ -622,7 +623,8 @@ async fn load_all_project_files_background(
         }
 
         // Phase 1: Discover and read files (no lock needed - just file I/O)
-        let discovery_result = graphql_ide::discover_document_files(project_config, workspace_path);
+        let discovery_result =
+            graphql_ide::discover_document_files(project_config, workspace_path, &extract_config);
 
         // Convert content mismatch errors to ConfigValidationError
         for error in &discovery_result.errors {
@@ -727,8 +729,9 @@ async fn load_all_project_files_background(
         );
 
         let project_msg = format!(
-            "Project '{}' loaded: {} files in {:.1}s",
+            "Project '{}' loaded: {} schema file(s), {} document file(s) in {:.1}s",
             project_name,
+            schema_count,
             loaded_files.len(),
             project_start.elapsed().as_secs_f64()
         );
@@ -1291,8 +1294,11 @@ documents: "**/*.graphql"
                         };
 
                     // Load documents in the same lock acquisition
-                    let (docs, doc_result) =
-                        h.load_documents_from_config(project_config, workspace_path);
+                    let (docs, doc_result) = h.load_documents_from_config(
+                        project_config,
+                        workspace_path,
+                        &extract_config,
+                    );
 
                     (schema_result, docs, doc_result)
                 })
@@ -1435,8 +1441,9 @@ documents: "**/*.graphql"
             }
 
             let project_msg = format!(
-                "Project '{}' loaded: {} files in {:.1}s",
+                "Project '{}' loaded: {} schema file(s), {} document file(s) in {:.1}s",
                 project_name,
+                schema_result.loaded_count,
                 loaded_files.len(),
                 project_start.elapsed().as_secs_f64()
             );


### PR DESCRIPTION
## Summary

Fixes a regression from #759 where document discovery used `ExtractConfig::default()` instead of the project's configured extract config. This caused files relying on `allowGlobalIdentifiers` or custom `tagIdentifiers` to be silently skipped during initialization — the LSP only became aware of them when manually opened.

- Thread the project's `ExtractConfig` through to `discover_document_files` and `load_documents_from_config`
- Improve per-project init log to show schema and document file counts separately

## Test plan

- [ ] Open a project with `allowGlobalIdentifiers: true` in `.graphqlrc.yml` — verify all document files are discovered on init without needing to open them
- [ ] Check the output channel log shows correct schema/document counts per project
- [ ] Existing tests pass (`cargo test -p graphql-ide`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)