### PR TITLE
feat(linter): add `descriptionStyle` lint rule

### DIFF
--- a/.changeset/descriptionStyle-rule.md
+++ b/.changeset/descriptionStyle-rule.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+---
+
+Add `descriptionStyle` lint rule: Enforces consistent description style (block vs inline) (broken out from #613)

--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -138,3 +138,4 @@ projects:
           noDuplicateFields: warn
           selectionSetDepth: [warn, { maxDepth: 3 }]
           noOnePlaceFragments: warn
+          descriptionStyle: warn

--- a/crates/config/schema/graphqlrc.schema.json
+++ b/crates/config/schema/graphqlrc.schema.json
@@ -287,6 +287,10 @@
             "noOnePlaceFragments": {
               "$ref": "#/definitions/LintRuleConfig",
               "description": "Detects fragments that are used in only one place and could be inlined"
+            },
+            "descriptionStyle": {
+              "$ref": "#/definitions/LintRuleConfig",
+              "description": "Enforces consistent description style (block vs inline)"
             }
           },
           "additionalProperties": {

--- a/crates/linter/src/registry.rs
+++ b/crates/linter/src/registry.rs
@@ -1,10 +1,10 @@
 /// Registry of all available lint rules
 use crate::rules::{
-    AlphabetizeRuleImpl, LoneExecutableDefinitionRuleImpl, NamingConventionRuleImpl,
-    NoAnonymousOperationsRuleImpl, NoDeprecatedRuleImpl, NoDuplicateFieldsRuleImpl,
-    NoOnePlaceFragmentsRuleImpl, OperationNameSuffixRuleImpl, RedundantFieldsRuleImpl,
-    RequireIdFieldRuleImpl, SelectionSetDepthRuleImpl, UniqueNamesRuleImpl, UnusedFieldsRuleImpl,
-    UnusedFragmentsRuleImpl, UnusedVariablesRuleImpl,
+    AlphabetizeRuleImpl, DescriptionStyleRuleImpl, LoneExecutableDefinitionRuleImpl,
+    NamingConventionRuleImpl, NoAnonymousOperationsRuleImpl, NoDeprecatedRuleImpl,
+    NoDuplicateFieldsRuleImpl, NoOnePlaceFragmentsRuleImpl, OperationNameSuffixRuleImpl,
+    RedundantFieldsRuleImpl, RequireIdFieldRuleImpl, SelectionSetDepthRuleImpl,
+    UniqueNamesRuleImpl, UnusedFieldsRuleImpl, UnusedFragmentsRuleImpl, UnusedVariablesRuleImpl,
 };
 use crate::traits::{
     DocumentSchemaLintRule, ProjectLintRule, StandaloneDocumentLintRule, StandaloneSchemaLintRule,
@@ -52,7 +52,7 @@ static PROJECT_RULES: LazyLock<Vec<Arc<dyn ProjectLintRule>>> = LazyLock::new(||
 /// Lazily initialized standalone schema rules.
 /// Rules are created once and reused across all calls.
 static STANDALONE_SCHEMA_RULES: LazyLock<Vec<Arc<dyn StandaloneSchemaLintRule>>> =
-    LazyLock::new(Vec::new);
+    LazyLock::new(|| vec![Arc::new(DescriptionStyleRuleImpl)]);
 
 #[must_use]
 pub fn standalone_document_rules() -> &'static [Arc<dyn StandaloneDocumentLintRule>] {

--- a/crates/linter/src/rules/description_style.rs
+++ b/crates/linter/src/rules/description_style.rs
@@ -1,0 +1,218 @@
+use crate::diagnostics::{LintDiagnostic, LintSeverity};
+use crate::traits::{LintRule, StandaloneSchemaLintRule};
+use graphql_base_db::{FileId, ProjectFiles};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// The expected description style
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DescriptionStyleKind {
+    /// Inline string: "description"
+    Inline,
+    /// Block string: """description"""
+    Block,
+}
+
+/// Options for the `description_style` rule
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct DescriptionStyleOptions {
+    /// The expected style for descriptions
+    pub style: DescriptionStyleKind,
+}
+
+impl Default for DescriptionStyleOptions {
+    fn default() -> Self {
+        Self {
+            style: DescriptionStyleKind::Block,
+        }
+    }
+}
+
+impl DescriptionStyleOptions {
+    fn from_json(value: Option<&serde_json::Value>) -> Self {
+        value
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
+
+/// Lint rule that enforces consistent description style in schema
+pub struct DescriptionStyleRuleImpl;
+
+impl LintRule for DescriptionStyleRuleImpl {
+    fn name(&self) -> &'static str {
+        "descriptionStyle"
+    }
+
+    fn description(&self) -> &'static str {
+        "Enforces consistent description style (block vs inline)"
+    }
+
+    fn default_severity(&self) -> LintSeverity {
+        LintSeverity::Warning
+    }
+}
+
+impl StandaloneSchemaLintRule for DescriptionStyleRuleImpl {
+    fn check(
+        &self,
+        db: &dyn graphql_hir::GraphQLHirDatabase,
+        project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
+    ) -> HashMap<FileId, Vec<LintDiagnostic>> {
+        let opts = DescriptionStyleOptions::from_json(options);
+        let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
+        let schema_ids = project_files.schema_file_ids(db).ids(db);
+
+        for file_id in schema_ids.iter() {
+            let Some((content, metadata)) =
+                graphql_base_db::file_lookup(db, project_files, *file_id)
+            else {
+                continue;
+            };
+
+            let parse = graphql_syntax::parse(db, content, metadata);
+            if parse.has_errors() {
+                continue;
+            }
+
+            for doc in parse.documents() {
+                for definition in &doc.ast.definitions {
+                    let desc = match definition {
+                        apollo_compiler::ast::Definition::ObjectTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        apollo_compiler::ast::Definition::InterfaceTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        apollo_compiler::ast::Definition::UnionTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        apollo_compiler::ast::Definition::EnumTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        apollo_compiler::ast::Definition::ScalarTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        apollo_compiler::ast::Definition::InputObjectTypeDefinition(d) => {
+                            d.description.as_ref()
+                        }
+                        _ => continue,
+                    };
+
+                    let Some(desc) = desc else {
+                        continue;
+                    };
+
+                    let desc_str = desc.as_str();
+                    let desc_location = desc.location();
+
+                    // Determine the actual style used by checking source text
+                    let Some(location) = desc_location else {
+                        continue;
+                    };
+                    let start = location.offset();
+                    let end = location.end_offset();
+
+                    let source = doc.source;
+                    if start >= source.len() || end > source.len() {
+                        continue;
+                    }
+
+                    let raw = &source[start..end];
+                    let is_block = raw.starts_with("\"\"\"");
+
+                    let wrong_style = match opts.style {
+                        DescriptionStyleKind::Block => !is_block,
+                        DescriptionStyleKind::Inline => is_block,
+                    };
+
+                    if wrong_style {
+                        let expected = match opts.style {
+                            DescriptionStyleKind::Block => "block (\"\"\"...\"\"\")",
+                            DescriptionStyleKind::Inline => "inline (\"...\")",
+                        };
+
+                        diagnostics_by_file
+                            .entry(*file_id)
+                            .or_default()
+                            .push(LintDiagnostic::new(
+                                doc.span(start, end.min(start + desc_str.len().min(30) + 6)),
+                                LintSeverity::Warning,
+                                format!("Description should use {expected} style"),
+                                "descriptionStyle",
+                            ));
+                    }
+                }
+            }
+        }
+
+        diagnostics_by_file
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::StandaloneSchemaLintRule;
+    use graphql_base_db::{
+        DocumentFileIds, DocumentKind, FileContent, FileEntry, FileEntryMap, FileId, FileMetadata,
+        FileUri, Language, ProjectFiles, SchemaFileIds,
+    };
+    use graphql_ide_db::RootDatabase;
+    use std::sync::Arc;
+
+    fn create_schema_project(db: &RootDatabase, schema: &str) -> ProjectFiles {
+        let file_id = FileId::new(0);
+        let content = FileContent::new(db, Arc::from(schema));
+        let metadata = FileMetadata::new(
+            db,
+            file_id,
+            FileUri::new("file:///schema.graphql"),
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        let entry = FileEntry::new(db, content, metadata);
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(file_id, entry);
+        let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
+        let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
+        let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
+        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    }
+
+    #[test]
+    fn test_block_style_with_block_option() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""A user"""
+type User {
+    id: ID!
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None); // default is block
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn test_inline_style_with_block_option() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"A user"
+type User {
+    id: ID!
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None); // default is block
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].message.contains("block"));
+    }
+}

--- a/crates/linter/src/rules/mod.rs
+++ b/crates/linter/src/rules/mod.rs
@@ -26,6 +26,7 @@ pub fn get_operation_kind(op_type: &cst::OperationType) -> OperationKind {
 }
 
 mod alphabetize;
+mod description_style;
 mod lone_executable_definition;
 mod naming_convention;
 mod no_anonymous_operations;
@@ -42,6 +43,7 @@ mod unused_fragments;
 mod unused_variables;
 
 pub use alphabetize::AlphabetizeRuleImpl;
+pub use description_style::DescriptionStyleRuleImpl;
 pub use lone_executable_definition::LoneExecutableDefinitionRuleImpl;
 pub use naming_convention::NamingConventionRuleImpl;
 pub use no_anonymous_operations::NoAnonymousOperationsRuleImpl;

--- a/test-workspace/lint-examples/schema/description-style.graphql
+++ b/test-workspace/lint-examples/schema/description-style.graphql
@@ -1,0 +1,19 @@
+# Demonstrates: descriptionStyle
+# Default expects block descriptions ("""..."""). These use inline style ("...").
+
+"A category for organizing items"
+type Category {
+  """
+  Unique identifier
+  """
+  id: ID!
+  "The category label"
+  label: String!
+}
+
+"Available color options"
+enum Color {
+  RED
+  GREEN
+  BLUE
+}


### PR DESCRIPTION
## Summary
- Adds the `descriptionStyle` lint rule: Enforce block vs inline description style

Broken out from #613. Depends on #813 (schema lint infra).

## Test plan
- [x] `cargo test -p graphql-linter` passes
- [x] `cargo clippy` clean