### PR TITLE
feat(linter): add `loneExecutableDefinition` lint rule

### DIFF
--- a/.changeset/loneExecutableDefinition-rule.md
+++ b/.changeset/loneExecutableDefinition-rule.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+---
+
+Add `loneExecutableDefinition` lint rule: Requires each file to contain only one executable definition (operation or fragment) (broken out from #613)

--- a/.graphqlrc.yaml
+++ b/.graphqlrc.yaml
@@ -133,3 +133,4 @@ projects:
       lint:
         rules:
           alphabetize: [warn, { selections: true, arguments: true, variables: true }]
+          loneExecutableDefinition: warn

--- a/crates/config/schema/graphqlrc.schema.json
+++ b/crates/config/schema/graphqlrc.schema.json
@@ -267,6 +267,10 @@
             "alphabetize": {
               "$ref": "#/definitions/LintRuleConfig",
               "description": "Enforce alphabetical ordering of fields, arguments, and variables in selections"
+            },
+            "loneExecutableDefinition": {
+              "$ref": "#/definitions/LintRuleConfig",
+              "description": "Requires each file to contain only one executable definition (operation or fragment)"
             }
           },
           "additionalProperties": {

--- a/crates/linter/src/registry.rs
+++ b/crates/linter/src/registry.rs
@@ -1,8 +1,9 @@
 /// Registry of all available lint rules
 use crate::rules::{
-    AlphabetizeRuleImpl, NoAnonymousOperationsRuleImpl, NoDeprecatedRuleImpl,
-    OperationNameSuffixRuleImpl, RedundantFieldsRuleImpl, RequireIdFieldRuleImpl,
-    UniqueNamesRuleImpl, UnusedFieldsRuleImpl, UnusedFragmentsRuleImpl, UnusedVariablesRuleImpl,
+    AlphabetizeRuleImpl, LoneExecutableDefinitionRuleImpl, NoAnonymousOperationsRuleImpl,
+    NoDeprecatedRuleImpl, OperationNameSuffixRuleImpl, RedundantFieldsRuleImpl,
+    RequireIdFieldRuleImpl, UniqueNamesRuleImpl, UnusedFieldsRuleImpl, UnusedFragmentsRuleImpl,
+    UnusedVariablesRuleImpl,
 };
 use crate::traits::{
     DocumentSchemaLintRule, ProjectLintRule, StandaloneDocumentLintRule, StandaloneSchemaLintRule,
@@ -15,6 +16,7 @@ static STANDALONE_DOCUMENT_RULES: LazyLock<Vec<Arc<dyn StandaloneDocumentLintRul
     LazyLock::new(|| {
         vec![
             Arc::new(AlphabetizeRuleImpl),
+            Arc::new(LoneExecutableDefinitionRuleImpl),
             Arc::new(NoAnonymousOperationsRuleImpl),
             Arc::new(OperationNameSuffixRuleImpl),
             Arc::new(RedundantFieldsRuleImpl),

--- a/crates/linter/src/rules/lone_executable_definition.rs
+++ b/crates/linter/src/rules/lone_executable_definition.rs
@@ -1,0 +1,188 @@
+use crate::diagnostics::{LintDiagnostic, LintSeverity};
+use crate::traits::{LintRule, StandaloneDocumentLintRule};
+use apollo_parser::cst::{self, CstNode};
+use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
+
+/// Lint rule that requires each file to contain only one executable definition
+///
+/// Having one operation or fragment per file improves code organization and
+/// makes it easier to find and maintain GraphQL operations.
+pub struct LoneExecutableDefinitionRuleImpl;
+
+impl LintRule for LoneExecutableDefinitionRuleImpl {
+    fn name(&self) -> &'static str {
+        "loneExecutableDefinition"
+    }
+
+    fn description(&self) -> &'static str {
+        "Requires each file to contain only one executable definition (operation or fragment)"
+    }
+
+    fn default_severity(&self) -> LintSeverity {
+        LintSeverity::Warning
+    }
+}
+
+impl StandaloneDocumentLintRule for LoneExecutableDefinitionRuleImpl {
+    fn check(
+        &self,
+        db: &dyn graphql_hir::GraphQLHirDatabase,
+        _file_id: FileId,
+        content: FileContent,
+        metadata: FileMetadata,
+        _project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
+    ) -> Vec<LintDiagnostic> {
+        let mut diagnostics = Vec::new();
+
+        let parse = graphql_syntax::parse(db, content, metadata);
+        if parse.has_errors() {
+            return diagnostics;
+        }
+
+        for doc in parse.documents() {
+            let doc_cst = doc.tree.document();
+            let mut operations = Vec::new();
+            let mut fragments = Vec::new();
+
+            for definition in doc_cst.definitions() {
+                match &definition {
+                    cst::Definition::OperationDefinition(op) => {
+                        operations.push(op.clone());
+                    }
+                    cst::Definition::FragmentDefinition(frag) => {
+                        fragments.push(frag.clone());
+                    }
+                    _ => {}
+                }
+            }
+
+            let total_defs = operations.len() + fragments.len();
+            if total_defs <= 1 {
+                continue;
+            }
+
+            // Report all definitions after the first one
+            let mut all_defs: Vec<(&str, Option<String>, usize, usize)> = Vec::new();
+
+            for op in &operations {
+                let name = op.name().map(|n| n.text().to_string());
+                let name_or_keyword = op
+                    .name()
+                    .map(|n| {
+                        let start: usize = n.syntax().text_range().start().into();
+                        let end: usize = n.syntax().text_range().end().into();
+                        (start, end)
+                    })
+                    .or_else(|| {
+                        op.operation_type().map(|ot| {
+                            let start: usize = ot.syntax().text_range().start().into();
+                            let end: usize = ot.syntax().text_range().end().into();
+                            (start, end)
+                        })
+                    })
+                    .or_else(|| {
+                        op.selection_set().map(|ss| {
+                            let start: usize = ss.syntax().text_range().start().into();
+                            (start, start + 1)
+                        })
+                    });
+
+                if let Some((start, end)) = name_or_keyword {
+                    all_defs.push(("operation", name, start, end));
+                }
+            }
+
+            for frag in &fragments {
+                let name = frag
+                    .fragment_name()
+                    .and_then(|fn_| fn_.name())
+                    .map(|n| n.text().to_string());
+                let name_or_keyword = frag.fragment_name().and_then(|fn_| fn_.name()).map(|n| {
+                    let start: usize = n.syntax().text_range().start().into();
+                    let end: usize = n.syntax().text_range().end().into();
+                    (start, end)
+                });
+
+                if let Some((start, end)) = name_or_keyword {
+                    all_defs.push(("fragment", name, start, end));
+                }
+            }
+
+            // Sort by position and skip the first definition
+            all_defs.sort_by_key(|d| d.2);
+            for (kind, name, start, end) in all_defs.into_iter().skip(1) {
+                let def_desc =
+                    name.map_or_else(|| format!("anonymous {kind}"), |n| format!("{kind} '{n}'"));
+                diagnostics.push(LintDiagnostic::new(
+                    doc.span(start, end),
+                    LintSeverity::Warning,
+                    format!(
+                        "Only one executable definition is allowed per file. Found additional {def_desc}."
+                    ),
+                    "loneExecutableDefinition",
+                ));
+            }
+        }
+
+        diagnostics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::StandaloneDocumentLintRule;
+    use graphql_base_db::{DocumentKind, FileContent, FileId, FileMetadata, FileUri, Language};
+    use graphql_ide_db::RootDatabase;
+    use std::sync::Arc;
+
+    fn create_test_project_files(db: &RootDatabase) -> ProjectFiles {
+        let schema_file_ids = graphql_base_db::SchemaFileIds::new(db, Arc::new(vec![]));
+        let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
+        let file_entry_map =
+            graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
+        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    }
+
+    fn check(source: &str) -> Vec<LintDiagnostic> {
+        let db = RootDatabase::default();
+        let rule = LoneExecutableDefinitionRuleImpl;
+        let file_id = FileId::new(0);
+        let content = FileContent::new(&db, Arc::from(source));
+        let metadata = FileMetadata::new(
+            &db,
+            file_id,
+            FileUri::new("file:///test.graphql"),
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        let project_files = create_test_project_files(&db);
+        rule.check(&db, file_id, content, metadata, project_files, None)
+    }
+
+    #[test]
+    fn test_single_operation() {
+        let diagnostics = check("query Q { user { id } }");
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_single_fragment() {
+        let diagnostics = check("fragment F on User { id }");
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_operations() {
+        let diagnostics = check("query Q1 { user { id } } query Q2 { posts { id } }");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("Q2"));
+    }
+
+    #[test]
+    fn test_operation_and_fragment() {
+        let diagnostics = check("fragment F on User { id } query Q { user { ...F } }");
+        assert_eq!(diagnostics.len(), 1);
+    }
+}

--- a/crates/linter/src/rules/mod.rs
+++ b/crates/linter/src/rules/mod.rs
@@ -26,6 +26,7 @@ pub fn get_operation_kind(op_type: &cst::OperationType) -> OperationKind {
 }
 
 mod alphabetize;
+mod lone_executable_definition;
 mod no_anonymous_operations;
 mod no_deprecated;
 mod operation_name_suffix;
@@ -37,6 +38,7 @@ mod unused_fragments;
 mod unused_variables;
 
 pub use alphabetize::AlphabetizeRuleImpl;
+pub use lone_executable_definition::LoneExecutableDefinitionRuleImpl;
 pub use no_anonymous_operations::NoAnonymousOperationsRuleImpl;
 pub use no_deprecated::NoDeprecatedRuleImpl;
 pub use operation_name_suffix::OperationNameSuffixRuleImpl;

--- a/test-workspace/lint-examples/src/lone-executable-definition.graphql
+++ b/test-workspace/lint-examples/src/lone-executable-definition.graphql
@@ -1,0 +1,16 @@
+# Demonstrates: loneExecutableDefinition
+# Only one executable definition (operation or fragment) per file.
+
+query FirstQuery {
+  users {
+    id
+    name
+  }
+}
+
+query SecondQuery {
+  posts {
+    id
+    title
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the `loneExecutableDefinition` lint rule: require one operation or fragment per file

Broken out from #613. Replaces #815 (which was erroneously auto-merged by GitHub during a branch restack).

## Test plan
- [x] `cargo test -p graphql-linter` passes
- [x] `cargo clippy` clean