### PR TITLE
feat(mcp): add schema exploration, document analysis, and introspection tools

### DIFF
--- a/.changeset/mcp-schema-tools.md
+++ b/.changeset/mcp-schema-tools.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-mcp: minor
+---
+
+Add 6 new MCP tools: schema exploration (`get_schema_types`, `get_type_info`, `get_schema_sdl`), document analysis (`get_operations`, `get_query_complexity`), and remote introspection (`introspect_endpoint`) ([#837](https://github.com/trevor-scheer/graphql-analyzer/pull/837))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,9 +3193,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,7 @@ dependencies = [
  "anyhow",
  "glob",
  "graphql-config",
+ "graphql-hir",
  "graphql-ide",
  "graphql-introspect",
  "graphql-linter",

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -7,13 +7,16 @@ static CLONE_SNAPSHOT_ID: AtomicU64 = AtomicU64::new(1_000_000);
 
 use crate::database::IdeDatabase;
 use crate::db_files::DbFiles;
+use crate::helpers;
 use crate::helpers::{adjust_range_for_line_offset, convert_diagnostic, offset_range_to_range};
 use crate::symbol::{find_fragment_definition_full_range, find_operation_definition_ranges};
 use crate::types::{
     CodeLens, CodeLensInfo, ComplexityAnalysis, Diagnostic, DocumentSymbol, FieldComplexity,
     FieldCoverageReport, FieldUsageInfo, FilePath, FoldingRange, FragmentReference, FragmentUsage,
-    HoverResult, InlayHint, Location, Position, ProjectStatus, Range, RenameResult, SchemaStats,
-    SelectionRange, SignatureHelp, WorkspaceSymbol,
+    HoverResult, InlayHint, Location, OperationSummary, OperationVariableInfo, Position,
+    ProjectStatus, Range, RenameResult, SchemaStats, SchemaTypeEntry, SelectionRange,
+    SignatureHelp, TypeArgumentInfo, TypeDirectiveArgumentInfo, TypeDirectiveInfo,
+    TypeEnumValueInfo, TypeFieldInfo, TypeInfo, WorkspaceSymbol,
 };
 use crate::{
     code_lenses, completion, folding_ranges, goto_definition, hover, inlay_hints, references,
@@ -1037,6 +1040,190 @@ impl Analysis {
         deps
     }
 
+    /// Access the raw HIR `TypeDefMap` for the schema
+    ///
+    /// The callback receives a reference to the merged type map. This avoids
+    /// cloning the entire map when only a derived value (like SDL text) is needed.
+    pub fn with_schema_types<R>(&self, f: impl FnOnce(&graphql_hir::TypeDefMap) -> R) -> R {
+        let project_files = self.project_files.expect("no project files loaded");
+        let types = graphql_hir::schema_types(&self.db, project_files);
+        f(types)
+    }
+
+    /// List all schema types with lightweight metadata
+    pub fn schema_type_list(
+        &self,
+        kind_filter: Option<&str>,
+    ) -> (Vec<SchemaTypeEntry>, SchemaStats) {
+        let stats = self.schema_stats();
+        let Some(project_files) = self.project_files else {
+            return (Vec::new(), stats);
+        };
+
+        let types = graphql_hir::schema_types(&self.db, project_files);
+        let mut entries: Vec<SchemaTypeEntry> = types
+            .values()
+            .filter(|td| {
+                if let Some(filter) = kind_filter {
+                    type_def_kind_str(td.kind) == filter
+                } else {
+                    true
+                }
+            })
+            .map(|td| SchemaTypeEntry {
+                name: td.name.to_string(),
+                kind: type_def_kind_str(td.kind).to_string(),
+                description: td.description.as_ref().map(ToString::to_string),
+                field_count: td.fields.len(),
+                implements: td.implements.iter().map(ToString::to_string).collect(),
+                is_extension: td.is_extension,
+            })
+            .collect();
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        (entries, stats)
+    }
+
+    /// Get full details about a specific named type
+    pub fn type_info(&self, type_name: &str) -> Option<TypeInfo> {
+        let project_files = self.project_files?;
+        let types = graphql_hir::schema_types(&self.db, project_files);
+        let td = types.get(type_name)?;
+
+        Some(TypeInfo {
+            name: td.name.to_string(),
+            kind: type_def_kind_str(td.kind).to_string(),
+            description: td.description.as_ref().map(ToString::to_string),
+            implements: td.implements.iter().map(ToString::to_string).collect(),
+            fields: td
+                .fields
+                .iter()
+                .map(|f| TypeFieldInfo {
+                    name: f.name.to_string(),
+                    type_ref: helpers::format_type_ref(&f.type_ref),
+                    description: f.description.as_ref().map(ToString::to_string),
+                    arguments: f
+                        .arguments
+                        .iter()
+                        .map(|a| TypeArgumentInfo {
+                            name: a.name.to_string(),
+                            type_ref: helpers::format_type_ref(&a.type_ref),
+                            description: a.description.as_ref().map(ToString::to_string),
+                            default_value: a.default_value.as_ref().map(ToString::to_string),
+                        })
+                        .collect(),
+                    is_deprecated: f.is_deprecated,
+                    deprecation_reason: f.deprecation_reason.as_ref().map(ToString::to_string),
+                    directives: f
+                        .directives
+                        .iter()
+                        .map(|d| TypeDirectiveInfo {
+                            name: d.name.to_string(),
+                            arguments: d
+                                .arguments
+                                .iter()
+                                .map(|a| TypeDirectiveArgumentInfo {
+                                    name: a.name.to_string(),
+                                    value: a.value.to_string(),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            directives: td
+                .directives
+                .iter()
+                .map(|d| TypeDirectiveInfo {
+                    name: d.name.to_string(),
+                    arguments: d
+                        .arguments
+                        .iter()
+                        .map(|a| TypeDirectiveArgumentInfo {
+                            name: a.name.to_string(),
+                            value: a.value.to_string(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            enum_values: td
+                .enum_values
+                .iter()
+                .map(|v| TypeEnumValueInfo {
+                    name: v.name.to_string(),
+                    description: v.description.as_ref().map(ToString::to_string),
+                    is_deprecated: v.is_deprecated,
+                    deprecation_reason: v.deprecation_reason.as_ref().map(ToString::to_string),
+                })
+                .collect(),
+            union_members: td.union_members.iter().map(ToString::to_string).collect(),
+        })
+    }
+
+    /// Extract all operations with their metadata and fragment dependencies
+    pub fn operations_summary(&self, file_filter: Option<&FilePath>) -> Vec<OperationSummary> {
+        let Some(project_files) = self.project_files else {
+            return Vec::new();
+        };
+
+        let operations = graphql_hir::all_operations(&self.db, project_files);
+        let registry = DbFiles::new(&self.db, self.project_files);
+
+        let mut results = Vec::new();
+        for op in operations.iter() {
+            let Some(file_path) = registry.get_path(op.file_id) else {
+                continue;
+            };
+
+            if let Some(filter) = file_filter {
+                if file_path.as_str() != filter.as_str() {
+                    continue;
+                }
+            }
+
+            let Some(content) = registry.get_content(op.file_id) else {
+                continue;
+            };
+            let Some(metadata) = registry.get_metadata(op.file_id) else {
+                continue;
+            };
+
+            // Get fragment dependencies from the operation body
+            let body = graphql_hir::operation_body(&self.db, content, metadata, op.index);
+            let mut fragment_deps: Vec<String> = body
+                .fragment_spreads
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            fragment_deps.sort();
+
+            #[allow(clippy::match_same_arms)]
+            let op_type = match op.operation_type {
+                graphql_hir::OperationType::Query => "query",
+                graphql_hir::OperationType::Mutation => "mutation",
+                graphql_hir::OperationType::Subscription => "subscription",
+                _ => "query",
+            };
+
+            results.push(OperationSummary {
+                name: op.name.as_ref().map(ToString::to_string),
+                operation_type: op_type.to_string(),
+                file: file_path,
+                variables: op
+                    .variables
+                    .iter()
+                    .map(|v| OperationVariableInfo {
+                        name: v.name.to_string(),
+                        type_ref: helpers::format_type_ref(&v.type_ref),
+                        default_value: v.default_value.as_ref().map(ToString::to_string),
+                    })
+                    .collect(),
+                fragment_dependencies: fragment_deps,
+            });
+        }
+
+        results
+    }
+
     /// Get code lenses for a file
     ///
     /// Returns code lenses for fragment definitions showing reference counts.
@@ -1188,4 +1375,16 @@ fn get_type_info(
         }
     }
     (false, "Unknown".to_string())
+}
+
+fn type_def_kind_str(kind: graphql_hir::TypeDefKind) -> &'static str {
+    match kind {
+        graphql_hir::TypeDefKind::Object => "object",
+        graphql_hir::TypeDefKind::Interface => "interface",
+        graphql_hir::TypeDefKind::Union => "union",
+        graphql_hir::TypeDefKind::Enum => "enum",
+        graphql_hir::TypeDefKind::Scalar => "scalar",
+        graphql_hir::TypeDefKind::InputObject => "input_object",
+        _ => "unknown",
+    }
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -71,10 +71,12 @@ pub use types::{
     ComplexityAnalysis, Diagnostic, DiagnosticSeverity, DocumentLoadResult, DocumentSymbol,
     FieldComplexity, FieldCoverageReport, FieldUsageInfo, FilePath, FoldingRange, FoldingRangeKind,
     FragmentReference, FragmentUsage, HoverResult, InlayHint, InlayHintKind, InsertTextFormat,
-    Location, ParameterInformation, PendingIntrospection, Position, ProjectStatus, Range,
-    RenameResult, SchemaContentError, SchemaLoadResult, SchemaStats, SelectionRange, SemanticToken,
-    SemanticTokenModifiers, SemanticTokenType, SignatureHelp, SignatureInformation, SymbolKind,
-    TextEdit, TypeCoverageInfo, WorkspaceSymbol,
+    Location, OperationSummary, OperationVariableInfo, ParameterInformation, PendingIntrospection,
+    Position, ProjectStatus, Range, RenameResult, SchemaContentError, SchemaLoadResult,
+    SchemaStats, SchemaTypeEntry, SelectionRange, SemanticToken, SemanticTokenModifiers,
+    SemanticTokenType, SignatureHelp, SignatureInformation, SymbolKind, TextEdit, TypeArgumentInfo,
+    TypeCoverageInfo, TypeDirectiveArgumentInfo, TypeDirectiveInfo, TypeEnumValueInfo,
+    TypeFieldInfo, TypeInfo, WorkspaceSymbol,
 };
 
 // `FileRegistry` is owned by `AnalysisHost` and not exposed publicly. Snapshots

--- a/crates/ide/src/types.rs
+++ b/crates/ide/src/types.rs
@@ -1223,6 +1223,92 @@ impl ComplexityAnalysis {
     }
 }
 
+/// A lightweight summary of a schema type for listing
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaTypeEntry {
+    pub name: String,
+    pub kind: String,
+    pub description: Option<String>,
+    pub field_count: usize,
+    pub implements: Vec<String>,
+    pub is_extension: bool,
+}
+
+/// Full details about a specific schema type
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeInfo {
+    pub name: String,
+    pub kind: String,
+    pub description: Option<String>,
+    pub implements: Vec<String>,
+    pub fields: Vec<TypeFieldInfo>,
+    pub directives: Vec<TypeDirectiveInfo>,
+    pub enum_values: Vec<TypeEnumValueInfo>,
+    pub union_members: Vec<String>,
+}
+
+/// A field in a type definition
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeFieldInfo {
+    pub name: String,
+    pub type_ref: String,
+    pub description: Option<String>,
+    pub arguments: Vec<TypeArgumentInfo>,
+    pub is_deprecated: bool,
+    pub deprecation_reason: Option<String>,
+    pub directives: Vec<TypeDirectiveInfo>,
+}
+
+/// An argument on a field or directive
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeArgumentInfo {
+    pub name: String,
+    pub type_ref: String,
+    pub description: Option<String>,
+    pub default_value: Option<String>,
+}
+
+/// A directive applied to a schema element
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeDirectiveInfo {
+    pub name: String,
+    pub arguments: Vec<TypeDirectiveArgumentInfo>,
+}
+
+/// An argument passed to a directive
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeDirectiveArgumentInfo {
+    pub name: String,
+    pub value: String,
+}
+
+/// An enum value in an enum type
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeEnumValueInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub is_deprecated: bool,
+    pub deprecation_reason: Option<String>,
+}
+
+/// Summary of an operation for document analysis
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationSummary {
+    pub name: Option<String>,
+    pub operation_type: String,
+    pub file: FilePath,
+    pub variables: Vec<OperationVariableInfo>,
+    pub fragment_dependencies: Vec<String>,
+}
+
+/// A variable defined on an operation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationVariableInfo {
+    pub name: String,
+    pub type_ref: String,
+    pub default_value: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 # Internal dependencies
 graphql-ide = { path = "../ide" }
+graphql-hir = { path = "../hir" }
 graphql-config = { path = "../config" }
 graphql-introspect = { path = "../introspect" }
 graphql-linter = { path = "../linter" }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -37,6 +37,7 @@
 //! GraphQLMcpServer::run_with_analysis(analysis, transport).await?;
 //! ```
 
+mod sdl_printer;
 mod service;
 mod tools;
 mod types;

--- a/crates/mcp/src/sdl_printer.rs
+++ b/crates/mcp/src/sdl_printer.rs
@@ -1,0 +1,256 @@
+//! SDL printer for reconstructing schema SDL from the merged HIR types.
+//!
+//! This generates valid GraphQL SDL from the resolved TypeDefMap, giving
+//! agents a single canonical view of the schema with all extensions merged.
+
+use graphql_hir::{TypeDef, TypeDefKind, TypeDefMap};
+
+/// Built-in scalars that should not be printed
+const BUILTIN_SCALARS: &[&str] = &["String", "Int", "Float", "Boolean", "ID"];
+
+/// Print the full schema SDL from a merged TypeDefMap.
+pub fn print_schema_sdl(types: &TypeDefMap) -> String {
+    let mut output = String::new();
+    let mut sorted_types: Vec<_> = types.iter().collect();
+
+    // Sort: root types first (Query, Mutation, Subscription), then alphabetically
+    sorted_types.sort_by(|(name_a, _), (name_b, _)| {
+        fn root_order(name: &str) -> u8 {
+            match name {
+                "Query" => 0,
+                "Mutation" => 1,
+                "Subscription" => 2,
+                _ => 3,
+            }
+        }
+        let ord_a = root_order(name_a);
+        let ord_b = root_order(name_b);
+        ord_a.cmp(&ord_b).then_with(|| name_a.cmp(name_b))
+    });
+
+    let mut first = true;
+    for (_, type_def) in &sorted_types {
+        // Skip built-in scalars
+        if type_def.kind == TypeDefKind::Scalar && BUILTIN_SCALARS.contains(&type_def.name.as_ref())
+        {
+            continue;
+        }
+
+        if !first {
+            output.push('\n');
+        }
+        first = false;
+
+        print_type_def(&mut output, type_def);
+    }
+
+    output
+}
+
+fn print_type_def(out: &mut String, td: &TypeDef) {
+    print_description(out, td.description.as_deref(), "");
+
+    match td.kind {
+        TypeDefKind::Scalar => print_scalar(out, td),
+        TypeDefKind::Enum => print_enum(out, td),
+        TypeDefKind::Union => print_union(out, td),
+        TypeDefKind::Object => print_object(out, td, "type"),
+        TypeDefKind::Interface => print_object(out, td, "interface"),
+        TypeDefKind::InputObject => print_input_object(out, td),
+        _ => {}
+    }
+}
+
+fn print_description(out: &mut String, desc: Option<&str>, indent: &str) {
+    let Some(desc) = desc else { return };
+    if desc.is_empty() {
+        return;
+    }
+    if desc.contains('\n') {
+        out.push_str(indent);
+        out.push_str("\"\"\"\n");
+        for line in desc.lines() {
+            out.push_str(indent);
+            out.push_str(line);
+            out.push('\n');
+        }
+        out.push_str(indent);
+        out.push_str("\"\"\"\n");
+    } else {
+        out.push_str(indent);
+        out.push('"');
+        out.push_str(desc);
+        out.push_str("\"\n");
+    }
+}
+
+fn print_scalar(out: &mut String, td: &TypeDef) {
+    out.push_str("scalar ");
+    out.push_str(&td.name);
+    print_directives_inline(out, &td.directives);
+    out.push('\n');
+}
+
+fn print_enum(out: &mut String, td: &TypeDef) {
+    out.push_str("enum ");
+    out.push_str(&td.name);
+    print_directives_inline(out, &td.directives);
+    out.push_str(" {\n");
+    for value in &td.enum_values {
+        print_description(out, value.description.as_deref(), "  ");
+        out.push_str("  ");
+        out.push_str(&value.name);
+        if value.is_deprecated {
+            out.push_str(" @deprecated");
+            if let Some(ref reason) = value.deprecation_reason {
+                out.push_str("(reason: \"");
+                out.push_str(reason);
+                out.push_str("\")");
+            }
+        }
+        print_directives_inline(out, &value.directives);
+        out.push('\n');
+    }
+    out.push_str("}\n");
+}
+
+fn print_union(out: &mut String, td: &TypeDef) {
+    out.push_str("union ");
+    out.push_str(&td.name);
+    print_directives_inline(out, &td.directives);
+    if !td.union_members.is_empty() {
+        out.push_str(" = ");
+        for (i, member) in td.union_members.iter().enumerate() {
+            if i > 0 {
+                out.push_str(" | ");
+            }
+            out.push_str(member);
+        }
+    }
+    out.push('\n');
+}
+
+fn print_object(out: &mut String, td: &TypeDef, keyword: &str) {
+    out.push_str(keyword);
+    out.push(' ');
+    out.push_str(&td.name);
+    if !td.implements.is_empty() {
+        out.push_str(" implements ");
+        for (i, iface) in td.implements.iter().enumerate() {
+            if i > 0 {
+                out.push_str(" & ");
+            }
+            out.push_str(iface);
+        }
+    }
+    print_directives_inline(out, &td.directives);
+    out.push_str(" {\n");
+    for field in &td.fields {
+        print_field(out, field);
+    }
+    out.push_str("}\n");
+}
+
+fn print_input_object(out: &mut String, td: &TypeDef) {
+    out.push_str("input ");
+    out.push_str(&td.name);
+    print_directives_inline(out, &td.directives);
+    out.push_str(" {\n");
+    for field in &td.fields {
+        print_description(out, field.description.as_deref(), "  ");
+        out.push_str("  ");
+        out.push_str(&field.name);
+        out.push_str(": ");
+        out.push_str(&format_type_ref(&field.type_ref));
+        print_directives_inline(out, &field.directives);
+        out.push('\n');
+    }
+    out.push_str("}\n");
+}
+
+fn print_field(out: &mut String, field: &graphql_hir::FieldSignature) {
+    print_description(out, field.description.as_deref(), "  ");
+    out.push_str("  ");
+    out.push_str(&field.name);
+    if !field.arguments.is_empty() {
+        out.push('(');
+        for (i, arg) in field.arguments.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str(&arg.name);
+            out.push_str(": ");
+            out.push_str(&format_type_ref(&arg.type_ref));
+            if let Some(ref default) = arg.default_value {
+                out.push_str(" = ");
+                out.push_str(default);
+            }
+        }
+        out.push(')');
+    }
+    out.push_str(": ");
+    out.push_str(&format_type_ref(&field.type_ref));
+    if field.is_deprecated {
+        out.push_str(" @deprecated");
+        if let Some(ref reason) = field.deprecation_reason {
+            out.push_str("(reason: \"");
+            out.push_str(reason);
+            out.push_str("\")");
+        }
+    }
+    print_directives_inline(out, &field.directives);
+    out.push('\n');
+}
+
+fn print_directives_inline(out: &mut String, directives: &[graphql_hir::DirectiveUsage]) {
+    for dir in directives {
+        // Skip @deprecated — handled explicitly
+        if dir.name.as_ref() == "deprecated" {
+            continue;
+        }
+        out.push_str(" @");
+        out.push_str(&dir.name);
+        if !dir.arguments.is_empty() {
+            out.push('(');
+            for (i, arg) in dir.arguments.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str(&arg.name);
+                out.push_str(": ");
+                out.push_str(&arg.value);
+            }
+            out.push(')');
+        }
+    }
+}
+
+fn format_type_ref(type_ref: &graphql_hir::TypeRef) -> String {
+    let mut result = type_ref.name.to_string();
+
+    if type_ref.is_list {
+        if type_ref.inner_non_null {
+            result.push('!');
+        }
+        result = format!("[{result}]");
+    }
+
+    if type_ref.is_non_null {
+        result.push('!');
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builtin_scalars_excluded() {
+        // Verify the constant is correct
+        assert!(BUILTIN_SCALARS.contains(&"String"));
+        assert!(BUILTIN_SCALARS.contains(&"ID"));
+        assert!(!BUILTIN_SCALARS.contains(&"DateTime"));
+    }
+}

--- a/crates/mcp/src/service.rs
+++ b/crates/mcp/src/service.rs
@@ -4,10 +4,13 @@
 //! It can work with either owned `AnalysisHost` instances or shared `Analysis` snapshots.
 
 use crate::types::{
-    CompletionInfo, CompletionsResult, DiagnosticInfo, DocumentSymbolsResult, FileDiagnostics,
-    HoverResultInfo, LintResult, LoadProjectResult, LocationResult, LocationsResult,
-    ProjectDiagnosticsResult, SymbolInfo, ValidateDocumentParams, ValidateDocumentResult,
-    WorkspaceSymbolInfo, WorkspaceSymbolsResult,
+    ArgumentInfo, CompletionInfo, CompletionsResult, ComplexityInfo, DiagnosticInfo,
+    DirectiveArgumentInfo, DirectiveInfo, DocumentSymbolsResult, EnumValueInfo,
+    FieldComplexityInfo, FieldInfo, FileDiagnostics, HoverResultInfo, LintResult,
+    LoadProjectResult, LocationResult, LocationsResult, OperationInfo, OperationsResult,
+    ProjectDiagnosticsResult, QueryComplexityResult, SchemaSdlResult, SchemaStatsInfo,
+    SchemaTypeInfo, SchemaTypesResult, SymbolInfo, TypeInfoResult, ValidateDocumentParams,
+    ValidateDocumentResult, VariableInfo, WorkspaceSymbolInfo, WorkspaceSymbolsResult,
 };
 use crate::McpPreloadConfig;
 use anyhow::{Context, Result};
@@ -665,6 +668,216 @@ impl McpService {
         })
     }
 
+    /// List all schema types with metadata
+    pub fn schema_types(
+        &self,
+        kind_filter: Option<&str>,
+        project: Option<&str>,
+    ) -> Option<SchemaTypesResult> {
+        let project_name = self.resolve_project(project)?;
+        let analysis = self.analysis(&project_name)?;
+
+        let (entries, stats) = analysis.schema_type_list(kind_filter);
+        let count = entries.len();
+        let types = entries
+            .into_iter()
+            .map(|e| SchemaTypeInfo {
+                name: e.name,
+                kind: e.kind,
+                description: e.description,
+                field_count: e.field_count,
+                implements: e.implements,
+                is_extension: e.is_extension,
+            })
+            .collect();
+
+        Some(SchemaTypesResult {
+            types,
+            count,
+            stats: SchemaStatsInfo {
+                objects: stats.objects,
+                interfaces: stats.interfaces,
+                unions: stats.unions,
+                enums: stats.enums,
+                scalars: stats.scalars,
+                input_objects: stats.input_objects,
+                total_fields: stats.total_fields,
+                directives: stats.directives,
+            },
+        })
+    }
+
+    /// Get full details about a specific type
+    pub fn type_info(&self, type_name: &str, project: Option<&str>) -> Option<TypeInfoResult> {
+        let project_name = self.resolve_project(project)?;
+        let analysis = self.analysis(&project_name)?;
+        let info = analysis.type_info(type_name)?;
+
+        Some(TypeInfoResult {
+            name: info.name,
+            kind: info.kind,
+            description: info.description,
+            implements: info.implements,
+            fields: info
+                .fields
+                .into_iter()
+                .map(|f| FieldInfo {
+                    name: f.name,
+                    type_ref: f.type_ref,
+                    description: f.description,
+                    arguments: f
+                        .arguments
+                        .into_iter()
+                        .map(|a| ArgumentInfo {
+                            name: a.name,
+                            type_ref: a.type_ref,
+                            description: a.description,
+                            default_value: a.default_value,
+                        })
+                        .collect(),
+                    is_deprecated: f.is_deprecated,
+                    deprecation_reason: f.deprecation_reason,
+                    directives: f
+                        .directives
+                        .into_iter()
+                        .map(|d| DirectiveInfo {
+                            name: d.name,
+                            arguments: d
+                                .arguments
+                                .into_iter()
+                                .map(|a| DirectiveArgumentInfo {
+                                    name: a.name,
+                                    value: a.value,
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            directives: info
+                .directives
+                .into_iter()
+                .map(|d| DirectiveInfo {
+                    name: d.name,
+                    arguments: d
+                        .arguments
+                        .into_iter()
+                        .map(|a| DirectiveArgumentInfo {
+                            name: a.name,
+                            value: a.value,
+                        })
+                        .collect(),
+                })
+                .collect(),
+            enum_values: info
+                .enum_values
+                .into_iter()
+                .map(|v| EnumValueInfo {
+                    name: v.name,
+                    description: v.description,
+                    is_deprecated: v.is_deprecated,
+                    deprecation_reason: v.deprecation_reason,
+                })
+                .collect(),
+            union_members: info.union_members,
+        })
+    }
+
+    /// Get the full merged schema SDL
+    pub fn schema_sdl(&self, project: Option<&str>) -> Option<SchemaSdlResult> {
+        let project_name = self.resolve_project(project)?;
+        let analysis = self.analysis(&project_name)?;
+        let (entries, _) = analysis.schema_type_list(None);
+        let type_count = entries.len();
+
+        // Access the HIR types directly for SDL printing
+        let sdl = analysis.with_schema_types(crate::sdl_printer::print_schema_sdl);
+
+        Some(SchemaSdlResult { sdl, type_count })
+    }
+
+    /// Extract operations from the project
+    pub fn operations(
+        &self,
+        file_path: Option<&str>,
+        project: Option<&str>,
+    ) -> Option<OperationsResult> {
+        let project_name = self.resolve_project(project)?;
+        let analysis = self.analysis(&project_name)?;
+
+        let file_filter = file_path.map(Self::resolve_file_path);
+        let summaries = analysis.operations_summary(file_filter.as_ref());
+        let count = summaries.len();
+
+        let operations = summaries
+            .into_iter()
+            .map(|s| OperationInfo {
+                name: s.name,
+                operation_type: s.operation_type,
+                file: s.file.as_str().to_string(),
+                variables: s
+                    .variables
+                    .into_iter()
+                    .map(|v| VariableInfo {
+                        name: v.name,
+                        type_ref: v.type_ref,
+                        default_value: v.default_value,
+                    })
+                    .collect(),
+                fragment_dependencies: s.fragment_dependencies,
+            })
+            .collect();
+
+        Some(OperationsResult { operations, count })
+    }
+
+    /// Get complexity analysis for operations
+    pub fn query_complexity(
+        &self,
+        operation_name: Option<&str>,
+        project: Option<&str>,
+    ) -> Option<QueryComplexityResult> {
+        let project_name = self.resolve_project(project)?;
+        let analysis = self.analysis(&project_name)?;
+
+        let all = analysis.complexity_analysis();
+        let filtered: Vec<_> = if let Some(name) = operation_name {
+            all.into_iter()
+                .filter(|c| c.operation_name == name)
+                .collect()
+        } else {
+            all
+        };
+
+        let count = filtered.len();
+        let operations = filtered
+            .into_iter()
+            .map(|c| ComplexityInfo {
+                operation_name: c.operation_name,
+                operation_type: c.operation_type,
+                total_complexity: c.total_complexity,
+                depth: c.depth,
+                breakdown: c
+                    .breakdown
+                    .into_iter()
+                    .map(|b| FieldComplexityInfo {
+                        path: b.path,
+                        complexity: b.complexity,
+                        multiplier: if b.multiplier > 1 {
+                            Some(b.multiplier)
+                        } else {
+                            None
+                        },
+                    })
+                    .collect(),
+                warnings: c.warnings,
+                file: c.file.as_str().to_string(),
+            })
+            .collect();
+
+        Some(QueryComplexityResult { operations, count })
+    }
+
     /// Update the shared analysis snapshot for a project
     ///
     /// This is used in embedded mode to refresh the analysis when the LSP
@@ -1003,5 +1216,300 @@ mod tests {
     fn test_resolve_file_path_absolute() {
         let fp = McpService::resolve_file_path("/home/user/query.graphql");
         assert_eq!(fp.as_str(), "file:///home/user/query.graphql");
+    }
+
+    // --- Schema exploration tests ---
+
+    #[test]
+    fn test_schema_types_lists_all() {
+        let service = setup_service_with_schema(
+            "type Query { user: User }
+             type User { id: ID!, name: String }
+             enum Status { ACTIVE INACTIVE }
+             input CreateUserInput { name: String! }",
+        );
+
+        let result = service.schema_types(None, None).unwrap();
+        assert!(result.count >= 4); // Query, User, Status, CreateUserInput
+        assert!(result
+            .types
+            .iter()
+            .any(|t| t.name == "User" && t.kind == "object"));
+        assert!(result
+            .types
+            .iter()
+            .any(|t| t.name == "Status" && t.kind == "enum"));
+        assert!(result
+            .types
+            .iter()
+            .any(|t| t.name == "CreateUserInput" && t.kind == "input_object"));
+    }
+
+    #[test]
+    fn test_schema_types_filter_by_kind() {
+        let service = setup_service_with_schema(
+            "type Query { user: User }
+             type User { id: ID! }
+             enum Status { ACTIVE }",
+        );
+
+        let result = service.schema_types(Some("enum"), None).unwrap();
+        assert!(result.types.iter().all(|t| t.kind == "enum"));
+        assert!(result.types.iter().any(|t| t.name == "Status"));
+    }
+
+    #[test]
+    fn test_schema_types_stats() {
+        let service = setup_service_with_schema(
+            "type Query { user: User }
+             type User { id: ID!, name: String }
+             interface Node { id: ID! }
+             union SearchResult = User
+             enum Status { ACTIVE }
+             scalar DateTime
+             input CreateUserInput { name: String! }",
+        );
+
+        let result = service.schema_types(None, None).unwrap();
+        assert!(result.stats.objects >= 2); // Query + User
+        assert!(result.stats.interfaces >= 1);
+        assert!(result.stats.unions >= 1);
+        assert!(result.stats.enums >= 1);
+        assert!(result.stats.scalars >= 1);
+        assert!(result.stats.input_objects >= 1);
+    }
+
+    #[test]
+    fn test_type_info_object() {
+        let service = setup_service_with_schema(
+            "type Query { user(id: ID!): User }
+             type User implements Node { id: ID!, name: String, email: String }
+             interface Node { id: ID! }",
+        );
+
+        let result = service.type_info("User", None).unwrap();
+        assert_eq!(result.name, "User");
+        assert_eq!(result.kind, "object");
+        assert_eq!(result.implements, vec!["Node"]);
+        assert!(result.fields.len() >= 3);
+        assert!(result
+            .fields
+            .iter()
+            .any(|f| f.name == "id" && f.type_ref == "ID!"));
+        assert!(result.fields.iter().any(|f| f.name == "name"));
+    }
+
+    #[test]
+    fn test_type_info_enum() {
+        let service = setup_service_with_schema(
+            "type Query { status: Status }
+             enum Status { ACTIVE INACTIVE PENDING }",
+        );
+
+        let result = service.type_info("Status", None).unwrap();
+        assert_eq!(result.kind, "enum");
+        assert_eq!(result.enum_values.len(), 3);
+        assert!(result.enum_values.iter().any(|v| v.name == "ACTIVE"));
+    }
+
+    #[test]
+    fn test_type_info_union() {
+        let service = setup_service_with_schema(
+            "type Query { search: SearchResult }
+             union SearchResult = User | Post
+             type User { id: ID! }
+             type Post { title: String }",
+        );
+
+        let result = service.type_info("SearchResult", None).unwrap();
+        assert_eq!(result.kind, "union");
+        assert_eq!(result.union_members.len(), 2);
+        assert!(result.union_members.contains(&"User".to_string()));
+        assert!(result.union_members.contains(&"Post".to_string()));
+    }
+
+    #[test]
+    fn test_type_info_not_found() {
+        let service = setup_service_with_schema("type Query { hello: String }");
+        let result = service.type_info("NonExistent", None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_type_info_field_arguments() {
+        let service = setup_service_with_schema(
+            "type Query { users(first: Int = 10, after: String): [User] }
+             type User { id: ID! }",
+        );
+
+        let result = service.type_info("Query", None).unwrap();
+        let users_field = result.fields.iter().find(|f| f.name == "users").unwrap();
+        assert_eq!(users_field.arguments.len(), 2);
+        let first_arg = users_field
+            .arguments
+            .iter()
+            .find(|a| a.name == "first")
+            .unwrap();
+        assert_eq!(first_arg.type_ref, "Int");
+        assert_eq!(first_arg.default_value.as_deref(), Some("10"));
+    }
+
+    #[test]
+    fn test_schema_sdl() {
+        let service = setup_service_with_schema(
+            "type Query { user: User }
+             type User { id: ID!, name: String }",
+        );
+
+        let result = service.schema_sdl(None).unwrap();
+        assert!(result.sdl.contains("type Query"));
+        assert!(result.sdl.contains("type User"));
+        assert!(result.sdl.contains("id: ID!"));
+        assert!(result.type_count >= 2);
+    }
+
+    #[test]
+    fn test_schema_sdl_enum() {
+        let service = setup_service_with_schema(
+            "type Query { status: Status }
+             enum Status { ACTIVE INACTIVE }",
+        );
+
+        let result = service.schema_sdl(None).unwrap();
+        assert!(result.sdl.contains("enum Status"));
+        assert!(result.sdl.contains("ACTIVE"));
+        assert!(result.sdl.contains("INACTIVE"));
+    }
+
+    // --- Document analysis tests ---
+
+    #[test]
+    fn test_operations() {
+        let service = setup_service_with_documents(
+            "type Query { user(id: ID!): User }
+             type User { id: ID!, name: String }",
+            "file:///test/query.graphql",
+            "query GetUser($id: ID!) { user(id: $id) { id name } }
+             mutation { __typename }",
+        );
+
+        let result = service.operations(None, None).unwrap();
+        assert!(result.count >= 1);
+        let get_user = result
+            .operations
+            .iter()
+            .find(|o| o.name.as_deref() == Some("GetUser"));
+        assert!(get_user.is_some());
+        let get_user = get_user.unwrap();
+        assert_eq!(get_user.operation_type, "query");
+        assert_eq!(get_user.variables.len(), 1);
+        assert_eq!(get_user.variables[0].name, "id");
+        assert_eq!(get_user.variables[0].type_ref, "ID!");
+    }
+
+    #[test]
+    fn test_operations_with_fragments() {
+        let service = {
+            let mut service = McpService::new();
+            let host = service.get_or_create_host("default");
+            host.add_file(
+                &FilePath::new("file:///test/schema.graphql".to_string()),
+                "type Query { user: User }\ntype User { id: ID!, name: String }",
+                Language::GraphQL,
+                DocumentKind::Schema,
+            );
+            host.add_file(
+                &FilePath::new("file:///test/fragment.graphql".to_string()),
+                "fragment UserFields on User { id name }",
+                Language::GraphQL,
+                DocumentKind::Executable,
+            );
+            host.add_file(
+                &FilePath::new("file:///test/query.graphql".to_string()),
+                "query GetUser { user { ...UserFields } }",
+                Language::GraphQL,
+                DocumentKind::Executable,
+            );
+            host.rebuild_project_files();
+            service
+        };
+
+        let result = service.operations(None, None).unwrap();
+        let get_user = result
+            .operations
+            .iter()
+            .find(|o| o.name.as_deref() == Some("GetUser"))
+            .unwrap();
+        assert!(get_user
+            .fragment_dependencies
+            .contains(&"UserFields".to_string()));
+    }
+
+    #[test]
+    fn test_operations_filter_by_file() {
+        let service = {
+            let mut service = McpService::new();
+            let host = service.get_or_create_host("default");
+            host.add_file(
+                &FilePath::new("file:///test/schema.graphql".to_string()),
+                "type Query { a: String, b: String }",
+                Language::GraphQL,
+                DocumentKind::Schema,
+            );
+            host.add_file(
+                &FilePath::new("file:///test/a.graphql".to_string()),
+                "query A { a }",
+                Language::GraphQL,
+                DocumentKind::Executable,
+            );
+            host.add_file(
+                &FilePath::new("file:///test/b.graphql".to_string()),
+                "query B { b }",
+                Language::GraphQL,
+                DocumentKind::Executable,
+            );
+            host.rebuild_project_files();
+            service
+        };
+
+        let result = service
+            .operations(Some("file:///test/a.graphql"), None)
+            .unwrap();
+        assert_eq!(result.count, 1);
+        assert_eq!(result.operations[0].name.as_deref(), Some("A"));
+    }
+
+    #[test]
+    fn test_query_complexity() {
+        let service = setup_service_with_documents(
+            "type Query { user: User }
+             type User { id: ID!, name: String, posts: [Post] }
+             type Post { id: ID!, title: String }",
+            "file:///test/query.graphql",
+            "query GetUser { user { id name posts { id title } } }",
+        );
+
+        let result = service.query_complexity(None, None).unwrap();
+        assert!(result.count >= 1);
+        let get_user = result
+            .operations
+            .iter()
+            .find(|o| o.operation_name == "GetUser")
+            .unwrap();
+        assert!(get_user.total_complexity > 0);
+        assert!(get_user.depth > 0);
+    }
+
+    #[test]
+    fn test_query_complexity_filter_by_name() {
+        let service = setup_service_with_documents(
+            "type Query { a: String, b: String }",
+            "file:///test/query.graphql",
+            "query A { a }\nquery B { b }",
+        );
+
+        let result = service.query_complexity(Some("A"), None).unwrap();
+        assert_eq!(result.count, 1);
+        assert_eq!(result.operations[0].operation_name, "A");
     }
 }

--- a/crates/mcp/src/tools.rs
+++ b/crates/mcp/src/tools.rs
@@ -5,7 +5,8 @@
 use crate::service::McpService;
 use crate::types::{
     DocumentSymbolsParams, FileDiagnosticsParams, FilePositionParams, FindReferencesParams,
-    ValidateDocumentParams, WorkspaceSymbolsParams,
+    IntrospectEndpointParams, OperationsParams, QueryComplexityParams, SchemaSdlParams,
+    SchemaTypesParams, TypeInfoParams, ValidateDocumentParams, WorkspaceSymbolsParams,
 };
 use rmcp::handler::server::tool::{ToolCallContext, ToolRouter};
 use rmcp::handler::server::wrapper::Parameters;
@@ -338,6 +339,160 @@ impl GraphQLToolRouter {
             )])),
         }
     }
+
+    #[tool(
+        name = "get_schema_types",
+        description = "List all types in the schema with their kind and basic metadata. Optionally filter by kind (object, interface, union, enum, scalar, input_object). Returns JSON with {types[{name, kind, description?, field_count, implements?, is_extension?}], count, stats}."
+    )]
+    pub async fn get_schema_types(
+        &self,
+        params: Parameters<SchemaTypesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let service = self.service.lock().await;
+        let result = service.schema_types(params.0.kind.as_deref(), params.0.project.as_deref());
+        match result {
+            Some(types) => {
+                let json = serde_json::to_string(&types).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(
+                r#"{"types":[],"count":0,"stats":{"objects":0,"interfaces":0,"unions":0,"enums":0,"scalars":0,"input_objects":0,"total_fields":0,"directives":0}}"#,
+            )])),
+        }
+    }
+
+    #[tool(
+        name = "get_type_info",
+        description = "Get full details about a specific named type including fields, arguments, interfaces, directives, enum values, and union members. Returns JSON with {name, kind, description?, implements?, fields?, directives?, enum_values?, union_members?}."
+    )]
+    pub async fn get_type_info(
+        &self,
+        params: Parameters<TypeInfoParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let service = self.service.lock().await;
+        let result = service.type_info(&params.0.type_name, params.0.project.as_deref());
+        match result {
+            Some(info) => {
+                let json = serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(format!(
+                r#"{{"error":"Type '{}' not found"}}"#,
+                params.0.type_name
+            ))])),
+        }
+    }
+
+    #[tool(
+        name = "get_schema_sdl",
+        description = "Return the full merged schema as SDL text. This reconstructs SDL from the resolved types with all extensions merged. Returns JSON with {sdl, type_count}."
+    )]
+    pub async fn get_schema_sdl(
+        &self,
+        params: Parameters<SchemaSdlParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let service = self.service.lock().await;
+        let result = service.schema_sdl(params.0.project.as_deref());
+        match result {
+            Some(sdl) => {
+                let json = serde_json::to_string(&sdl).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(
+                r#"{"sdl":"","type_count":0}"#,
+            )])),
+        }
+    }
+
+    #[tool(
+        name = "get_operations",
+        description = "Extract all operations from the loaded project with names, types, variables, and fragment dependencies. Optionally filter by file path. Returns JSON with {operations[{name?, operation_type, file, variables?, fragment_dependencies?}], count}."
+    )]
+    pub async fn get_operations(
+        &self,
+        params: Parameters<OperationsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let service = self.service.lock().await;
+        let result = service.operations(params.0.file_path.as_deref(), params.0.project.as_deref());
+        match result {
+            Some(ops) => {
+                let json = serde_json::to_string(&ops).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(
+                r#"{"operations":[],"count":0}"#,
+            )])),
+        }
+    }
+
+    #[tool(
+        name = "get_query_complexity",
+        description = "Calculate complexity scores for operations. Returns total complexity, depth, per-field breakdown, and warnings. Optionally filter by operation name. Returns JSON with {operations[{operation_name, operation_type, total_complexity, depth, breakdown, warnings?, file}], count}."
+    )]
+    pub async fn get_query_complexity(
+        &self,
+        params: Parameters<QueryComplexityParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let service = self.service.lock().await;
+        let result = service.query_complexity(
+            params.0.operation_name.as_deref(),
+            params.0.project.as_deref(),
+        );
+        match result {
+            Some(complexity) => {
+                let json = serde_json::to_string(&complexity).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(
+                r#"{"operations":[],"count":0}"#,
+            )])),
+        }
+    }
+
+    #[tool(
+        name = "introspect_endpoint",
+        description = "Fetch a schema from a remote GraphQL endpoint via introspection and return the SDL. Supports custom headers for authentication. Returns JSON with {sdl, url}."
+    )]
+    pub async fn introspect_endpoint(
+        &self,
+        params: Parameters<IntrospectEndpointParams>,
+    ) -> Result<CallToolResult, McpError> {
+        // Don't hold the service lock during HTTP — run introspection directly
+        let result = run_introspection(&params.0.url, params.0.headers.as_ref()).await;
+        match result {
+            Ok(introspection) => {
+                let json =
+                    serde_json::to_string(&introspection).unwrap_or_else(|_| "{}".to_string());
+                Ok(CallToolResult::success(vec![Content::text(json)]))
+            }
+            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                r#"{{"error":"{e}"}}"#
+            ))])),
+        }
+    }
+}
+
+async fn run_introspection(
+    url: &str,
+    headers: Option<&std::collections::HashMap<String, String>>,
+) -> Result<crate::types::IntrospectEndpointResult, String> {
+    let mut client = graphql_introspect::IntrospectionClient::new();
+    if let Some(headers) = headers {
+        for (key, value) in headers {
+            client = client.with_header(key, value);
+        }
+    }
+
+    let response = client
+        .execute(url)
+        .await
+        .map_err(|e| format!("Introspection failed: {e}"))?;
+
+    let sdl = graphql_introspect::introspection_to_sdl(&response);
+    Ok(crate::types::IntrospectEndpointResult {
+        sdl,
+        url: url.to_string(),
+    })
 }
 
 impl ServerHandler for GraphQLToolRouter {
@@ -351,8 +506,12 @@ impl ServerHandler for GraphQLToolRouter {
                 "GraphQL MCP server providing schema-aware validation, linting, and code intelligence. \
                  Use validate_document to check if GraphQL operations are valid. \
                  Use lint_document to get best practice suggestions. \
+                 Use get_schema_types, get_type_info, and get_schema_sdl to explore the schema. \
                  Use goto_definition, find_references, hover, document_symbols, workspace_symbols, \
                  and get_completions for code navigation on loaded project files. \
+                 Use get_operations to extract operations with their variables and fragment dependencies. \
+                 Use get_query_complexity to analyze operation complexity. \
+                 Use introspect_endpoint to fetch a schema from a remote URL. \
                  Use get_file_diagnostics for per-file diagnostics.",
             )
     }

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -385,6 +385,321 @@ pub struct CompletionsResult {
     pub count: usize,
 }
 
