### PR TITLE
fix: use field file_id instead of type file_id for extension fields

### DIFF
--- a/.changeset/fix-extension-field-offset-panic.md
+++ b/.changeset/fix-extension-field-offset-panic.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-lsp: patch
+graphql-analyzer-vscode: patch
+---
+
+Fix panic on goto definition, find references, and code lens for fields from type extensions across files ([#778](https://github.com/trevor-scheer/graphql-analyzer/pull/778))

--- a/crates/ide/src/code_lenses.rs
+++ b/crates/ide/src/code_lenses.rs
@@ -115,11 +115,11 @@ pub fn deprecated_field_code_lenses(
     let line_index = graphql_syntax::line_index(db, content);
 
     for type_def in schema_types.values() {
-        if type_def.file_id != file_id {
-            continue;
-        }
-
         for field in &type_def.fields {
+            if field.file_id != file_id {
+                continue;
+            }
+
             if !field.is_deprecated {
                 continue;
             }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -6448,4 +6448,119 @@ directive @skip(if: Boolean!) on FIELD"#,
         let help = snapshot.signature_help(&path, Position::new(0, 0));
         assert!(help.is_none());
     }
+
+    // ========================================================================
+    // Type extension tests: fields defined in a different file via `extend type`
+    // Regression tests for offset/file_id mismatch panics
+    // ========================================================================
+
+    #[test]
+    fn test_goto_definition_field_from_type_extension() {
+        let mut host = AnalysisHost::new();
+
+        // Base type in one file
+        let base_file = FilePath::new("file:///base.graphql");
+        host.add_file(
+            &base_file,
+            "type Query { user: User }\ntype User { id: ID! }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        // Extension adds a field in a separate file
+        let ext_file = FilePath::new("file:///extension.graphql");
+        host.add_file(
+            &ext_file,
+            "extend type User { name: String! }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        let query_file = FilePath::new("file:///query.graphql");
+        let (query_text, cursor_pos) = extract_cursor("query { user { na*me } }");
+        host.add_file(
+            &query_file,
+            &query_text,
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let locations = snapshot.goto_definition(&query_file, cursor_pos);
+
+        assert!(
+            locations.is_some(),
+            "Should find field definition from extension"
+        );
+        let locations = locations.unwrap();
+        assert_eq!(locations.len(), 1);
+        // Should point to the extension file, not the base file
+        assert_eq!(locations[0].file.as_str(), ext_file.as_str());
+        assert_eq!(locations[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn test_find_references_field_from_type_extension() {
+        let mut host = AnalysisHost::new();
+
+        // Base type in one file
+        let base_file = FilePath::new("file:///base.graphql");
+        host.add_file(
+            &base_file,
+            "type Query { user: User }\ntype User { id: ID! }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        // Extension adds a field in a separate file
+        let ext_file = FilePath::new("file:///extension.graphql");
+        host.add_file(
+            &ext_file,
+            "extend type User { name: String! }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        let query_file = FilePath::new("file:///query.graphql");
+        host.add_file(
+            &query_file,
+            "query { user { name } }",
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        host.rebuild_project_files();
+
+        // Find references to "name" from the extension file, including declaration
+        // "extend type User { " = 19 chars, "name" at position 19
+        let snapshot = host.snapshot();
+        let locations = snapshot.find_references(&ext_file, Position::new(0, 19), true);
+
+        assert!(
+            locations.is_some(),
+            "Should find references for extension field"
+        );
+        let locations = locations.unwrap();
+        // declaration (in ext_file) + usage (in query_file) = 2
+        assert_eq!(
+            locations.len(),
+            2,
+            "Expected declaration + usage, got {locations:?}",
+        );
+
+        let ext_refs: Vec<_> = locations
+            .iter()
+            .filter(|l| l.file.as_str() == ext_file.as_str())
+            .collect();
+        let query_refs: Vec<_> = locations
+            .iter()
+            .filter(|l| l.file.as_str() == query_file.as_str())
+            .collect();
+        assert_eq!(
+            ext_refs.len(),
+            1,
+            "Should have 1 declaration in extension file"
+        );
+        assert_eq!(query_refs.len(), 1, "Should have 1 usage in query file");
+    }
 }

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -244,7 +244,7 @@ pub fn find_field_references(
                 .iter()
                 .find(|f| f.name.as_ref() == field_name)
             {
-                let field_file_id = type_def.file_id;
+                let field_file_id = field_sig.file_id;
                 let file_path = registry.get_path(field_file_id);
 
                 if let (Some(file_path), Some((content, _metadata))) = (

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -580,6 +580,12 @@ impl LineIndex {
     /// For byte-based columns (internal use), see [`line_col_bytes`](Self::line_col_bytes).
     #[must_use]
     pub fn line_col(&self, offset: usize) -> (usize, usize) {
+        assert!(
+            offset <= self.source.len(),
+            "byte offset {offset} is out of bounds of source ({} bytes). \
+             This is a bug — the offset likely comes from a different file than the LineIndex.",
+            self.source.len()
+        );
         let (line, byte_col) = self.line_col_bytes(offset);
         let line_start = self.line_starts[line];
         let line_text = &self.source[line_start..line_start + byte_col];


### PR DESCRIPTION
## Summary

Fixes #777

- **`references.rs`**: Use `field_sig.file_id` instead of `type_def.file_id` when looking up content for field declaration positions. When fields come from type extensions in different files, the type's file_id points to the base file while the field's name_range offsets are relative to the extension file.
- **`code_lenses.rs`**: Filter by `field.file_id` instead of `type_def.file_id` so only fields actually defined in the current file get code lenses (extension fields have offsets from their own files).
- **`syntax/lib.rs`**: Improved panic message in `line_col()` to clearly indicate offset/file mismatch as the root cause.
- Added regression tests that reproduce the panic with `extend type` across files.

## Test plan

- [x] New tests: `test_goto_definition_field_from_type_extension` and `test_find_references_field_from_type_extension`
- [x] Verified tests fail when bug is reintroduced (reverted fix, test panicked)
- [x] Full `cargo test -p graphql-ide -p graphql-syntax` passes
- [x] `cargo clippy` clean
- [x] Manual: cmd+click on field from `extend type` in VS Code navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)