### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ Open any GraphQL file, TypeScript/JavaScript file, or Vue/Svelte/Astro component
 Install the CLI for CI/CD integration:
 
 ```sh
-# Install the CLI (default)
-curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
+# Homebrew (macOS/Linux)
+brew install trevor-scheer/graphql-analyzer/graphql-analyzer
 
-# Install LSP or MCP server
-curl -fsSL .../install.sh | sh -s -- lsp
-curl -fsSL .../install.sh | sh -s -- mcp
+# Or via install script
+curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
 ```
 
 Validate your GraphQL:

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -13,7 +13,13 @@ Command-line tool for validating and linting GraphQL projects.
 
 ## Installation
 
-### Via Installation Script (Recommended)
+### Homebrew (macOS/Linux)
+
+```bash
+brew install trevor-scheer/graphql-analyzer/graphql-analyzer
+```
+
+### Via Installation Script
 
 **macOS and Linux:**
 

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -5,6 +5,18 @@ description: Command-line tool for validating and linting GraphQL projects.
 
 The `graphql` CLI validates and lints your GraphQL projects. Use it in CI/CD pipelines or during local development.
 
+## Install
+
+```sh
+# Homebrew (macOS/Linux)
+brew install trevor-scheer/graphql-analyzer/graphql-analyzer
+
+# Or via install script
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+```
+
+See [Installation](/graphql-analyzer/getting-started/installation/) for all methods.
+
 ## Commands
 
 | Command        | Description                               | Recommended for      |

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -44,6 +44,12 @@ Platform-specific packages:
 
 ## CLI
 
+**Homebrew (macOS/Linux):**
+
+```sh
+brew install trevor-scheer/graphql-analyzer/graphql-analyzer
+```
+
 **Install script (macOS/Linux):**
 
 ```sh


### PR DESCRIPTION
## Summary

Add Homebrew as the primary CLI install method across all user-facing docs, following up on #812 which added the tap and release automation.

## Changes

- **README.md**: Replace curl-only CLI install with Homebrew first, curl as fallback
- **crates/cli/README.md**: Add "Homebrew (macOS/Linux)" as the first install method
- **docs/getting-started/installation.mdx**: Add Homebrew above the install script in the CLI section
- **docs/cli/overview.mdx**: Add an "Install" section with Homebrew + install script link

## Consulted SME Agents

N/A

## Manual Testing Plan

N/A — docs-only change

## Related Issues

Follow-up to #812