### PR TITLE
docs: add documentation for 17 new lint rules

### DIFF
--- a/.changeset/lint-rule-docs.md
+++ b/.changeset/lint-rule-docs.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Add documentation for 17 new lint rules (broken out from #613)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -95,21 +95,62 @@ export default defineConfig({
           label: "Rules",
           items: [
             { label: "Rules Catalog", slug: "rules/catalog" },
+            { label: "alphabetize", slug: "rules/alphabetize" },
+            { label: "description-style", slug: "rules/description-style" },
+            { label: "input-name", slug: "rules/input-name" },
+            {
+              label: "lone-executable-definition",
+              slug: "rules/lone-executable-definition",
+            },
+            { label: "naming-convention", slug: "rules/naming-convention" },
             {
               label: "no-anonymous-operations",
               slug: "rules/no-anonymous-operations",
             },
             { label: "no-deprecated", slug: "rules/no-deprecated" },
-            { label: "redundant-fields", slug: "rules/redundant-fields" },
-            { label: "require-id-field", slug: "rules/require-id-field" },
-            { label: "unique-names", slug: "rules/unique-names" },
-            { label: "unused-fields", slug: "rules/unused-fields" },
-            { label: "unused-fragments", slug: "rules/unused-fragments" },
-            { label: "unused-variables", slug: "rules/unused-variables" },
+            { label: "no-duplicate-fields", slug: "rules/no-duplicate-fields" },
+            {
+              label: "no-hashtag-description",
+              slug: "rules/no-hashtag-description",
+            },
+            {
+              label: "no-one-place-fragments",
+              slug: "rules/no-one-place-fragments",
+            },
+            {
+              label: "no-scalar-result-type-on-mutation",
+              slug: "rules/no-scalar-result-type-on-mutation",
+            },
+            { label: "no-typename-prefix", slug: "rules/no-typename-prefix" },
+            {
+              label: "no-unreachable-types",
+              slug: "rules/no-unreachable-types",
+            },
             {
               label: "operation-name-suffix",
               slug: "rules/operation-name-suffix",
             },
+            { label: "redundant-fields", slug: "rules/redundant-fields" },
+            {
+              label: "require-deprecation-reason",
+              slug: "rules/require-deprecation-reason",
+            },
+            { label: "require-description", slug: "rules/require-description" },
+            {
+              label: "require-field-of-type-query-in-mutation-result",
+              slug: "rules/require-field-of-type-query-in-mutation-result",
+            },
+            { label: "require-id-field", slug: "rules/require-id-field" },
+            { label: "selection-set-depth", slug: "rules/selection-set-depth" },
+            { label: "strict-id-in-types", slug: "rules/strict-id-in-types" },
+            {
+              label: "unique-enum-value-names",
+              slug: "rules/unique-enum-value-names",
+            },
+            { label: "unique-names", slug: "rules/unique-names" },
+            { label: "unused-fields", slug: "rules/unused-fields" },
+            { label: "unused-fragments", slug: "rules/unused-fragments" },
+            { label: "unused-variables", slug: "rules/unused-variables" },
           ],
         },
         {

--- a/docs/src/content/docs/linting/overview.mdx
+++ b/docs/src/content/docs/linting/overview.mdx
@@ -18,24 +18,41 @@ The `recommended` preset enables rules that are objectively beneficial without b
 
 ## The `recommended` preset
 
-| Rule                    | Severity | Description                                  |
-| ----------------------- | -------- | -------------------------------------------- |
-| `noAnonymousOperations` | error    | Require named operations                     |
-| `noDeprecated`          | warn     | Alert on deprecated field usage              |
-| `redundantFields`       | warn     | Detect fields duplicated by fragment spreads |
-| `unusedFragments`       | warn     | Detect unused fragment definitions           |
-| `unusedFields`          | warn     | Detect unused schema fields                  |
+| Rule                        | Severity | Description                                  |
+| --------------------------- | -------- | -------------------------------------------- |
+| `noAnonymousOperations`     | error    | Require named operations                     |
+| `noDeprecated`              | warn     | Alert on deprecated field usage              |
+| `noDuplicateFields`         | warn     | Disallow duplicate fields in selection sets  |
+| `noHashtagDescription`      | warn     | Disallow # comments as type descriptions     |
+| `noUnreachableTypes`        | warn     | Detect types unreachable from root operations|
+| `redundantFields`           | warn     | Detect fields duplicated by fragment spreads |
+| `requireDeprecationReason`  | warn     | Require reason in @deprecated directives     |
+| `uniqueEnumValueNames`      | warn     | Detect duplicate enum values across enums    |
+| `unusedFragments`           | warn     | Detect unused fragment definitions           |
+| `unusedFields`              | warn     | Detect unused schema fields                  |
 
 ## Additional rules
 
 These rules are available but not in the `recommended` preset — enable them based on your project's needs:
 
-| Rule                  | Description                                |
-| --------------------- | ------------------------------------------ |
-| `uniqueNames`         | Ensure operation/fragment names are unique |
-| `requireIdField`      | Require `id` field for cache normalization |
-| `operationNameSuffix` | Enforce operation name conventions         |
-| `unusedVariables`     | Detect unused query variables              |
+| Rule                                        | Description                                |
+| ------------------------------------------- | ------------------------------------------ |
+| `alphabetize`                               | Enforce alphabetical ordering              |
+| `descriptionStyle`                          | Enforce block vs inline description style  |
+| `inputName`                                 | Require configurable suffix on input types |
+| `loneExecutableDefinition`                  | Require one operation or fragment per file |
+| `namingConvention`                          | Enforce naming conventions                 |
+| `noOnePlaceFragments`                       | Detect fragments used in only one place    |
+| `noScalarResultTypeOnMutation`              | Require mutations to return object types   |
+| `noTypenamePrefix`                          | Disallow field names prefixed with type name|
+| `operationNameSuffix`                       | Enforce operation name conventions         |
+| `requireDescription`                        | Require descriptions on type definitions   |
+| `requireFieldOfTypeQueryInMutationResult`   | Require Query field in mutation results    |
+| `requireIdField`                            | Require `id` field for cache normalization |
+| `selectionSetDepth`                         | Limit selection set nesting depth          |
+| `strictIdInTypes`                           | Require ID field in object types           |
+| `uniqueNames`                               | Ensure operation/fragment names are unique |
+| `unusedVariables`                            | Detect unused query variables              |
 
 See the [Rules Catalog](/graphql-analyzer/rules/catalog/) for details on each rule.
 

--- a/docs/src/content/docs/rules/alphabetize.mdx
+++ b/docs/src/content/docs/rules/alphabetize.mdx
@@ -1,0 +1,48 @@
+---
+title: alphabetize
+description: Enforce alphabetical ordering of selections, arguments, and variables.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `alphabetize` |
+| Default severity | `—`                 |
+| Context          | Document                |
+| In recommended   | No                     |
+
+## What it checks
+
+Enforce alphabetical ordering of selections, arguments, and variables.
+
+## Examples
+
+```graphql
+# ❌ Bad — unsorted fields
+query GetUser {
+  user {
+    name
+    id
+    email
+  }
+}
+```
+
+```graphql
+# ✅ Good — alphabetized fields
+query GetUser {
+  user {
+    email
+    id
+    name
+  }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      alphabetize: [warn, { selections: true, arguments: true, variables: true }]
+```

--- a/docs/src/content/docs/rules/catalog.mdx
+++ b/docs/src/content/docs/rules/catalog.mdx
@@ -9,16 +9,34 @@ description: All available lint rules.
 | --------------------------------------------------------------------------- | ---------------- | --------------- | ----------------- |
 | [no-anonymous-operations](/graphql-analyzer/rules/no-anonymous-operations/) | error            | Document        | Yes               |
 | [no-deprecated](/graphql-analyzer/rules/no-deprecated/)                     | warn             | Document-Schema | Yes               |
+| [no-duplicate-fields](/graphql-analyzer/rules/no-duplicate-fields/)         | warn             | Document        | Yes               |
+| [no-hashtag-description](/graphql-analyzer/rules/no-hashtag-description/)   | warn             | Schema          | Yes               |
+| [no-unreachable-types](/graphql-analyzer/rules/no-unreachable-types/)       | warn             | Schema          | Yes               |
 | [redundant-fields](/graphql-analyzer/rules/redundant-fields/)               | warn             | Document        | Yes               |
+| [require-deprecation-reason](/graphql-analyzer/rules/require-deprecation-reason/) | warn       | Schema          | Yes               |
+| [unique-enum-value-names](/graphql-analyzer/rules/unique-enum-value-names/) | warn             | Schema          | Yes               |
 | [unused-fragments](/graphql-analyzer/rules/unused-fragments/)               | warn             | Project         | Yes               |
 | [unused-fields](/graphql-analyzer/rules/unused-fields/)                     | warn             | Project         | Yes               |
-| [unique-names](/graphql-analyzer/rules/unique-names/)                       | error            | Project         | No                |
-| [require-id-field](/graphql-analyzer/rules/require-id-field/)               | —                | Document-Schema | No                |
+| [alphabetize](/graphql-analyzer/rules/alphabetize/)                         | —                | Document        | No                |
+| [description-style](/graphql-analyzer/rules/description-style/)             | —                | Schema          | No                |
+| [input-name](/graphql-analyzer/rules/input-name/)                           | —                | Schema          | No                |
+| [lone-executable-definition](/graphql-analyzer/rules/lone-executable-definition/) | —           | Document        | No                |
+| [naming-convention](/graphql-analyzer/rules/naming-convention/)             | —                | Document        | No                |
+| [no-one-place-fragments](/graphql-analyzer/rules/no-one-place-fragments/)   | —                | Project         | No                |
+| [no-scalar-result-type-on-mutation](/graphql-analyzer/rules/no-scalar-result-type-on-mutation/) | — | Schema     | No                |
+| [no-typename-prefix](/graphql-analyzer/rules/no-typename-prefix/)           | —                | Schema          | No                |
 | [operation-name-suffix](/graphql-analyzer/rules/operation-name-suffix/)     | —                | Document        | No                |
+| [require-description](/graphql-analyzer/rules/require-description/)         | —                | Schema          | No                |
+| [require-field-of-type-query-in-mutation-result](/graphql-analyzer/rules/require-field-of-type-query-in-mutation-result/) | — | Schema | No |
+| [require-id-field](/graphql-analyzer/rules/require-id-field/)               | —                | Document-Schema | No                |
+| [selection-set-depth](/graphql-analyzer/rules/selection-set-depth/)         | —                | Document        | No                |
+| [strict-id-in-types](/graphql-analyzer/rules/strict-id-in-types/)           | —                | Schema          | No                |
+| [unique-names](/graphql-analyzer/rules/unique-names/)                       | error            | Project         | No                |
 | [unused-variables](/graphql-analyzer/rules/unused-variables/)               | —                | Document        | No                |
 
 ## Contexts
 
 - **Document** — Analyzes a single document without schema. Fast.
 - **Document-Schema** — Analyzes a single document against the schema. Fast.
+- **Schema** — Analyzes the schema definition. Fast.
 - **Project** — Analyzes all documents together. Slower, best for CI.

--- a/docs/src/content/docs/rules/description-style.mdx
+++ b/docs/src/content/docs/rules/description-style.mdx
@@ -1,0 +1,45 @@
+---
+title: description-style
+description: Enforce block vs inline description style.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `descriptionStyle` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Enforce block vs inline description style.
+
+## Examples
+
+```graphql
+# ❌ Bad — inline description on multi-line type
+"A user" type User {
+  id: ID!
+  name: String
+}
+```
+
+```graphql
+# ✅ Good — block description
+"""
+A user
+"""
+type User {
+  id: ID!
+  name: String
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      descriptionStyle: warn
+```

--- a/docs/src/content/docs/rules/input-name.mdx
+++ b/docs/src/content/docs/rules/input-name.mdx
@@ -1,0 +1,40 @@
+---
+title: input-name
+description: Require configurable suffix on input types.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `inputName` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require configurable suffix on input types.
+
+## Examples
+
+```graphql
+# ❌ Bad — input type without "Input" suffix
+input CreateUser {
+  name: String!
+}
+```
+
+```graphql
+# ✅ Good — input type with "Input" suffix
+input CreateUserInput {
+  name: String!
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      inputName: warn
+```

--- a/docs/src/content/docs/rules/lone-executable-definition.mdx
+++ b/docs/src/content/docs/rules/lone-executable-definition.mdx
@@ -1,0 +1,44 @@
+---
+title: lone-executable-definition
+description: Require one operation or fragment per file.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `loneExecutableDefinition` |
+| Default severity | `—`                 |
+| Context          | Document                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require one operation or fragment per file.
+
+## Examples
+
+```graphql
+# ❌ Bad — multiple operations in one file
+query GetUser {
+  user { id }
+}
+
+query GetPosts {
+  posts { id }
+}
+```
+
+```graphql
+# ✅ Good — one operation per file
+query GetUser {
+  user { id }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      loneExecutableDefinition: warn
+```

--- a/docs/src/content/docs/rules/naming-convention.mdx
+++ b/docs/src/content/docs/rules/naming-convention.mdx
@@ -1,0 +1,40 @@
+---
+title: naming-convention
+description: Enforce naming conventions for operations, fragments, and variables.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `namingConvention` |
+| Default severity | `—`                 |
+| Context          | Document                |
+| In recommended   | No                     |
+
+## What it checks
+
+Enforce naming conventions for operations, fragments, and variables.
+
+## Examples
+
+```graphql
+# ❌ Bad — inconsistent naming
+query get_user {
+  user { id }
+}
+```
+
+```graphql
+# ✅ Good — PascalCase operation name
+query GetUser {
+  user { id }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      namingConvention: warn
+```

--- a/docs/src/content/docs/rules/no-duplicate-fields.mdx
+++ b/docs/src/content/docs/rules/no-duplicate-fields.mdx
@@ -1,0 +1,47 @@
+---
+title: no-duplicate-fields
+description: Disallow duplicate fields in selection sets.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noDuplicateFields` |
+| Default severity | `warn`                 |
+| Context          | Document                |
+| In recommended   | Yes                     |
+
+## What it checks
+
+Disallow duplicate fields in selection sets.
+
+## Examples
+
+```graphql
+# ❌ Bad — duplicate field
+query GetUser {
+  user {
+    id
+    name
+    id
+  }
+}
+```
+
+```graphql
+# ✅ Good — no duplicates
+query GetUser {
+  user {
+    id
+    name
+  }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noDuplicateFields: warn
+```

--- a/docs/src/content/docs/rules/no-hashtag-description.mdx
+++ b/docs/src/content/docs/rules/no-hashtag-description.mdx
@@ -1,0 +1,42 @@
+---
+title: no-hashtag-description
+description: Disallow # comments as type descriptions.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noHashtagDescription` |
+| Default severity | `warn`                 |
+| Context          | Schema                |
+| In recommended   | Yes                     |
+
+## What it checks
+
+Disallow # comments as type descriptions.
+
+## Examples
+
+```graphql
+# ❌ Bad — comment used as description
+# A user type
+type User {
+  id: ID!
+}
+```
+
+```graphql
+# ✅ Good — proper description string
+"A user type"
+type User {
+  id: ID!
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noHashtagDescription: warn
+```

--- a/docs/src/content/docs/rules/no-one-place-fragments.mdx
+++ b/docs/src/content/docs/rules/no-one-place-fragments.mdx
@@ -1,0 +1,50 @@
+---
+title: no-one-place-fragments
+description: Detect fragments used in only one place.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noOnePlaceFragments` |
+| Default severity | `—`                 |
+| Context          | Project                |
+| In recommended   | No                     |
+
+## What it checks
+
+Detect fragments used in only one place.
+
+## Examples
+
+```graphql
+# ❌ Bad — fragment used only once
+fragment UserFields on User {
+  id
+  name
+}
+
+query GetUser {
+  user {
+    ...UserFields
+  }
+}
+```
+
+```graphql
+# ✅ Good — inline the fields
+query GetUser {
+  user {
+    id
+    name
+  }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noOnePlaceFragments: warn
+```

--- a/docs/src/content/docs/rules/no-scalar-result-type-on-mutation.mdx
+++ b/docs/src/content/docs/rules/no-scalar-result-type-on-mutation.mdx
@@ -1,0 +1,44 @@
+---
+title: no-scalar-result-type-on-mutation
+description: Require mutations to return object types.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noScalarResultTypeOnMutation` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require mutations to return object types.
+
+## Examples
+
+```graphql
+# ❌ Bad — mutation returns scalar
+type Mutation {
+  deleteUser(id: ID!): Boolean
+}
+```
+
+```graphql
+# ✅ Good — mutation returns object type
+type Mutation {
+  deleteUser(id: ID!): DeleteUserPayload
+}
+
+type DeleteUserPayload {
+  success: Boolean!
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noScalarResultTypeOnMutation: warn
+```

--- a/docs/src/content/docs/rules/no-typename-prefix.mdx
+++ b/docs/src/content/docs/rules/no-typename-prefix.mdx
@@ -1,0 +1,42 @@
+---
+title: no-typename-prefix
+description: Disallow field names prefixed with type name.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noTypenamePrefix` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Disallow field names prefixed with type name.
+
+## Examples
+
+```graphql
+# ❌ Bad — field prefixed with type name
+type User {
+  userId: ID!
+  userName: String
+}
+```
+
+```graphql
+# ✅ Good — clean field names
+type User {
+  id: ID!
+  name: String
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noTypenamePrefix: warn
+```

--- a/docs/src/content/docs/rules/no-unreachable-types.mdx
+++ b/docs/src/content/docs/rules/no-unreachable-types.mdx
@@ -1,0 +1,52 @@
+---
+title: no-unreachable-types
+description: Detect types unreachable from root operations.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `noUnreachableTypes` |
+| Default severity | `warn`                 |
+| Context          | Schema                |
+| In recommended   | Yes                     |
+
+## What it checks
+
+Detect types unreachable from root operations.
+
+## Examples
+
+```graphql
+# ❌ Bad — OrphanType is unreachable
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+}
+
+type OrphanType {
+  id: ID!
+}
+```
+
+```graphql
+# ✅ Good — all types reachable from Query
+type Query {
+  user: User
+}
+
+type User {
+  id: ID!
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      noUnreachableTypes: warn
+```

--- a/docs/src/content/docs/rules/require-deprecation-reason.mdx
+++ b/docs/src/content/docs/rules/require-deprecation-reason.mdx
@@ -1,0 +1,42 @@
+---
+title: require-deprecation-reason
+description: Require reason in @deprecated directives.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `requireDeprecationReason` |
+| Default severity | `warn`                 |
+| Context          | Schema                |
+| In recommended   | Yes                     |
+
+## What it checks
+
+Require reason in @deprecated directives.
+
+## Examples
+
+```graphql
+# ❌ Bad — @deprecated without reason
+type User {
+  id: ID!
+  oldField: String @deprecated
+}
+```
+
+```graphql
+# ✅ Good — @deprecated with reason
+type User {
+  id: ID!
+  oldField: String @deprecated(reason: "Use newField instead")
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      requireDeprecationReason: warn
+```

--- a/docs/src/content/docs/rules/require-description.mdx
+++ b/docs/src/content/docs/rules/require-description.mdx
@@ -1,0 +1,41 @@
+---
+title: require-description
+description: Require descriptions on type definitions.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `requireDescription` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require descriptions on type definitions.
+
+## Examples
+
+```graphql
+# ❌ Bad — type without description
+type User {
+  id: ID!
+}
+```
+
+```graphql
+# ✅ Good — type with description
+"Represents a registered user"
+type User {
+  id: ID!
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      requireDescription: warn
+```

--- a/docs/src/content/docs/rules/require-field-of-type-query-in-mutation-result.mdx
+++ b/docs/src/content/docs/rules/require-field-of-type-query-in-mutation-result.mdx
@@ -1,0 +1,49 @@
+---
+title: require-field-of-type-query-in-mutation-result
+description: Require Query field in mutation result types.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `requireFieldOfTypeQueryInMutationResult` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require Query field in mutation result types.
+
+## Examples
+
+```graphql
+# ❌ Bad — mutation result without Query field
+type Mutation {
+  createUser(name: String!): CreateUserPayload
+}
+
+type CreateUserPayload {
+  user: User
+}
+```
+
+```graphql
+# ✅ Good — mutation result with Query field
+type Mutation {
+  createUser(name: String!): CreateUserPayload
+}
+
+type CreateUserPayload {
+  user: User
+  query: Query
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      requireFieldOfTypeQueryInMutationResult: warn
+```

--- a/docs/src/content/docs/rules/selection-set-depth.mdx
+++ b/docs/src/content/docs/rules/selection-set-depth.mdx
@@ -1,0 +1,52 @@
+---
+title: selection-set-depth
+description: Limit selection set nesting depth.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `selectionSetDepth` |
+| Default severity | `—`                 |
+| Context          | Document                |
+| In recommended   | No                     |
+
+## What it checks
+
+Limit selection set nesting depth.
+
+## Examples
+
+```graphql
+# ❌ Bad — too deeply nested
+query Deep {
+  a {
+    b {
+      c {
+        d {
+          id
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+# ✅ Good — reasonable depth
+query Shallow {
+  user {
+    posts {
+      id
+    }
+  }
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      selectionSetDepth: [warn, { maxDepth: 3 }]
+```

--- a/docs/src/content/docs/rules/strict-id-in-types.mdx
+++ b/docs/src/content/docs/rules/strict-id-in-types.mdx
@@ -1,0 +1,43 @@
+---
+title: strict-id-in-types
+description: Require ID field in object types.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `strictIdInTypes` |
+| Default severity | `—`                 |
+| Context          | Schema                |
+| In recommended   | No                     |
+
+## What it checks
+
+Require ID field in object types.
+
+## Examples
+
+```graphql
+# ❌ Bad — object type without ID field
+type User {
+  name: String
+  email: String
+}
+```
+
+```graphql
+# ✅ Good — object type with ID field
+type User {
+  id: ID!
+  name: String
+  email: String
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      strictIdInTypes: warn
+```

--- a/docs/src/content/docs/rules/unique-enum-value-names.mdx
+++ b/docs/src/content/docs/rules/unique-enum-value-names.mdx
@@ -1,0 +1,52 @@
+---
+title: unique-enum-value-names
+description: Detect duplicate enum values across enums.
+---
+
+| Property         | Value                   |
+| ---------------- | ----------------------- |
+| Config name      | `uniqueEnumValueNames` |
+| Default severity | `warn`                 |
+| Context          | Schema                |
+| In recommended   | Yes                     |
+
+## What it checks
+
+Detect duplicate enum values across enums.
+
+## Examples
+
+```graphql
+# ❌ Bad — ACTIVE appears in both enums
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+
+enum ProjectStatus {
+  ACTIVE
+  ARCHIVED
+}
+```
+
+```graphql
+# ✅ Good — unique values across enums
+enum UserStatus {
+  USER_ACTIVE
+  USER_INACTIVE
+}
+
+enum ProjectStatus {
+  PROJECT_ACTIVE
+  PROJECT_ARCHIVED
+}
+```
+
+## Configuration
+
+```yaml
+extensions:
+  lint:
+    rules:
+      uniqueEnumValueNames: warn
+```


### PR DESCRIPTION
## Summary
- Adds individual MDX documentation pages for all 17 new lint rules
- Updates rules catalog with new entries and Schema context definition
- Updates sidebar with all new rule links

Broken out from #613.

## Test plan
- [x] `npm run build` passes (57 pages, no broken links)