### PR TITLE
feat(linter): add `inputName` lint rule

### DIFF
--- a/.changeset/inputName-rule.md
+++ b/.changeset/inputName-rule.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+---
+
+Add `inputName` lint rule: Enforces that input type names end with a specific suffix (broken out from #613)

--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -139,3 +139,4 @@ projects:
           selectionSetDepth: [warn, { maxDepth: 3 }]
           noOnePlaceFragments: warn
           descriptionStyle: warn
+          inputName: warn

--- a/crates/config/schema/graphqlrc.schema.json
+++ b/crates/config/schema/graphqlrc.schema.json
@@ -291,6 +291,10 @@
             "descriptionStyle": {
               "$ref": "#/definitions/LintRuleConfig",
               "description": "Enforces consistent description style (block vs inline)"
+            },
+            "inputName": {
+              "$ref": "#/definitions/LintRuleConfig",
+              "description": "Enforces that input type names end with a specific suffix"
             }
           },
           "additionalProperties": {

--- a/crates/linter/src/registry.rs
+++ b/crates/linter/src/registry.rs
@@ -1,10 +1,11 @@
 /// Registry of all available lint rules
 use crate::rules::{
-    AlphabetizeRuleImpl, DescriptionStyleRuleImpl, LoneExecutableDefinitionRuleImpl,
-    NamingConventionRuleImpl, NoAnonymousOperationsRuleImpl, NoDeprecatedRuleImpl,
-    NoDuplicateFieldsRuleImpl, NoOnePlaceFragmentsRuleImpl, OperationNameSuffixRuleImpl,
-    RedundantFieldsRuleImpl, RequireIdFieldRuleImpl, SelectionSetDepthRuleImpl,
-    UniqueNamesRuleImpl, UnusedFieldsRuleImpl, UnusedFragmentsRuleImpl, UnusedVariablesRuleImpl,
+    AlphabetizeRuleImpl, DescriptionStyleRuleImpl, InputNameRuleImpl,
+    LoneExecutableDefinitionRuleImpl, NamingConventionRuleImpl, NoAnonymousOperationsRuleImpl,
+    NoDeprecatedRuleImpl, NoDuplicateFieldsRuleImpl, NoOnePlaceFragmentsRuleImpl,
+    OperationNameSuffixRuleImpl, RedundantFieldsRuleImpl, RequireIdFieldRuleImpl,
+    SelectionSetDepthRuleImpl, UniqueNamesRuleImpl, UnusedFieldsRuleImpl, UnusedFragmentsRuleImpl,
+    UnusedVariablesRuleImpl,
 };
 use crate::traits::{
     DocumentSchemaLintRule, ProjectLintRule, StandaloneDocumentLintRule, StandaloneSchemaLintRule,
@@ -52,7 +53,12 @@ static PROJECT_RULES: LazyLock<Vec<Arc<dyn ProjectLintRule>>> = LazyLock::new(||
 /// Lazily initialized standalone schema rules.
 /// Rules are created once and reused across all calls.
 static STANDALONE_SCHEMA_RULES: LazyLock<Vec<Arc<dyn StandaloneSchemaLintRule>>> =
-    LazyLock::new(|| vec![Arc::new(DescriptionStyleRuleImpl)]);
+    LazyLock::new(|| {
+        vec![
+            Arc::new(DescriptionStyleRuleImpl),
+            Arc::new(InputNameRuleImpl),
+        ]
+    });
 
 #[must_use]
 pub fn standalone_document_rules() -> &'static [Arc<dyn StandaloneDocumentLintRule>] {

--- a/crates/linter/src/rules/input_name.rs
+++ b/crates/linter/src/rules/input_name.rs
@@ -1,0 +1,150 @@
+use crate::diagnostics::{LintDiagnostic, LintSeverity};
+use crate::traits::{LintRule, StandaloneSchemaLintRule};
+use graphql_base_db::{FileId, ProjectFiles};
+use graphql_hir::TypeDefKind;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Options for the `input_name` rule
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct InputNameOptions {
+    /// Required suffix for input type names. Defaults to "Input".
+    pub suffix: String,
+}
+
+impl Default for InputNameOptions {
+    fn default() -> Self {
+        Self {
+            suffix: "Input".to_string(),
+        }
+    }
+}
+
+impl InputNameOptions {
+    fn from_json(value: Option<&serde_json::Value>) -> Self {
+        value
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
+
+/// Lint rule that enforces naming convention for input types
+///
+/// Input type names should end with "Input" (or a configurable suffix)
+/// to distinguish them from output types.
+pub struct InputNameRuleImpl;
+
+impl LintRule for InputNameRuleImpl {
+    fn name(&self) -> &'static str {
+        "inputName"
+    }
+
+    fn description(&self) -> &'static str {
+        "Enforces that input type names end with a specific suffix"
+    }
+
+    fn default_severity(&self) -> LintSeverity {
+        LintSeverity::Warning
+    }
+}
+
+impl StandaloneSchemaLintRule for InputNameRuleImpl {
+    fn check(
+        &self,
+        db: &dyn graphql_hir::GraphQLHirDatabase,
+        project_files: ProjectFiles,
+        options: Option<&serde_json::Value>,
+    ) -> HashMap<FileId, Vec<LintDiagnostic>> {
+        let opts = InputNameOptions::from_json(options);
+        let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
+        let schema_types = graphql_hir::schema_types(db, project_files);
+
+        for type_def in schema_types.values() {
+            if type_def.kind != TypeDefKind::InputObject {
+                continue;
+            }
+
+            if !type_def.name.ends_with(&opts.suffix) {
+                let start: usize = type_def.name_range.start().into();
+                let end: usize = type_def.name_range.end().into();
+                let span = graphql_syntax::SourceSpan {
+                    start,
+                    end,
+                    line_offset: 0,
+                    byte_offset: 0,
+                    source: None,
+                };
+
+                diagnostics_by_file
+                    .entry(type_def.file_id)
+                    .or_default()
+                    .push(LintDiagnostic::new(
+                        span,
+                        LintSeverity::Warning,
+                        format!(
+                            "Input type '{}' should end with '{}'",
+                            type_def.name, opts.suffix
+                        ),
+                        "inputName",
+                    ));
+            }
+        }
+
+        diagnostics_by_file
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::StandaloneSchemaLintRule;
+    use graphql_base_db::{
+        DocumentFileIds, DocumentKind, FileContent, FileEntry, FileEntryMap, FileId, FileMetadata,
+        FileUri, Language, ProjectFiles, SchemaFileIds,
+    };
+    use graphql_ide_db::RootDatabase;
+    use std::sync::Arc;
+
+    fn create_schema_project(db: &RootDatabase, schema: &str) -> ProjectFiles {
+        let file_id = FileId::new(0);
+        let content = FileContent::new(db, Arc::from(schema));
+        let metadata = FileMetadata::new(
+            db,
+            file_id,
+            FileUri::new("file:///schema.graphql"),
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        let entry = FileEntry::new(db, content, metadata);
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(file_id, entry);
+        let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
+        let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
+        let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
+        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    }
+
+    #[test]
+    fn test_input_with_suffix() {
+        let db = RootDatabase::default();
+        let rule = InputNameRuleImpl;
+        let schema = "input CreateUserInput { name: String! }";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn test_input_without_suffix() {
+        let db = RootDatabase::default();
+        let rule = InputNameRuleImpl;
+        let schema = "input CreateUser { name: String! }";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].message.contains("should end with 'Input'"));
+    }
+}

--- a/crates/linter/src/rules/mod.rs
+++ b/crates/linter/src/rules/mod.rs
@@ -27,6 +27,7 @@ pub fn get_operation_kind(op_type: &cst::OperationType) -> OperationKind {
 
 mod alphabetize;
 mod description_style;
+mod input_name;
 mod lone_executable_definition;
 mod naming_convention;
 mod no_anonymous_operations;
@@ -44,6 +45,7 @@ mod unused_variables;
 
 pub use alphabetize::AlphabetizeRuleImpl;
 pub use description_style::DescriptionStyleRuleImpl;
+pub use input_name::InputNameRuleImpl;
 pub use lone_executable_definition::LoneExecutableDefinitionRuleImpl;
 pub use naming_convention::NamingConventionRuleImpl;
 pub use no_anonymous_operations::NoAnonymousOperationsRuleImpl;

--- a/test-workspace/lint-examples/schema/input-name.graphql
+++ b/test-workspace/lint-examples/schema/input-name.graphql
@@ -1,0 +1,44 @@
+# Demonstrates: inputName
+# These input types don't end with the required "Input" suffix.
+
+"""
+Data for creating a user
+"""
+input CreateUserData {
+  """
+  User name
+  """
+  name: String!
+  """
+  User email
+  """
+  email: String!
+}
+
+"""
+Filter for posts
+"""
+input PostFilter {
+  """
+  Author ID
+  """
+  authorId: ID
+  """
+  Title contains
+  """
+  titleContains: String
+}
+
+"""
+This one is correct - ends with Input
+"""
+input UpdateUserInput {
+  """
+  New name
+  """
+  name: String
+  """
+  New email
+  """
+  email: String
+}


### PR DESCRIPTION
## Summary
- Adds the `inputName` lint rule: Require configurable suffix (default 'Input') on input types

Broken out from #613. Depends on #813 (schema lint infra).

## Test plan
- [x] `cargo test -p graphql-linter` passes
- [x] `cargo clippy` clean