### PR TITLE
fix(vscode): reset extension state on language server restart

### DIFF
--- a/.changeset/reset-extension-on-restart.md
+++ b/.changeset/reset-extension-on-restart.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Reset extension health state and status bar on server restart

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -482,6 +482,7 @@ export async function activate(context: ExtensionContext) {
 
       try {
         stopHealthCheck();
+        isServerHealthy = true;
 
         if (client) {
           outputChannel.appendLine("Stopping existing client...");
@@ -496,6 +497,11 @@ export async function activate(context: ExtensionContext) {
             );
           }
         }
+
+        // Reset status bar to loading state while restarting
+        statusBarItem.text = "$(loading~spin) graphql-analyzer";
+        statusBarItem.tooltip = "graphql-analyzer is restarting...";
+        statusBarItem.backgroundColor = new ThemeColor("statusBarItem.warningBackground");
 
         await startLanguageServer(context);
         window.showInformationMessage("graphql-analyzer restarted successfully");


### PR DESCRIPTION
## Summary
- Reset `isServerHealthy` and set the status bar back to its loading/spinner state when the restart command is invoked
- Previously, if health check had marked the server unhealthy before a restart, the error state persisted through the restart because `updateStatusBar` skips updates for `State.Running` when `isServerHealthy` is false
- Now the status bar immediately shows the loading spinner during restart instead of a stale error state

## Test plan
- [ ] Enable health check (`graphql-analyzer.debug.healthCheck.enabled: true`)
- [ ] Simulate an unresponsive server (or wait for a health check failure)
- [ ] Run "Restart Language Server" command
- [ ] Verify status bar shows loading spinner during restart, not error state
- [ ] Verify status bar shows checkmark once server is ready again

https://claude.ai/code/session_011n4MDc2ChsDz5Dv1rxkVdZ