### PR TITLE
feat(linter): add 5 rules to recommended preset

### DIFF
--- a/.changeset/recommended-preset-update.md
+++ b/.changeset/recommended-preset-update.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-cli: minor
+graphql-analyzer-lsp: minor
+---
+
+Add noDuplicateFields, noUnreachableTypes, requireDeprecationReason, noHashtagDescription, and uniqueEnumValueNames to the recommended lint preset

--- a/crates/linter/src/config.rs
+++ b/crates/linter/src/config.rs
@@ -348,9 +348,15 @@ impl LintConfig {
     fn recommended_severity(rule_name: &str) -> Option<LintSeverity> {
         match rule_name {
             "noAnonymousOperations" => Some(LintSeverity::Error),
-            "noDeprecated" | "redundantFields" | "unusedFragments" | "unusedFields" => {
-                Some(LintSeverity::Warn)
-            }
+            "noDeprecated"
+            | "redundantFields"
+            | "unusedFragments"
+            | "unusedFields"
+            | "noDuplicateFields"
+            | "noUnreachableTypes"
+            | "requireDeprecationReason"
+            | "noHashtagDescription"
+            | "uniqueEnumValueNames" => Some(LintSeverity::Warn),
             _ => None,
         }
     }
@@ -378,6 +384,11 @@ mod tests {
         assert!(!config.is_enabled("uniqueNames"));
         assert!(config.is_enabled("noDeprecated"));
         assert!(config.is_enabled("unusedFields"));
+        assert!(config.is_enabled("noDuplicateFields"));
+        assert!(config.is_enabled("noUnreachableTypes"));
+        assert!(config.is_enabled("requireDeprecationReason"));
+        assert!(config.is_enabled("noHashtagDescription"));
+        assert!(config.is_enabled("uniqueEnumValueNames"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds 5 rules to the `recommended` lint preset as warnings:
  - `noDuplicateFields` — duplicate fields in selection sets are always a bug
  - `noUnreachableTypes` — dead types in schema are noise
  - `requireDeprecationReason` — `@deprecated` without reason is useless
  - `noHashtagDescription` — `#` comments aren't actual GraphQL descriptions
  - `uniqueEnumValueNames` — duplicate enum values across types cause confusion

Broken out from #613.

## Test plan
- [x] `cargo test -p graphql-linter` passes (179 tests)
- [x] `cargo clippy` clean
- [x] Docs build passes