### PR TITLE
Add GraphQL snippets to VS Code extension

### DIFF
--- a/.changeset/vscode-snippets.md
+++ b/.changeset/vscode-snippets.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: minor
+---
+
+Add GraphQL snippets to VS Code extension ([#926](https://github.com/trevor-scheer/graphql-analyzer/pull/926))

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -217,6 +217,12 @@
         "url": "./schema/graphqlrc.schema.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "graphql",
+        "path": "./snippets/graphql.json"
+      }
+    ],
     "keybindings": [
       {
         "command": "graphql-analyzer.restartServer",

--- a/editors/vscode/snippets/graphql.json
+++ b/editors/vscode/snippets/graphql.json
@@ -1,0 +1,116 @@
+{
+  "Query Operation": {
+    "prefix": "query",
+    "body": [
+      "query ${1:OperationName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Query operation"
+  },
+  "Query with Variables": {
+    "prefix": "queryv",
+    "body": [
+      "query ${1:OperationName}($$${2:var}: ${3:Type}) {",
+      "  $0",
+      "}"
+    ],
+    "description": "Query operation with variables"
+  },
+  "Mutation Operation": {
+    "prefix": "mutation",
+    "body": [
+      "mutation ${1:OperationName}($$${2:input}: ${3:InputType}!) {",
+      "  $0",
+      "}"
+    ],
+    "description": "Mutation operation"
+  },
+  "Subscription Operation": {
+    "prefix": "subscription",
+    "body": [
+      "subscription ${1:OperationName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Subscription operation"
+  },
+  "Fragment Definition": {
+    "prefix": "fragment",
+    "body": [
+      "fragment ${1:FragmentName} on ${2:TypeName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Fragment definition"
+  },
+  "Type Definition": {
+    "prefix": "type",
+    "body": [
+      "type ${1:TypeName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Object type definition"
+  },
+  "Input Type": {
+    "prefix": "input",
+    "body": [
+      "input ${1:InputName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Input type definition"
+  },
+  "Enum Definition": {
+    "prefix": "enum",
+    "body": [
+      "enum ${1:EnumName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Enum type definition"
+  },
+  "Interface Definition": {
+    "prefix": "interface",
+    "body": [
+      "interface ${1:InterfaceName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Interface type definition"
+  },
+  "Union Definition": {
+    "prefix": "union",
+    "body": [
+      "union ${1:UnionName} = ${1:Type1} | ${2:Type2}",
+      "$0"
+    ],
+    "description": "Union type definition"
+  },
+  "Scalar Definition": {
+    "prefix": "scalar",
+    "body": [
+      "scalar ${1:ScalarName}",
+      "$0"
+    ],
+    "description": "Custom scalar definition"
+  },
+  "Directive Definition": {
+    "prefix": "directive",
+    "body": [
+      "directive @${1:directiveName}(${2:arg}: ${3:Type}) on ${4|FIELD,OBJECT,INTERFACE,UNION,ENUM,INPUT_OBJECT,SCALAR,FIELD_DEFINITION,ARGUMENT_DEFINITION,ENUM_VALUE,INPUT_FIELD_DEFINITION,SCHEMA|}",
+      "$0"
+    ],
+    "description": "Directive definition"
+  },
+  "Extend Type": {
+    "prefix": "extend",
+    "body": [
+      "extend type ${1:TypeName} {",
+      "  $0",
+      "}"
+    ],
+    "description": "Type extension"
+  }
+}

--- a/editors/vscode/snippets/graphql.json
+++ b/editors/vscode/snippets/graphql.json
@@ -1,99 +1,57 @@
 {
   "Query Operation": {
     "prefix": "query",
-    "body": [
-      "query ${1:OperationName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["query ${1:OperationName} {", "  $0", "}"],
     "description": "Query operation"
   },
   "Query with Variables": {
     "prefix": "queryv",
-    "body": [
-      "query ${1:OperationName}($$${2:var}: ${3:Type}) {",
-      "  $0",
-      "}"
-    ],
+    "body": ["query ${1:OperationName}($$${2:var}: ${3:Type}) {", "  $0", "}"],
     "description": "Query operation with variables"
   },
   "Mutation Operation": {
     "prefix": "mutation",
-    "body": [
-      "mutation ${1:OperationName}($$${2:input}: ${3:InputType}!) {",
-      "  $0",
-      "}"
-    ],
+    "body": ["mutation ${1:OperationName}($$${2:input}: ${3:InputType}!) {", "  $0", "}"],
     "description": "Mutation operation"
   },
   "Subscription Operation": {
     "prefix": "subscription",
-    "body": [
-      "subscription ${1:OperationName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["subscription ${1:OperationName} {", "  $0", "}"],
     "description": "Subscription operation"
   },
   "Fragment Definition": {
     "prefix": "fragment",
-    "body": [
-      "fragment ${1:FragmentName} on ${2:TypeName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["fragment ${1:FragmentName} on ${2:TypeName} {", "  $0", "}"],
     "description": "Fragment definition"
   },
   "Type Definition": {
     "prefix": "type",
-    "body": [
-      "type ${1:TypeName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["type ${1:TypeName} {", "  $0", "}"],
     "description": "Object type definition"
   },
   "Input Type": {
     "prefix": "input",
-    "body": [
-      "input ${1:InputName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["input ${1:InputName} {", "  $0", "}"],
     "description": "Input type definition"
   },
   "Enum Definition": {
     "prefix": "enum",
-    "body": [
-      "enum ${1:EnumName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["enum ${1:EnumName} {", "  $0", "}"],
     "description": "Enum type definition"
   },
   "Interface Definition": {
     "prefix": "interface",
-    "body": [
-      "interface ${1:InterfaceName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["interface ${1:InterfaceName} {", "  $0", "}"],
     "description": "Interface type definition"
   },
   "Union Definition": {
     "prefix": "union",
-    "body": [
-      "union ${1:UnionName} = ${1:Type1} | ${2:Type2}",
-      "$0"
-    ],
+    "body": ["union ${1:UnionName} = ${1:Type1} | ${2:Type2}", "$0"],
     "description": "Union type definition"
   },
   "Scalar Definition": {
     "prefix": "scalar",
-    "body": [
-      "scalar ${1:ScalarName}",
-      "$0"
-    ],
+    "body": ["scalar ${1:ScalarName}", "$0"],
     "description": "Custom scalar definition"
   },
   "Directive Definition": {
@@ -106,11 +64,7 @@
   },
   "Extend Type": {
     "prefix": "extend",
-    "body": [
-      "extend type ${1:TypeName} {",
-      "  $0",
-      "}"
-    ],
+    "body": ["extend type ${1:TypeName} {", "  $0", "}"],
     "description": "Type extension"
   }
 }


### PR DESCRIPTION
## Summary

Adds 13 GraphQL code snippets to the VS Code extension for faster authoring of common GraphQL patterns.

### Snippets included
**Operations:** `query`, `queryv` (with variables), `mutation`, `subscription`, `fragment`
**Schema:** `type`, `input`, `enum`, `interface`, `union`, `scalar`, `directive`, `extend`

### Changes
- New `editors/vscode/snippets/graphql.json` with all snippet definitions
- Updated `editors/vscode/package.json` to register snippets under `contributes.snippets`

Closes #889