+// --- Schema exploration types ---
+
+/// Parameters for get_schema_types tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaTypesParams {
+    /// Optional filter by type kind: "object", "interface", "union", "enum", "scalar", "input_object"
+    #[schemars(
+        description = "Filter by type kind. Options: object, interface, union, enum, scalar, input_object"
+    )]
+    #[serde(default)]
+    pub kind: Option<String>,
+
+    /// Optional project name
+    #[schemars(
+        description = "Optional project name. If not provided, uses the first/only loaded project."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Result of get_schema_types
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaTypesResult {
+    /// List of types
+    pub types: Vec<SchemaTypeInfo>,
+    /// Total number of types returned
+    pub count: usize,
+    /// Schema statistics
+    pub stats: SchemaStatsInfo,
+}
+
+/// A type in the schema listing
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaTypeInfo {
+    /// Type name
+    pub name: String,
+    /// Type kind (object, interface, union, enum, scalar, input_object)
+    pub kind: String,
+    /// Type description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Number of fields
+    pub field_count: usize,
+    /// Interfaces this type implements
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub implements: Vec<String>,
+    /// Whether this type comes from an extension
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_extension: bool,
+}
+
+/// Schema-level statistics
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaStatsInfo {
+    pub objects: usize,
+    pub interfaces: usize,
+    pub unions: usize,
+    pub enums: usize,
+    pub scalars: usize,
+    pub input_objects: usize,
+    pub total_fields: usize,
+    pub directives: usize,
+}
+
+/// Parameters for get_type_info tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TypeInfoParams {
+    /// The name of the type to look up
+    #[schemars(
+        description = "The name of the GraphQL type (e.g. \"User\", \"Query\", \"Status\")"
+    )]
+    pub type_name: String,
+
+    /// Optional project name
+    #[schemars(
+        description = "Optional project name. If not provided, uses the first/only loaded project."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Result of get_type_info
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TypeInfoResult {
+    /// Type name
+    pub name: String,
+    /// Type kind
+    pub kind: String,
+    /// Type description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Interfaces this type implements
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub implements: Vec<String>,
+    /// Fields (for object, interface, input_object types)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<FieldInfo>,
+    /// Directives applied to this type
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub directives: Vec<DirectiveInfo>,
+    /// Enum values (for enum types)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<EnumValueInfo>,
+    /// Union members (for union types)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub union_members: Vec<String>,
+}
+
+/// A field in a type
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FieldInfo {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<ArgumentInfo>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_deprecated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecation_reason: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub directives: Vec<DirectiveInfo>,
+}
+
+/// An argument on a field
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ArgumentInfo {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<String>,
+}
+
+/// A directive applied to a schema element
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DirectiveInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<DirectiveArgumentInfo>,
+}
+
+/// An argument passed to a directive
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DirectiveArgumentInfo {
+    pub name: String,
+    pub value: String,
+}
+
+/// An enum value
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct EnumValueInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_deprecated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecation_reason: Option<String>,
+}
+
+/// Parameters for get_schema_sdl tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaSdlParams {
+    /// Optional project name
+    #[schemars(
+        description = "Optional project name. If not provided, uses the first/only loaded project."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Result of get_schema_sdl
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SchemaSdlResult {
+    /// The full merged schema as SDL text
+    pub sdl: String,
+    /// Number of types in the schema
+    pub type_count: usize,
+}
+
+// --- Document analysis types ---
+
+/// Parameters for get_operations tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OperationsParams {
+    /// Optional file path to filter operations from a single file
+    #[schemars(description = "Optional file path to limit results to a single file")]
+    #[serde(default)]
+    pub file_path: Option<String>,
+
+    /// Optional project name
+    #[schemars(
+        description = "Optional project name. If not provided, uses the first/only loaded project."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Result of get_operations
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OperationsResult {
+    /// List of operations
+    pub operations: Vec<OperationInfo>,
+    /// Total count
+    pub count: usize,
+}
+
+/// An operation extracted from a document
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OperationInfo {
+    /// Operation name (null for anonymous)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Operation type: query, mutation, subscription
+    pub operation_type: String,
+    /// File containing this operation
+    pub file: String,
+    /// Variables defined on this operation
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub variables: Vec<VariableInfo>,
+    /// Fragment names this operation depends on
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fragment_dependencies: Vec<String>,
+}
+
+/// A variable on an operation
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VariableInfo {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_value: Option<String>,
+}
+
+/// Parameters for get_query_complexity tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct QueryComplexityParams {
+    /// Optional operation name to filter (returns all if omitted)
+    #[schemars(
+        description = "Optional operation name. If omitted, returns complexity for all operations."
+    )]
+    #[serde(default)]
+    pub operation_name: Option<String>,
+
+    /// Optional project name
+    #[schemars(
+        description = "Optional project name. If not provided, uses the first/only loaded project."
+    )]
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Result of get_query_complexity
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct QueryComplexityResult {
+    /// Complexity analysis per operation
+    pub operations: Vec<ComplexityInfo>,
+    /// Number of operations analyzed
+    pub count: usize,
+}
+
+/// Complexity analysis for a single operation
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ComplexityInfo {
+    pub operation_name: String,
+    pub operation_type: String,
+    pub total_complexity: u32,
+    pub depth: u32,
+    pub breakdown: Vec<FieldComplexityInfo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    pub file: String,
+}
+
+/// Per-field complexity breakdown
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FieldComplexityInfo {
+    pub path: String,
+    pub complexity: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multiplier: Option<u32>,
+}
+
+// --- Utility types ---
+
+/// Parameters for introspect_endpoint tool
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IntrospectEndpointParams {
+    /// The GraphQL endpoint URL to introspect
+    #[schemars(description = "GraphQL endpoint URL (e.g. https://api.example.com/graphql)")]
+    pub url: String,
+
+    /// Optional HTTP headers (e.g. for authentication)
+    #[schemars(
+        description = "Optional HTTP headers as key-value pairs (e.g. {\"Authorization\": \"Bearer token\"})"
+    )]
+    #[serde(default)]
+    pub headers: Option<std::collections::HashMap<String, String>>,
+}
+
+/// Result of introspect_endpoint
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct IntrospectEndpointResult {
+    /// The schema SDL
+    pub sdl: String,
+    /// The URL that was introspected
+    pub url: String,
+}
+
 // Conversion implementations from graphql_ide types
 
 impl From<graphql_ide::Location> for LocationResult {

--- a/docs/superpowers/specs/2026-03-29-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-03-29-mcp-tools-design.md
@@ -16,10 +16,12 @@ Two tools from the original issue (`get_completions`, `goto_definition`) are alr
 List all types in the loaded schema with their kind and basic metadata.
 
 **Parameters:**
+
 - `project` (optional string): Project name. Defaults to first/only loaded project.
 - `kind` (optional string): Filter by type kind — `"object"`, `"interface"`, `"union"`, `"enum"`, `"scalar"`, `"input_object"`. If omitted, returns all types.
 
 **Returns:**
+
 ```json
 {
   "types": [
@@ -53,10 +55,12 @@ List all types in the loaded schema with their kind and basic metadata.
 Get full details about a specific named type including fields, arguments, interfaces, directives, enum values, and union members.
 
 **Parameters:**
+
 - `type_name` (string, required): The name of the type to look up.
 - `project` (optional string): Project name.
 
 **Returns (for an object type):**
+
 ```json
 {
   "name": "User",
@@ -77,9 +81,7 @@ Get full details about a specific named type including fields, arguments, interf
       "name": "posts",
       "type": "[Post!]!",
       "description": null,
-      "arguments": [
-        { "name": "first", "type": "Int", "description": null, "default_value": null }
-      ],
+      "arguments": [{ "name": "first", "type": "Int", "description": null, "default_value": null }],
       "is_deprecated": false,
       "deprecation_reason": null,
       "directives": []
@@ -100,9 +102,11 @@ For enums, `enum_values` is populated. For unions, `union_members` is populated.
 Return the full merged schema as SDL text. This reconstructs SDL from the resolved HIR types (with extensions merged), giving agents a single canonical view of the schema.
 
 **Parameters:**
+
 - `project` (optional string): Project name.
 
 **Returns:**
+
 ```json
 {
   "sdl": "type Query {\n  user(id: ID!): User\n  ...\n}\n\ntype User implements Node {\n  id: ID!\n  ...\n}\n...",
@@ -128,10 +132,12 @@ The SDL printer lives in `crates/mcp/src/sdl_printer.rs` since it's specific to 
 Extract all operations from the loaded project with their names, types, variables, and fragment dependencies.
 
 **Parameters:**
+
 - `project` (optional string): Project name.
 - `file_path` (optional string): If provided, only return operations from this file.
 
 **Returns:**
+
 ```json
 {
   "operations": [
@@ -139,9 +145,7 @@ Extract all operations from the loaded project with their names, types, variable
       "name": "GetUser",
       "operation_type": "query",
       "file": "/path/to/queries.graphql",
-      "variables": [
-        { "name": "id", "type": "ID!", "default_value": null }
-      ],
+      "variables": [{ "name": "id", "type": "ID!", "default_value": null }],
       "fragment_dependencies": ["UserFields", "AddressFields"]
     }
   ],
@@ -156,10 +160,12 @@ Extract all operations from the loaded project with their names, types, variable
 Calculate complexity scores for operations in the project.
 
 **Parameters:**
+
 - `project` (optional string): Project name.
 - `operation_name` (optional string): If provided, only return complexity for this operation. Otherwise returns all.
 
 **Returns:**
+
 ```json
 {
   "operations": [
@@ -187,10 +193,12 @@ Calculate complexity scores for operations in the project.
 Fetch a schema from a remote GraphQL endpoint via introspection and return the SDL.
 
 **Parameters:**
+
 - `url` (string, required): The GraphQL endpoint URL.
 - `headers` (optional object): Additional HTTP headers (e.g., `{"Authorization": "Bearer token"}`).
 
 **Returns:**
+
 ```json
 {
   "sdl": "type Query { ... }",
@@ -203,9 +211,11 @@ Fetch a schema from a remote GraphQL endpoint via introspection and return the S
 ## Architecture
 
 ### New Files
+
 - `crates/mcp/src/sdl_printer.rs` — SDL reconstruction from HIR TypeDefMap
 
 ### Modified Files
+
 - `crates/mcp/src/types.rs` — New param/result types for all 6 tools
 - `crates/mcp/src/tools.rs` — 6 new `#[tool]` methods on `GraphQLToolRouter`
 - `crates/mcp/src/service.rs` — 6 new service methods
@@ -237,6 +247,7 @@ MCP Tool handler (#[tool] method)
 The SDL printer is a standalone function: `fn print_schema_sdl(types: &TypeDefMap) -> String`
 
 It iterates the TypeDefMap (sorted), and for each type emits:
+
 - Description (triple-quoted block string if multiline, inline `"..."` if single line)
 - Type keyword + name + implements clause (if any)
 - Fields with arguments, types, descriptions, directives, deprecation
@@ -245,6 +256,7 @@ It iterates the TypeDefMap (sorted), and for each type emits:
 - Directives on types
 
 It does NOT print:
+
 - Directive definitions (could be added later)
 - Schema definition block (the root types are implicit from `Query`/`Mutation`/`Subscription` type names)
 - Built-in scalars (`String`, `Int`, `Float`, `Boolean`, `ID`)

--- a/docs/superpowers/specs/2026-03-29-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-03-29-mcp-tools-design.md
@@ -1,0 +1,271 @@
+# MCP Tools: Schema Exploration, Document Analysis, and Utilities
+
+**Issue**: [#444](https://github.com/trevor-scheer/graphql-analyzer/pull/444)
+**Date**: 2026-03-29
+
+## Overview
+
+Add 6 new MCP tools to make the server more useful for AI agents working with GraphQL projects. These tools fall into three categories: schema exploration (understanding what's in the schema), document analysis (understanding operations), and utilities (introspecting remote endpoints).
+
+Two tools from the original issue (`get_completions`, `goto_definition`) are already implemented. One (`format_document`) is deferred to a separate issue as it requires building a full formatter.
+
+## Tools
+
+### 1. `get_schema_types`
+
+List all types in the loaded schema with their kind and basic metadata.
+
+**Parameters:**
+- `project` (optional string): Project name. Defaults to first/only loaded project.
+- `kind` (optional string): Filter by type kind — `"object"`, `"interface"`, `"union"`, `"enum"`, `"scalar"`, `"input_object"`. If omitted, returns all types.
+
+**Returns:**
+```json
+{
+  "types": [
+    {
+      "name": "User",
+      "kind": "object",
+      "description": "A user account",
+      "field_count": 5,
+      "implements": ["Node"],
+      "is_extension": false
+    }
+  ],
+  "count": 42,
+  "stats": {
+    "objects": 20,
+    "interfaces": 3,
+    "unions": 2,
+    "enums": 8,
+    "scalars": 5,
+    "input_objects": 4,
+    "total_fields": 150,
+    "directives": 3
+  }
+}
+```
+
+**Implementation:** New `Analysis::schema_type_list()` method that iterates `schema_types()` from HIR and returns a lightweight summary. The `stats` field reuses the existing `schema_stats()` method.
+
+### 2. `get_type_info`
+
+Get full details about a specific named type including fields, arguments, interfaces, directives, enum values, and union members.
+
+**Parameters:**
+- `type_name` (string, required): The name of the type to look up.
+- `project` (optional string): Project name.
+
+**Returns (for an object type):**
+```json
+{
+  "name": "User",
+  "kind": "object",
+  "description": "A user account",
+  "implements": ["Node"],
+  "fields": [
+    {
+      "name": "id",
+      "type": "ID!",
+      "description": "Unique identifier",
+      "arguments": [],
+      "is_deprecated": false,
+      "deprecation_reason": null,
+      "directives": []
+    },
+    {
+      "name": "posts",
+      "type": "[Post!]!",
+      "description": null,
+      "arguments": [
+        { "name": "first", "type": "Int", "description": null, "default_value": null }
+      ],
+      "is_deprecated": false,
+      "deprecation_reason": null,
+      "directives": []
+    }
+  ],
+  "directives": [{ "name": "key", "arguments": [{ "name": "fields", "value": "\"id\"" }] }],
+  "enum_values": [],
+  "union_members": []
+}
+```
+
+For enums, `enum_values` is populated. For unions, `union_members` is populated. For interfaces, `fields` and `implements` (extended by) could both be present.
+
+**Implementation:** New `Analysis::type_info()` method that looks up a single type in `schema_types()` and converts the HIR `TypeDef` to an MCP-friendly representation. Uses `format_type_ref()` from `ide/src/helpers.rs` to render `TypeRef` as strings like `"[Post!]!"`.
+
+### 3. `get_schema_sdl`
+
+Return the full merged schema as SDL text. This reconstructs SDL from the resolved HIR types (with extensions merged), giving agents a single canonical view of the schema.
+
+**Parameters:**
+- `project` (optional string): Project name.
+
+**Returns:**
+```json
+{
+  "sdl": "type Query {\n  user(id: ID!): User\n  ...\n}\n\ntype User implements Node {\n  id: ID!\n  ...\n}\n...",
+  "type_count": 42
+}
+```
+
+**Implementation:** New `sdl_printer` module in the `mcp` crate (or `ide` crate if reuse is likely). Walks the `TypeDefMap` from `schema_types()` and emits each type definition as valid SDL:
+
+- Scalars: `scalar DateTime`
+- Enums: `enum Status { ACTIVE INACTIVE }` (with descriptions and deprecation)
+- Input objects: `input CreateUserInput { name: String! }`
+- Objects/Interfaces: type with fields, arguments, implements clauses
+- Unions: `union SearchResult = User | Post`
+- Includes descriptions as `"""..."""` block strings
+- Includes directives on types and fields
+- Sorted alphabetically by type name, with `Query`/`Mutation`/`Subscription` first
+
+The SDL printer lives in `crates/mcp/src/sdl_printer.rs` since it's specific to the MCP use case (providing context to agents). If the LSP or CLI later needs it, it can be moved to `ide`.
+
+### 4. `get_operations`
+
+Extract all operations from the loaded project with their names, types, variables, and fragment dependencies.
+
+**Parameters:**
+- `project` (optional string): Project name.
+- `file_path` (optional string): If provided, only return operations from this file.
+
+**Returns:**
+```json
+{
+  "operations": [
+    {
+      "name": "GetUser",
+      "operation_type": "query",
+      "file": "/path/to/queries.graphql",
+      "variables": [
+        { "name": "id", "type": "ID!", "default_value": null }
+      ],
+      "fragment_dependencies": ["UserFields", "AddressFields"]
+    }
+  ],
+  "count": 15
+}
+```
+
+**Implementation:** New `Analysis::operations_summary()` method. Uses `all_operations()` for the operation list and `operation_body()` + fragment spread walking for dependency extraction. The fragment dependency extraction walks the operation body's selection sets to find `FragmentSpread` nodes, then transitively resolves their dependencies via `all_fragments()`.
+
+### 5. `get_query_complexity`
+
+Calculate complexity scores for operations in the project.
+
+**Parameters:**
+- `project` (optional string): Project name.
+- `operation_name` (optional string): If provided, only return complexity for this operation. Otherwise returns all.
+
+**Returns:**
+```json
+{
+  "operations": [
+    {
+      "operation_name": "GetUser",
+      "operation_type": "query",
+      "total_complexity": 15,
+      "depth": 4,
+      "breakdown": [
+        { "path": "user", "complexity": 1, "multiplier": null },
+        { "path": "user.posts", "complexity": 10, "multiplier": 10 }
+      ],
+      "warnings": ["Nested pagination detected: user.posts.comments"],
+      "file": "/path/to/queries.graphql"
+    }
+  ],
+  "count": 1
+}
+```
+
+**Implementation:** Wraps the existing `Analysis::complexity_analysis()` method. The IDE type `ComplexityAnalysis` already has all the fields needed. Add MCP wrapper types and convert.
+
+### 6. `introspect_endpoint`
+
+Fetch a schema from a remote GraphQL endpoint via introspection and return the SDL.
+
+**Parameters:**
+- `url` (string, required): The GraphQL endpoint URL.
+- `headers` (optional object): Additional HTTP headers (e.g., `{"Authorization": "Bearer token"}`).
+
+**Returns:**
+```json
+{
+  "sdl": "type Query { ... }",
+  "url": "https://api.example.com/graphql"
+}
+```
+
+**Implementation:** Wraps `graphql_introspect::introspect_url_to_sdl()`. This is the only async tool in this batch. The existing introspect crate handles the HTTP request and SDL conversion. We need to add header support — the current `execute_introspection()` function doesn't accept custom headers. Add an optional `headers` parameter to the introspection function.
+
+## Architecture
+
+### New Files
+- `crates/mcp/src/sdl_printer.rs` — SDL reconstruction from HIR TypeDefMap
+
+### Modified Files
+- `crates/mcp/src/types.rs` — New param/result types for all 6 tools
+- `crates/mcp/src/tools.rs` — 6 new `#[tool]` methods on `GraphQLToolRouter`
+- `crates/mcp/src/service.rs` — 6 new service methods
+- `crates/ide/src/analysis.rs` — New methods: `schema_type_list()`, `type_info()`, `operations_summary()`
+- `crates/introspect/src/lib.rs` — Add header support to `execute_introspection()` / `introspect_url_to_sdl()`
+
+### New IDE Analysis Methods
+
+Three new methods on `Analysis`:
+
+1. **`schema_type_list(kind_filter: Option<&str>) -> Vec<SchemaTypeEntry>`** — Lightweight type listing from `schema_types()`. Returns name, kind, description, field count, implements list.
+
+2. **`type_info(type_name: &str) -> Option<TypeInfo>`** — Full type details from `schema_types()` lookup. Converts HIR `TypeDef` fields/args/directives to IDE POD types.
+
+3. **`operations_summary(file_filter: Option<&FilePath>) -> Vec<OperationSummary>`** — Operation extraction with fragment dependency resolution. Uses `all_operations()` for the list and `operation_body()` selection set walking for fragment deps.
+
+### Data Flow
+
+```
+MCP Tool handler (#[tool] method)
+  → McpService method (project resolution, file path normalization)
+    → Analysis method (query over Salsa DB)
+      → HIR queries (schema_types, all_operations, operation_body)
+        → Salsa cache (memoized, incremental)
+```
+
+### SDL Printer Design
+
+The SDL printer is a standalone function: `fn print_schema_sdl(types: &TypeDefMap) -> String`
+
+It iterates the TypeDefMap (sorted), and for each type emits:
+- Description (triple-quoted block string if multiline, inline `"..."` if single line)
+- Type keyword + name + implements clause (if any)
+- Fields with arguments, types, descriptions, directives, deprecation
+- Enum values with descriptions and deprecation
+- Union members
+- Directives on types
+
+It does NOT print:
+- Directive definitions (could be added later)
+- Schema definition block (the root types are implicit from `Query`/`Mutation`/`Subscription` type names)
+- Built-in scalars (`String`, `Int`, `Float`, `Boolean`, `ID`)
+
+## Testing
+
+Each tool gets integration tests following the existing pattern in `crates/mcp/`:
+
+1. **`get_schema_types`** — Load a test schema, verify type listing with kind filter
+2. **`get_type_info`** — Verify field details, arguments, enum values, union members, directives for different type kinds
+3. **`get_schema_sdl`** — Verify output is valid SDL that round-trips (parse the output and compare type counts)
+4. **`get_operations`** — Load documents with operations and fragments, verify extraction and dependency resolution
+5. **`get_query_complexity`** — Verify complexity scores match expected values for known queries
+6. **`introspect_endpoint`** — Unit test the SDL conversion; skip live HTTP in CI (or mock with a test server)
+
+The SDL printer gets its own unit tests with snapshot-style assertions for various type kinds.
+
+## Out of Scope
+
+- `format_document` — Requires building a full GraphQL formatter (separate issue)
+- `get_completions` — Already implemented
+- `goto_definition` — Already implemented
+- Directive definition listing in `get_schema_types` — Could be added later
+- Schema definition block in SDL output — Root types are implicit


### PR DESCRIPTION
## Summary

Adds 6 new MCP tools to make the server more useful for AI agents working with GraphQL projects. Closes #444.

## Changes

- **`get_schema_types`**: List all types with kind, description, field count, and implements interfaces. Supports filtering by type kind.
- **`get_type_info`**: Full type details including fields, arguments, directives, enum values, and union members.
- **`get_schema_sdl`**: Reconstructs merged schema SDL from resolved HIR types (extensions merged into base types).
- **`get_operations`**: Extracts operations with names, types, variables, and fragment dependencies.
- **`get_query_complexity`**: Complexity scoring with depth, per-field breakdown, and warnings.
- **`introspect_endpoint`**: Fetches schema from remote GraphQL URL with custom header support.
- New `sdl_printer` module in MCP crate for SDL reconstruction from `TypeDefMap`
- New `Analysis` methods: `schema_type_list()`, `type_info()`, `operations_summary()`, `with_schema_types()`
- New IDE types: `SchemaTypeEntry`, `TypeInfo`, `TypeFieldInfo`, `OperationSummary`, etc.

## Consulted SME Agents

- N/A — leveraged existing IDE APIs and established MCP tool patterns

## Manual Testing Plan

- Run `graphql-mcp` against a project with `.graphqlrc.yaml` and invoke each new tool via an MCP client
- Verify `get_schema_sdl` output is valid GraphQL SDL (parseable)
- Verify `get_type_info` returns complete field/argument/directive details
- Verify `get_operations` includes fragment dependencies from spreads

## Related Issues

Closes #444