### PR TITLE
Add help text, related locations, and documentation URLs to diagnostics

### DIFF
--- a/.changeset/diagnostic-enrichment.md
+++ b/.changeset/diagnostic-enrichment.md
@@ -1,0 +1,7 @@
+---
+graphql-analyzer-cli: minor
+graphql-analyzer-lsp: minor
+graphql-analyzer-vscode: minor
+---
+
+Add help text, related locations, and documentation URLs to diagnostics ([#934](https://github.com/trevor-scheer/graphql-analyzer/pull/934))

--- a/crates/analysis/src/diagnostics.rs
+++ b/crates/analysis/src/diagnostics.rs
@@ -2,6 +2,15 @@
 
 use std::sync::Arc;
 
+/// A tag attached to a diagnostic providing additional classification
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    /// The diagnostic marks code as unnecessary (e.g., unused fragments)
+    Unnecessary,
+    /// The diagnostic marks code as deprecated
+    Deprecated,
+}
+
 /// A diagnostic message (error, warning, or info)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
@@ -15,6 +24,12 @@ pub struct Diagnostic {
     pub source: Arc<str>,
     /// Optional diagnostic code
     pub code: Option<Arc<str>>,
+    /// Optional help text explaining how to resolve the issue
+    pub help: Option<Arc<str>>,
+    /// Optional documentation URL for the rule
+    pub url: Option<Arc<str>>,
+    /// Diagnostic tags for additional classification
+    pub tags: Vec<DiagnosticTag>,
 }
 
 impl Diagnostic {
@@ -27,6 +42,9 @@ impl Diagnostic {
             range,
             source: "graphql-analysis".into(),
             code: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -39,6 +57,9 @@ impl Diagnostic {
             range,
             source: "graphql-analysis".into(),
             code: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -51,6 +72,9 @@ impl Diagnostic {
             range,
             source: "graphql-analysis".into(),
             code: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -69,6 +93,9 @@ impl Diagnostic {
             range,
             source: source.into(),
             code: Some(code.into()),
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 }

--- a/crates/analysis/src/lib.rs
+++ b/crates/analysis/src/lib.rs
@@ -78,6 +78,9 @@ fn syntax_diagnostics(
             },
             source: "graphql-parser".into(),
             code: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         });
     }
 
@@ -121,6 +124,9 @@ fn file_validation_diagnostics_impl(
             },
             source: "graphql-parser".into(),
             code: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         });
     }
 

--- a/crates/analysis/src/lint_integration.rs
+++ b/crates/analysis/src/lint_integration.rs
@@ -688,7 +688,7 @@ fn convert_lint_diagnostics(
                 source: "graphql-linter".into(),
                 code: Some(rule_name.to_string().into()),
                 help: ld.help.map(Into::into),
-                url: ld.url.map(Into::into),
+                url: Some(resolve_rule_url(ld.url, rule_name).into()),
                 tags: ld
                     .tags
                     .into_iter()
@@ -704,4 +704,32 @@ fn convert_lint_diagnostics(
             })
         })
         .collect()
+}
+
+/// Pick a documentation URL for a lint diagnostic, falling back to the
+/// canonical per-rule URL when the rule didn't set one explicitly.
+fn resolve_rule_url(explicit: Option<String>, rule_name: &str) -> String {
+    explicit.unwrap_or_else(|| graphql_linter::rule_doc_url(rule_name))
+}
+
+#[cfg(test)]
+mod url_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn falls_back_to_canonical_url_when_not_set() {
+        assert_eq!(
+            resolve_rule_url(None, "unusedFields"),
+            "https://graphql-analyzer.dev/rules/unusedFields"
+        );
+    }
+
+    #[test]
+    fn respects_rule_provided_url() {
+        let custom = "https://docs.example.com/custom-rule".to_string();
+        assert_eq!(
+            resolve_rule_url(Some(custom.clone()), "unusedFields"),
+            custom
+        );
+    }
 }

--- a/crates/analysis/src/lint_integration.rs
+++ b/crates/analysis/src/lint_integration.rs
@@ -720,7 +720,7 @@ mod url_resolution_tests {
     fn falls_back_to_canonical_url_when_not_set() {
         assert_eq!(
             resolve_rule_url(None, "unusedFields"),
-            "https://graphql-analyzer.dev/rules/unusedFields"
+            "https://trevor-scheer.github.io/graphql-analyzer/rules/unused-fields/"
         );
     }
 

--- a/crates/analysis/src/lint_integration.rs
+++ b/crates/analysis/src/lint_integration.rs
@@ -535,6 +535,9 @@ fn unused_ignore_diagnostics(
                     },
                     source: "graphql-linter".into(),
                     code: Some("unused_ignore".into()),
+                    help: None,
+                    url: None,
+                    tags: vec![crate::DiagnosticTag::Unnecessary],
                 }]
             }
             graphql_linter::ignore::UnusedIgnore::UnusedRules { rules, .. } => rules
@@ -561,6 +564,9 @@ fn unused_ignore_diagnostics(
                         },
                         source: "graphql-linter".into(),
                         code: Some("unused_ignore".into()),
+                        help: None,
+                        url: None,
+                        tags: vec![crate::DiagnosticTag::Unnecessary],
                     }
                 })
                 .collect(),
@@ -681,6 +687,20 @@ fn convert_lint_diagnostics(
                 },
                 source: "graphql-linter".into(),
                 code: Some(rule_name.to_string().into()),
+                help: ld.help.map(Into::into),
+                url: ld.url.map(Into::into),
+                tags: ld
+                    .tags
+                    .into_iter()
+                    .map(|t| match t {
+                        graphql_linter::DiagnosticTag::Unnecessary => {
+                            crate::DiagnosticTag::Unnecessary
+                        }
+                        graphql_linter::DiagnosticTag::Deprecated => {
+                            crate::DiagnosticTag::Deprecated
+                        }
+                    })
+                    .collect(),
             })
         })
         .collect()

--- a/crates/analysis/src/merged_schema.rs
+++ b/crates/analysis/src/merged_schema.rs
@@ -63,6 +63,9 @@ fn collect_apollo_diagnostics(errors: &DiagnosticList) -> HashMap<Arc<str>, Vec<
                 range,
                 source: "apollo-compiler".into(),
                 code: None,
+                help: None,
+                url: None,
+                tags: Vec::new(),
             });
     }
 
@@ -282,6 +285,9 @@ mod tests {
                 range: DiagnosticRange::default(),
                 source: "test".into(),
                 code: None,
+                help: None,
+                url: None,
+                tags: Vec::new(),
             }],
         );
 

--- a/crates/analysis/src/validation.rs
+++ b/crates/analysis/src/validation.rs
@@ -160,6 +160,9 @@ pub fn validate_file(
                         range,
                         source: "apollo-compiler".into(),
                         code: None,
+                        help: None,
+                        url: None,
+                        tags: Vec::new(),
                     });
                 }
             }

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -13,7 +13,7 @@ use crate::watch::{FileWatcher, WatchConfig, WatchMode};
 use crate::{ExitCode, OutputFormat, OutputOptions};
 use anyhow::Result;
 use colored::Colorize;
-use graphql_ide::{Diagnostic, DiagnosticSeverity};
+use graphql_ide::{Diagnostic, DiagnosticSeverity, DiagnosticTag};
 use std::path::PathBuf;
 
 /// Diagnostic output structure for unified display
@@ -28,6 +28,15 @@ struct DiagnosticOutput {
     source: DiagnosticSource,
     rule: Option<String>,
     help: Option<String>,
+    url: Option<String>,
+    tags: Vec<DiagnosticTag>,
+}
+
+fn tag_name(tag: &DiagnosticTag) -> &'static str {
+    match tag {
+        DiagnosticTag::Unnecessary => "unnecessary",
+        DiagnosticTag::Deprecated => "deprecated",
+    }
 }
 
 /// Source of the diagnostic (validation or lint)
@@ -151,6 +160,8 @@ pub fn run(
                     source: DiagnosticSource::Validation,
                     rule: diag.code.clone(),
                     help: diag.help.clone(),
+                    url: diag.url.clone(),
+                    tags: diag.tags.clone(),
                 });
                 original_diagnostics
                     .entry(file_path.clone())
@@ -187,6 +198,8 @@ pub fn run(
                 source: DiagnosticSource::Lint,
                 rule: diag.code.clone(),
                 help: diag.help.clone(),
+                url: diag.url.clone(),
+                tags: diag.tags.clone(),
             });
             original_diagnostics
                 .entry(file_path.clone())
@@ -274,6 +287,9 @@ pub fn run(
                 if let Some(ref help) = issue.help {
                     println!("  {}: {}", "help".cyan(), help);
                 }
+                if let Some(ref url) = issue.url {
+                    println!("  {}: {}", "docs".dimmed(), url.dimmed());
+                }
             }
         }
         OutputFormat::Json => {
@@ -283,7 +299,10 @@ pub fn run(
                     "message": issue.message,
                     "severity": issue.severity,
                     "source": issue.source.to_string(),
-                    "rule": issue.rule
+                    "rule": issue.rule,
+                    "help": issue.help,
+                    "url": issue.url,
+                    "tags": issue.tags.iter().map(tag_name).collect::<Vec<_>>(),
                 });
                 if issue.line > 0 {
                     obj["location"] = serde_json::json!({

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -27,6 +27,7 @@ struct DiagnosticOutput {
     severity: String,
     source: DiagnosticSource,
     rule: Option<String>,
+    help: Option<String>,
 }
 
 /// Source of the diagnostic (validation or lint)
@@ -149,6 +150,7 @@ pub fn run(
                     severity: "error".to_string(),
                     source: DiagnosticSource::Validation,
                     rule: diag.code.clone(),
+                    help: diag.help.clone(),
                 });
                 original_diagnostics
                     .entry(file_path.clone())
@@ -184,6 +186,7 @@ pub fn run(
                 severity: severity_string,
                 source: DiagnosticSource::Lint,
                 rule: diag.code.clone(),
+                help: diag.help.clone(),
             });
             original_diagnostics
                 .entry(file_path.clone())
@@ -267,6 +270,9 @@ pub fn run(
 
                 if let Some(ref rule) = issue.rule {
                     println!("  {}: {}", "rule".dimmed(), rule.dimmed());
+                }
+                if let Some(ref help) = issue.help {
+                    println!("  {}: {}", "help".cyan(), help);
                 }
             }
         }

--- a/crates/cli/src/commands/lint.rs
+++ b/crates/cli/src/commands/lint.rs
@@ -225,6 +225,9 @@ pub fn run(
                     if let Some(ref rule) = diag.code {
                         println!("  {}: {}", "rule".dimmed(), rule.dimmed());
                     }
+                    if let Some(ref help) = diag.help {
+                        println!("  {}: {}", "help".cyan(), help);
+                    }
                 }
             }
         }

--- a/crates/cli/src/commands/lint.rs
+++ b/crates/cli/src/commands/lint.rs
@@ -6,7 +6,7 @@ use crate::watch::{FileWatcher, WatchConfig, WatchMode};
 use crate::{ExitCode, OutputFormat, OutputOptions};
 use anyhow::Result;
 use colored::Colorize;
-use graphql_ide::DiagnosticSeverity;
+use graphql_ide::{DiagnosticSeverity, DiagnosticTag};
 use std::path::PathBuf;
 
 /// Diagnostic output structure for collecting warnings and errors
@@ -19,6 +19,16 @@ struct DiagnosticOutput {
     message: String,
     severity: String,
     rule: Option<String>,
+    help: Option<String>,
+    url: Option<String>,
+    tags: Vec<DiagnosticTag>,
+}
+
+fn tag_name(tag: &DiagnosticTag) -> &'static str {
+    match tag {
+        DiagnosticTag::Unnecessary => "unnecessary",
+        DiagnosticTag::Deprecated => "deprecated",
+    }
 }
 
 /// File-level diagnostic grouping for JSON output
@@ -166,6 +176,9 @@ pub fn run(
                 message: diag.message.clone(),
                 severity: severity_string,
                 rule: diag.code.clone(),
+                help: diag.help.clone(),
+                url: diag.url.clone(),
+                tags: diag.tags.clone(),
             };
 
             let file_diags = files_with_diagnostics
@@ -228,6 +241,9 @@ pub fn run(
                     if let Some(ref help) = diag.help {
                         println!("  {}: {}", "help".cyan(), help);
                     }
+                    if let Some(ref url) = diag.url {
+                        println!("  {}: {}", "docs".dimmed(), url.dimmed());
+                    }
                 }
             }
         }
@@ -238,6 +254,9 @@ pub fn run(
                     "message": d.message,
                     "severity": d.severity,
                     "rule": d.rule,
+                    "help": d.help,
+                    "url": d.url,
+                    "tags": d.tags.iter().map(tag_name).collect::<Vec<_>>(),
                     "location": {
                         "start": { "line": d.line, "column": d.column },
                         "end": { "line": d.end_line, "column": d.end_column }

--- a/crates/ide/src/helpers.rs
+++ b/crates/ide/src/helpers.rs
@@ -86,6 +86,21 @@ pub fn convert_diagnostic(diag: &graphql_analysis::Diagnostic) -> crate::types::
         code: diag.code.as_ref().map(ToString::to_string),
         source: diag.source.to_string(),
         fix: None, // Fixes are handled separately via lint_diagnostics_with_fixes
+        help: diag.help.as_ref().map(ToString::to_string),
+        url: diag.url.as_ref().map(ToString::to_string),
+        tags: diag
+            .tags
+            .iter()
+            .map(|t| match t {
+                graphql_analysis::DiagnosticTag::Unnecessary => {
+                    crate::types::DiagnosticTag::Unnecessary
+                }
+                graphql_analysis::DiagnosticTag::Deprecated => {
+                    crate::types::DiagnosticTag::Deprecated
+                }
+            })
+            .collect(),
+        related: Vec::new(),
     }
 }
 

--- a/crates/ide/src/helpers.rs
+++ b/crates/ide/src/helpers.rs
@@ -100,7 +100,6 @@ pub fn convert_diagnostic(diag: &graphql_analysis::Diagnostic) -> crate::types::
                 }
             })
             .collect(),
-        related: Vec::new(),
     }
 }
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -68,15 +68,15 @@ mod symbols;
 // Re-export types from the types module
 pub use types::{
     CodeFix, CodeLens, CodeLensCommand, CodeLensInfo, CompletionItem, CompletionKind,
-    ComplexityAnalysis, Diagnostic, DiagnosticSeverity, DocumentLoadResult, DocumentSymbol,
-    FieldComplexity, FieldCoverageReport, FieldUsageInfo, FilePath, FoldingRange, FoldingRangeKind,
-    FragmentReference, FragmentUsage, HoverResult, InlayHint, InlayHintKind, InsertTextFormat,
-    Location, OperationSummary, OperationVariableInfo, ParameterInformation, PendingIntrospection,
-    Position, ProjectStatus, Range, RenameResult, SchemaContentError, SchemaLoadResult,
-    SchemaStats, SchemaTypeEntry, SelectionRange, SemanticToken, SemanticTokenModifiers,
-    SemanticTokenType, SignatureHelp, SignatureInformation, SymbolKind, TextEdit, TypeArgumentInfo,
-    TypeCoverageInfo, TypeDirectiveArgumentInfo, TypeDirectiveInfo, TypeEnumValueInfo,
-    TypeFieldInfo, TypeInfo, WorkspaceSymbol,
+    ComplexityAnalysis, Diagnostic, DiagnosticSeverity, DiagnosticTag, DocumentLoadResult,
+    DocumentSymbol, FieldComplexity, FieldCoverageReport, FieldUsageInfo, FilePath, FoldingRange,
+    FoldingRangeKind, FragmentReference, FragmentUsage, HoverResult, InlayHint, InlayHintKind,
+    InsertTextFormat, Location, OperationSummary, OperationVariableInfo, ParameterInformation,
+    PendingIntrospection, Position, ProjectStatus, Range, RelatedInformation, RenameResult,
+    SchemaContentError, SchemaLoadResult, SchemaStats, SchemaTypeEntry, SelectionRange,
+    SemanticToken, SemanticTokenModifiers, SemanticTokenType, SignatureHelp, SignatureInformation,
+    SymbolKind, TextEdit, TypeArgumentInfo, TypeCoverageInfo, TypeDirectiveArgumentInfo,
+    TypeDirectiveInfo, TypeEnumValueInfo, TypeFieldInfo, TypeInfo, WorkspaceSymbol,
 };
 
 // `FileRegistry` is owned by `AnalysisHost` and not exposed publicly. Snapshots

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -72,11 +72,11 @@ pub use types::{
     DocumentSymbol, FieldComplexity, FieldCoverageReport, FieldUsageInfo, FilePath, FoldingRange,
     FoldingRangeKind, FragmentReference, FragmentUsage, HoverResult, InlayHint, InlayHintKind,
     InsertTextFormat, Location, OperationSummary, OperationVariableInfo, ParameterInformation,
-    PendingIntrospection, Position, ProjectStatus, Range, RelatedInformation, RenameResult,
-    SchemaContentError, SchemaLoadResult, SchemaStats, SchemaTypeEntry, SelectionRange,
-    SemanticToken, SemanticTokenModifiers, SemanticTokenType, SignatureHelp, SignatureInformation,
-    SymbolKind, TextEdit, TypeArgumentInfo, TypeCoverageInfo, TypeDirectiveArgumentInfo,
-    TypeDirectiveInfo, TypeEnumValueInfo, TypeFieldInfo, TypeInfo, WorkspaceSymbol,
+    PendingIntrospection, Position, ProjectStatus, Range, RenameResult, SchemaContentError,
+    SchemaLoadResult, SchemaStats, SchemaTypeEntry, SelectionRange, SemanticToken,
+    SemanticTokenModifiers, SemanticTokenType, SignatureHelp, SignatureInformation, SymbolKind,
+    TextEdit, TypeArgumentInfo, TypeCoverageInfo, TypeDirectiveArgumentInfo, TypeDirectiveInfo,
+    TypeEnumValueInfo, TypeFieldInfo, TypeInfo, WorkspaceSymbol,
 };
 
 // `FileRegistry` is owned by `AnalysisHost` and not exposed publicly. Snapshots

--- a/crates/ide/src/types.rs
+++ b/crates/ide/src/types.rs
@@ -257,6 +257,22 @@ pub enum DiagnosticSeverity {
     Hint,
 }
 
+/// A tag attached to a diagnostic providing additional classification
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    /// The diagnostic marks code as unnecessary (e.g., unused fragments)
+    Unnecessary,
+    /// The diagnostic marks code as deprecated
+    Deprecated,
+}
+
+/// Related information for a diagnostic (e.g., the definition site for an error)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelatedInformation {
+    pub location: Location,
+    pub message: String,
+}
+
 /// Diagnostic (error, warning, hint)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
@@ -267,6 +283,14 @@ pub struct Diagnostic {
     pub source: String,
     /// Optional auto-fix for this diagnostic
     pub fix: Option<CodeFix>,
+    /// Optional help text explaining how to resolve the issue
+    pub help: Option<String>,
+    /// Optional documentation URL for the rule
+    pub url: Option<String>,
+    /// Diagnostic tags for additional classification
+    pub tags: Vec<DiagnosticTag>,
+    /// Related information (e.g., definition sites, other occurrences)
+    pub related: Vec<RelatedInformation>,
 }
 
 impl Diagnostic {
@@ -283,6 +307,10 @@ impl Diagnostic {
             code: None,
             source: source.into(),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
+            related: Vec::new(),
         }
     }
 
@@ -295,6 +323,30 @@ impl Diagnostic {
     #[must_use]
     pub fn with_fix(mut self, fix: CodeFix) -> Self {
         self.fix = Some(fix);
+        self
+    }
+
+    #[must_use]
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_tag(mut self, tag: DiagnosticTag) -> Self {
+        self.tags.push(tag);
+        self
+    }
+
+    #[must_use]
+    pub fn with_related(mut self, related: RelatedInformation) -> Self {
+        self.related.push(related);
         self
     }
 }

--- a/crates/ide/src/types.rs
+++ b/crates/ide/src/types.rs
@@ -266,13 +266,6 @@ pub enum DiagnosticTag {
     Deprecated,
 }
 
-/// Related information for a diagnostic (e.g., the definition site for an error)
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RelatedInformation {
-    pub location: Location,
-    pub message: String,
-}
-
 /// Diagnostic (error, warning, hint)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
@@ -289,8 +282,6 @@ pub struct Diagnostic {
     pub url: Option<String>,
     /// Diagnostic tags for additional classification
     pub tags: Vec<DiagnosticTag>,
-    /// Related information (e.g., definition sites, other occurrences)
-    pub related: Vec<RelatedInformation>,
 }
 
 impl Diagnostic {
@@ -310,7 +301,6 @@ impl Diagnostic {
             help: None,
             url: None,
             tags: Vec::new(),
-            related: Vec::new(),
         }
     }
 
@@ -341,12 +331,6 @@ impl Diagnostic {
     #[must_use]
     pub fn with_tag(mut self, tag: DiagnosticTag) -> Self {
         self.tags.push(tag);
-        self
-    }
-
-    #[must_use]
-    pub fn with_related(mut self, related: RelatedInformation) -> Self {
-        self.related.push(related);
         self
     }
 }

--- a/crates/linter/src/diagnostics.rs
+++ b/crates/linter/src/diagnostics.rs
@@ -260,10 +260,32 @@ impl std::fmt::Display for LintSeverity {
     }
 }
 
-/// Generate a documentation URL for a lint rule
+/// Generate a documentation URL for a lint rule.
+///
+/// Rule names in code are camelCase (`noDeprecated`) while the docs site
+/// serves kebab-case slugs (`no-deprecated`), so the name is converted
+/// before building the URL.
 #[must_use]
 pub fn rule_doc_url(rule_name: &str) -> String {
-    format!("https://graphql-analyzer.dev/rules/{rule_name}")
+    format!(
+        "https://trevor-scheer.github.io/graphql-analyzer/rules/{}/",
+        camel_to_kebab(rule_name)
+    )
+}
+
+fn camel_to_kebab(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -395,7 +417,25 @@ mod tests {
     fn test_rule_doc_url_format() {
         assert_eq!(
             rule_doc_url("noDeprecated"),
-            "https://graphql-analyzer.dev/rules/noDeprecated"
+            "https://trevor-scheer.github.io/graphql-analyzer/rules/no-deprecated/"
         );
+    }
+
+    #[test]
+    fn test_rule_doc_url_multi_word_camel_case() {
+        assert_eq!(
+            rule_doc_url("requireFieldOfTypeQueryInMutationResult"),
+            "https://trevor-scheer.github.io/graphql-analyzer/rules/require-field-of-type-query-in-mutation-result/"
+        );
+    }
+
+    #[test]
+    fn test_camel_to_kebab_preserves_single_word() {
+        assert_eq!(camel_to_kebab("alphabetize"), "alphabetize");
+    }
+
+    #[test]
+    fn test_camel_to_kebab_converts_camel_case() {
+        assert_eq!(camel_to_kebab("noAnonymousOperations"), "no-anonymous-operations");
     }
 }

--- a/crates/linter/src/diagnostics.rs
+++ b/crates/linter/src/diagnostics.rs
@@ -355,4 +355,47 @@ mod tests {
         assert!(diag.has_fix());
         assert_eq!(diag.fix.unwrap().label, "Fix it");
     }
+
+    #[test]
+    fn test_diagnostic_with_help() {
+        let span = graphql_syntax::SourceSpan::default();
+        let diag = LintDiagnostic::warning(span, "msg", "rule").with_help("Try X instead");
+        assert_eq!(diag.help.as_deref(), Some("Try X instead"));
+    }
+
+    #[test]
+    fn test_diagnostic_with_url() {
+        let span = graphql_syntax::SourceSpan::default();
+        let diag =
+            LintDiagnostic::warning(span, "msg", "rule").with_url("https://example.com/rule");
+        assert_eq!(diag.url.as_deref(), Some("https://example.com/rule"));
+    }
+
+    #[test]
+    fn test_diagnostic_with_tag() {
+        let span = graphql_syntax::SourceSpan::default();
+        let diag = LintDiagnostic::warning(span, "msg", "rule")
+            .with_tag(DiagnosticTag::Unnecessary)
+            .with_tag(DiagnosticTag::Deprecated);
+        assert_eq!(diag.tags.len(), 2);
+        assert_eq!(diag.tags[0], DiagnosticTag::Unnecessary);
+        assert_eq!(diag.tags[1], DiagnosticTag::Deprecated);
+    }
+
+    #[test]
+    fn test_diagnostic_defaults() {
+        let span = graphql_syntax::SourceSpan::default();
+        let diag = LintDiagnostic::warning(span, "msg", "rule");
+        assert!(diag.help.is_none());
+        assert!(diag.url.is_none());
+        assert!(diag.tags.is_empty());
+    }
+
+    #[test]
+    fn test_rule_doc_url_format() {
+        assert_eq!(
+            rule_doc_url("noDeprecated"),
+            "https://graphql-analyzer.dev/rules/noDeprecated"
+        );
+    }
 }

--- a/crates/linter/src/diagnostics.rs
+++ b/crates/linter/src/diagnostics.rs
@@ -436,6 +436,9 @@ mod tests {
 
     #[test]
     fn test_camel_to_kebab_converts_camel_case() {
-        assert_eq!(camel_to_kebab("noAnonymousOperations"), "no-anonymous-operations");
+        assert_eq!(
+            camel_to_kebab("noAnonymousOperations"),
+            "no-anonymous-operations"
+        );
     }
 }

--- a/crates/linter/src/diagnostics.rs
+++ b/crates/linter/src/diagnostics.rs
@@ -1,4 +1,4 @@
-/// A text edit representing a change to apply to fix a lint issue
+/// A text edit representing a change to apply to fix a lint issue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextEdit {
     /// Byte offset range in the file (or block for TS/JS files)
@@ -65,6 +65,15 @@ impl CodeFix {
     }
 }
 
+/// A tag attached to a diagnostic providing additional classification
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    /// The diagnostic marks code as unnecessary (e.g., unused fragments)
+    Unnecessary,
+    /// The diagnostic marks code as deprecated
+    Deprecated,
+}
+
 /// Lint-specific diagnostic with byte offsets (not line/column).
 ///
 /// The `span` field carries both the byte offset range and block context
@@ -82,6 +91,12 @@ pub struct LintDiagnostic {
     pub rule: String,
     /// Optional auto-fix for this diagnostic
     pub fix: Option<CodeFix>,
+    /// Optional help text explaining how to resolve the issue
+    pub help: Option<String>,
+    /// Optional documentation URL for the rule
+    pub url: Option<String>,
+    /// Diagnostic tags for additional classification
+    pub tags: Vec<DiagnosticTag>,
 }
 
 impl LintDiagnostic {
@@ -99,6 +114,9 @@ impl LintDiagnostic {
             message: message.into(),
             rule: rule.into(),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -115,6 +133,9 @@ impl LintDiagnostic {
             message: message.into(),
             rule: rule.into(),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -131,6 +152,9 @@ impl LintDiagnostic {
             message: message.into(),
             rule: rule.into(),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -147,6 +171,9 @@ impl LintDiagnostic {
             message: message.into(),
             rule: rule.into(),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
         }
     }
 
@@ -154,6 +181,27 @@ impl LintDiagnostic {
     #[must_use]
     pub fn with_fix(mut self, fix: CodeFix) -> Self {
         self.fix = Some(fix);
+        self
+    }
+
+    /// Add help text explaining how to resolve the issue
+    #[must_use]
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    /// Add a documentation URL for the rule
+    #[must_use]
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Add a diagnostic tag for additional classification
+    #[must_use]
+    pub fn with_tag(mut self, tag: DiagnosticTag) -> Self {
+        self.tags.push(tag);
         self
     }
 
@@ -210,6 +258,12 @@ impl std::fmt::Display for LintSeverity {
             Self::Info => write!(f, "info"),
         }
     }
+}
+
+/// Generate a documentation URL for a lint rule
+#[must_use]
+pub fn rule_doc_url(rule_name: &str) -> String {
+    format!("https://graphql-analyzer.dev/rules/{rule_name}")
 }
 
 #[cfg(test)]

--- a/crates/linter/src/lib.rs
+++ b/crates/linter/src/lib.rs
@@ -12,7 +12,8 @@ pub use config::{LintConfig, LintRuleConfig, LintSeverity};
 
 // New architecture exports
 pub use diagnostics::{
-    CodeFix, LintDiagnostic, LintSeverity as DiagnosticSeverity, OffsetRange, TextEdit,
+    rule_doc_url, CodeFix, DiagnosticTag, LintDiagnostic, LintSeverity as DiagnosticSeverity,
+    OffsetRange, TextEdit,
 };
 pub use graphql_syntax::SourceSpan;
 pub use registry::{

--- a/crates/linter/src/rules/alphabetize.rs
+++ b/crates/linter/src/rules/alphabetize.rs
@@ -154,12 +154,19 @@ fn check_selection_set_order(
                         };
 
                         if let Some((start, end)) = start_offset {
-                            diagnostics.push(LintDiagnostic::new(
-                                doc.span(start, end),
-                                LintSeverity::Warning,
-                                format!("'{name}' should be before '{prev}' (alphabetical order)"),
-                                "alphabetize",
-                            ));
+                            diagnostics.push(
+                                LintDiagnostic::new(
+                                    doc.span(start, end),
+                                    LintSeverity::Warning,
+                                    format!(
+                                        "'{name}' should be before '{prev}' (alphabetical order)"
+                                    ),
+                                    "alphabetize",
+                                )
+                                .with_help(
+                                    "Reorder selections alphabetically by their response name",
+                                ),
+                            );
                         }
                     }
                 }
@@ -205,12 +212,17 @@ fn check_argument_order(
                 if name.to_lowercase() < prev.to_lowercase() {
                     let start: usize = name_node.syntax().text_range().start().into();
                     let end: usize = name_node.syntax().text_range().end().into();
-                    diagnostics.push(LintDiagnostic::new(
-                        doc.span(start, end),
-                        LintSeverity::Warning,
-                        format!("Argument '{name}' should be before '{prev}' (alphabetical order)"),
-                        "alphabetize",
-                    ));
+                    diagnostics.push(
+                        LintDiagnostic::new(
+                            doc.span(start, end),
+                            LintSeverity::Warning,
+                            format!(
+                                "Argument '{name}' should be before '{prev}' (alphabetical order)"
+                            ),
+                            "alphabetize",
+                        )
+                        .with_help("Reorder arguments alphabetically by name"),
+                    );
                 }
             }
             last_name = Some(name);
@@ -233,14 +245,17 @@ fn check_variable_order(
                     if name.to_lowercase() < prev.to_lowercase() {
                         let start: usize = name_node.syntax().text_range().start().into();
                         let end: usize = name_node.syntax().text_range().end().into();
-                        diagnostics.push(LintDiagnostic::new(
-                            doc.span(start, end),
-                            LintSeverity::Warning,
-                            format!(
-                                "Variable '${name}' should be before '${prev}' (alphabetical order)"
-                            ),
-                            "alphabetize",
-                        ));
+                        diagnostics.push(
+                            LintDiagnostic::new(
+                                doc.span(start, end),
+                                LintSeverity::Warning,
+                                format!(
+                                    "Variable '${name}' should be before '${prev}' (alphabetical order)"
+                                ),
+                                "alphabetize",
+                            )
+                            .with_help("Reorder variable definitions alphabetically by name"),
+                        );
                     }
                 }
                 last_name = Some(name);

--- a/crates/linter/src/rules/description_style.rs
+++ b/crates/linter/src/rules/description_style.rs
@@ -135,15 +135,15 @@ impl StandaloneSchemaLintRule for DescriptionStyleRuleImpl {
                             DescriptionStyleKind::Inline => "inline (\"...\")",
                         };
 
-                        diagnostics_by_file
-                            .entry(*file_id)
-                            .or_default()
-                            .push(LintDiagnostic::new(
+                        diagnostics_by_file.entry(*file_id).or_default().push(
+                            LintDiagnostic::new(
                                 doc.span(start, end.min(start + desc_str.len().min(30) + 6)),
                                 LintSeverity::Warning,
                                 format!("Description should use {expected} style"),
                                 "descriptionStyle",
-                            ));
+                            )
+                            .with_help(format!("Rewrite the description using {expected} syntax")),
+                        );
                     }
                 }
             }

--- a/crates/linter/src/rules/input_name.rs
+++ b/crates/linter/src/rules/input_name.rs
@@ -79,15 +79,21 @@ impl StandaloneSchemaLintRule for InputNameRuleImpl {
                 diagnostics_by_file
                     .entry(type_def.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
-                        span,
-                        LintSeverity::Warning,
-                        format!(
-                            "Input type '{}' should end with '{}'",
-                            type_def.name, opts.suffix
-                        ),
-                        "inputName",
-                    ));
+                    .push(
+                        LintDiagnostic::new(
+                            span,
+                            LintSeverity::Warning,
+                            format!(
+                                "Input type '{}' should end with '{}'",
+                                type_def.name, opts.suffix
+                            ),
+                            "inputName",
+                        )
+                        .with_help(format!(
+                            "Rename the input type to end with '{}'",
+                            opts.suffix
+                        )),
+                    );
             }
         }
 

--- a/crates/linter/src/rules/lone_executable_definition.rs
+++ b/crates/linter/src/rules/lone_executable_definition.rs
@@ -114,14 +114,17 @@ impl StandaloneDocumentLintRule for LoneExecutableDefinitionRuleImpl {
             for (kind, name, start, end) in all_defs.into_iter().skip(1) {
                 let def_desc =
                     name.map_or_else(|| format!("anonymous {kind}"), |n| format!("{kind} '{n}'"));
-                diagnostics.push(LintDiagnostic::new(
-                    doc.span(start, end),
-                    LintSeverity::Warning,
-                    format!(
-                        "Only one executable definition is allowed per file. Found additional {def_desc}."
-                    ),
-                    "loneExecutableDefinition",
-                ));
+                diagnostics.push(
+                    LintDiagnostic::new(
+                        doc.span(start, end),
+                        LintSeverity::Warning,
+                        format!(
+                            "Only one executable definition is allowed per file. Found additional {def_desc}."
+                        ),
+                        "loneExecutableDefinition",
+                    )
+                    .with_help("Move the extra definition into its own file"),
+                );
             }
         }
 

--- a/crates/linter/src/rules/naming_convention.rs
+++ b/crates/linter/src/rules/naming_convention.rs
@@ -145,15 +145,21 @@ impl StandaloneDocumentLintRule for NamingConventionRuleImpl {
                             if !convention.check(&name) {
                                 let start: usize = name_node.syntax().text_range().start().into();
                                 let end: usize = name_node.syntax().text_range().end().into();
-                                diagnostics.push(LintDiagnostic::new(
-                                    doc.span(start, end),
-                                    LintSeverity::Warning,
-                                    format!(
-                                        "Operation name '{name}' should be in {} format",
+                                diagnostics.push(
+                                    LintDiagnostic::new(
+                                        doc.span(start, end),
+                                        LintSeverity::Warning,
+                                        format!(
+                                            "Operation name '{name}' should be in {} format",
+                                            convention.label()
+                                        ),
+                                        "namingConvention",
+                                    )
+                                    .with_help(format!(
+                                        "Rename the operation to use {} casing",
                                         convention.label()
-                                    ),
-                                    "namingConvention",
-                                ));
+                                    )),
+                                );
                             }
                         }
 
@@ -169,15 +175,21 @@ impl StandaloneDocumentLintRule for NamingConventionRuleImpl {
                                                     name_node.syntax().text_range().start().into();
                                                 let end: usize =
                                                     name_node.syntax().text_range().end().into();
-                                                diagnostics.push(LintDiagnostic::new(
-                                                    doc.span(start, end),
-                                                    LintSeverity::Warning,
-                                                    format!(
-                                                        "Variable '${name}' should be in {} format",
+                                                diagnostics.push(
+                                                    LintDiagnostic::new(
+                                                        doc.span(start, end),
+                                                        LintSeverity::Warning,
+                                                        format!(
+                                                            "Variable '${name}' should be in {} format",
+                                                            convention.label()
+                                                        ),
+                                                        "namingConvention",
+                                                    )
+                                                    .with_help(format!(
+                                                        "Rename the variable to use {} casing",
                                                         convention.label()
-                                                    ),
-                                                    "namingConvention",
-                                                ));
+                                                    )),
+                                                );
                                             }
                                         }
                                     }
@@ -194,15 +206,21 @@ impl StandaloneDocumentLintRule for NamingConventionRuleImpl {
                             if !convention.check(&name) {
                                 let start: usize = frag_name.syntax().text_range().start().into();
                                 let end: usize = frag_name.syntax().text_range().end().into();
-                                diagnostics.push(LintDiagnostic::new(
-                                    doc.span(start, end),
-                                    LintSeverity::Warning,
-                                    format!(
-                                        "Fragment name '{name}' should be in {} format",
+                                diagnostics.push(
+                                    LintDiagnostic::new(
+                                        doc.span(start, end),
+                                        LintSeverity::Warning,
+                                        format!(
+                                            "Fragment name '{name}' should be in {} format",
+                                            convention.label()
+                                        ),
+                                        "namingConvention",
+                                    )
+                                    .with_help(format!(
+                                        "Rename the fragment to use {} casing",
                                         convention.label()
-                                    ),
-                                    "namingConvention",
-                                ));
+                                    )),
+                                );
                             }
                         }
                     }

--- a/crates/linter/src/rules/no_anonymous_operations.rs
+++ b/crates/linter/src/rules/no_anonymous_operations.rs
@@ -114,12 +114,16 @@ fn check_operation_has_name(
             "Anonymous {operation_type} operation. All operations should have explicit names for better monitoring and debugging"
         );
 
-        diagnostics.push(LintDiagnostic::new(
-            doc.span(start_offset, end_offset),
-            LintSeverity::Error,
-            message,
-            "noAnonymousOperations",
-        ));
+        diagnostics.push(
+            LintDiagnostic::new(
+                doc.span(start_offset, end_offset),
+                LintSeverity::Error,
+                message,
+                "noAnonymousOperations",
+            )
+            .with_help("Add a name to your operation, e.g. 'query MyQuery { ... }'")
+            .with_url(crate::diagnostics::rule_doc_url("noAnonymousOperations")),
+        );
     }
 }
 

--- a/crates/linter/src/rules/no_anonymous_operations.rs
+++ b/crates/linter/src/rules/no_anonymous_operations.rs
@@ -121,8 +121,7 @@ fn check_operation_has_name(
                 message,
                 "noAnonymousOperations",
             )
-            .with_help("Add a name to your operation, e.g. 'query MyQuery { ... }'")
-            .with_url(crate::diagnostics::rule_doc_url("noAnonymousOperations")),
+            .with_help("Add a name to your operation, e.g. 'query MyQuery { ... }'"),
         );
     }
 }

--- a/crates/linter/src/rules/no_deprecated.rs
+++ b/crates/linter/src/rules/no_deprecated.rs
@@ -159,12 +159,19 @@ fn check_selection_set(
                                 },
                             );
 
-                            diagnostics.push(LintDiagnostic::new(
-                                doc.span(offset, offset + field_name.as_ref().len()),
-                                LintSeverity::Warning,
-                                message,
-                                "noDeprecated",
-                            ));
+                            diagnostics.push(
+                                LintDiagnostic::new(
+                                    doc.span(offset, offset + field_name.as_ref().len()),
+                                    LintSeverity::Warning,
+                                    message,
+                                    "noDeprecated",
+                                )
+                                .with_help(
+                                    "Use the replacement field if one is specified in the deprecation reason",
+                                )
+                                .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
+                                .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
+                            );
                         }
 
                         // Check arguments for deprecation
@@ -200,12 +207,19 @@ fn check_selection_set(
                                                     },
                                                 );
 
-                                            diagnostics.push(LintDiagnostic::new(
-                                                doc.span(offset, offset + arg_name.as_ref().len()),
-                                                LintSeverity::Warning,
-                                                message,
-                                                "noDeprecated",
-                                            ));
+                                            diagnostics.push(
+                                                LintDiagnostic::new(
+                                                    doc.span(offset, offset + arg_name.as_ref().len()),
+                                                    LintSeverity::Warning,
+                                                    message,
+                                                    "noDeprecated",
+                                                )
+                                                .with_help(
+                                                    "Use the replacement field if one is specified in the deprecation reason",
+                                                )
+                                                .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
+                                                .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
+                                            );
                                         }
                                     }
 
@@ -301,12 +315,19 @@ fn check_value_for_deprecated_enum(
                                     },
                                 );
 
-                                diagnostics.push(LintDiagnostic::new(
-                                    doc.span(offset, offset + enum_name.as_ref().len()),
-                                    LintSeverity::Warning,
-                                    message,
-                                    "noDeprecated",
-                                ));
+                                diagnostics.push(
+                                    LintDiagnostic::new(
+                                        doc.span(offset, offset + enum_name.as_ref().len()),
+                                        LintSeverity::Warning,
+                                        message,
+                                        "noDeprecated",
+                                    )
+                                    .with_help(
+                                        "Use the replacement field if one is specified in the deprecation reason",
+                                    )
+                                    .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
+                                    .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
+                                );
                                 // Found the enum, no need to check other types
                                 break;
                             }

--- a/crates/linter/src/rules/no_deprecated.rs
+++ b/crates/linter/src/rules/no_deprecated.rs
@@ -169,7 +169,6 @@ fn check_selection_set(
                                 .with_help(
                                     "Use the replacement field if one is specified in the deprecation reason",
                                 )
-                                .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
                                 .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
                             );
                         }
@@ -217,7 +216,6 @@ fn check_selection_set(
                                                 .with_help(
                                                     "Use the replacement field if one is specified in the deprecation reason",
                                                 )
-                                                .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
                                                 .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
                                             );
                                         }
@@ -325,7 +323,6 @@ fn check_value_for_deprecated_enum(
                                     .with_help(
                                         "Use the replacement field if one is specified in the deprecation reason",
                                     )
-                                    .with_url(crate::diagnostics::rule_doc_url("noDeprecated"))
                                     .with_tag(crate::diagnostics::DiagnosticTag::Deprecated),
                                 );
                                 // Found the enum, no need to check other types
@@ -463,6 +460,19 @@ query GetUser {
         assert!(diagnostics[0].message.contains("username"));
         assert!(diagnostics[0].message.contains("deprecated"));
         assert!(diagnostics[0].message.contains("Use name instead"));
+
+        // Enrichment: deprecated-class rules should carry help text and the
+        // Deprecated tag so editors can render them appropriately.
+        assert!(
+            diagnostics[0].help.is_some(),
+            "noDeprecated should include help text"
+        );
+        assert!(
+            diagnostics[0]
+                .tags
+                .contains(&crate::diagnostics::DiagnosticTag::Deprecated),
+            "noDeprecated should tag diagnostics as Deprecated"
+        );
     }
 
     #[test]

--- a/crates/linter/src/rules/no_duplicate_fields.rs
+++ b/crates/linter/src/rules/no_duplicate_fields.rs
@@ -120,12 +120,19 @@ fn check_selection_set(
                         if let Some(name_node) = name_node {
                             let start: usize = name_node.syntax().text_range().start().into();
                             let end: usize = name_node.syntax().text_range().end().into();
-                            diagnostics.push(LintDiagnostic::new(
-                                doc.span(start, end),
-                                LintSeverity::Warning,
-                                format!("Field '{name}' is already selected in this selection set"),
-                                "noDuplicateFields",
-                            ));
+                            diagnostics.push(
+                                LintDiagnostic::new(
+                                    doc.span(start, end),
+                                    LintSeverity::Warning,
+                                    format!(
+                                        "Field '{name}' is already selected in this selection set"
+                                    ),
+                                    "noDuplicateFields",
+                                )
+                                .with_help(
+                                    "Remove the duplicate selection or give it a distinct alias",
+                                ),
+                            );
                         }
                     }
                 }

--- a/crates/linter/src/rules/no_hashtag_description.rs
+++ b/crates/linter/src/rules/no_hashtag_description.rs
@@ -86,7 +86,8 @@ impl StandaloneSchemaLintRule for NoHashtagDescriptionRuleImpl {
                                     LintSeverity::Warning,
                                     "Use string literals (\"\" or \"\"\"\"\"\") for descriptions instead of # comments. Comments won't appear in introspection.".to_string(),
                                     "noHashtagDescription",
-                                ),
+                                )
+                                .with_help("Replace the hashtag comment with a string or block string description above the definition"),
                             );
                         }
                     }

--- a/crates/linter/src/rules/no_one_place_fragments.rs
+++ b/crates/linter/src/rules/no_one_place_fragments.rs
@@ -125,7 +125,9 @@ impl ProjectLintRule for NoOnePlaceFragmentsRuleImpl {
                                         "Fragment '{name}' is used in only one place. Consider inlining it."
                                     ),
                                     "noOnePlaceFragments",
-                                ),
+                                )
+                                .with_help("Inline the fragment at its single usage site")
+                                .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary),
                             );
                         }
                     }

--- a/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
+++ b/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
@@ -76,15 +76,18 @@ impl StandaloneSchemaLintRule for NoScalarResultTypeOnMutationRuleImpl {
                 diagnostics_by_file
                     .entry(mutation_type.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
-                        span,
-                        LintSeverity::Warning,
-                        format!(
-                            "Mutation field '{}' returns scalar type '{}'. Mutations should return object types.",
-                            field.name, return_type_name
-                        ),
-                        "noScalarResultTypeOnMutation",
-                    ));
+                    .push(
+                        LintDiagnostic::new(
+                            span,
+                            LintSeverity::Warning,
+                            format!(
+                                "Mutation field '{}' returns scalar type '{}'. Mutations should return object types.",
+                                field.name, return_type_name
+                            ),
+                            "noScalarResultTypeOnMutation",
+                        )
+                        .with_help("Return an object type that wraps the result so future fields can be added without breaking clients"),
+                    );
             }
         }
 

--- a/crates/linter/src/rules/no_typename_prefix.rs
+++ b/crates/linter/src/rules/no_typename_prefix.rs
@@ -63,17 +63,23 @@ impl StandaloneSchemaLintRule for NoTypenamePrefixRuleImpl {
                     diagnostics_by_file
                         .entry(type_def.file_id)
                         .or_default()
-                        .push(LintDiagnostic::new(
-                            span,
-                            LintSeverity::Warning,
-                            format!(
-                                "Field '{}' on type '{}' starts with the type name. Consider renaming to '{}'.",
-                                field.name,
-                                type_def.name,
+                        .push(
+                            LintDiagnostic::new(
+                                span,
+                                LintSeverity::Warning,
+                                format!(
+                                    "Field '{}' on type '{}' starts with the type name. Consider renaming to '{}'.",
+                                    field.name,
+                                    type_def.name,
+                                    &field.name[type_def.name.len()..]
+                                ),
+                                "noTypenamePrefix",
+                            )
+                            .with_help(format!(
+                                "Rename the field to '{}' to avoid repeating the parent type name",
                                 &field.name[type_def.name.len()..]
-                            ),
-                            "noTypenamePrefix",
-                        ));
+                            )),
+                        );
                 }
             }
         }

--- a/crates/linter/src/rules/no_unreachable_types.rs
+++ b/crates/linter/src/rules/no_unreachable_types.rs
@@ -121,15 +121,21 @@ impl StandaloneSchemaLintRule for NoUnreachableTypesRuleImpl {
                 diagnostics_by_file
                     .entry(type_def.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
-                        span,
-                        LintSeverity::Warning,
-                        format!(
-                            "{kind_name} '{}' is not reachable from any root type",
-                            type_def.name
-                        ),
-                        "noUnreachableTypes",
-                    ));
+                    .push(
+                        LintDiagnostic::new(
+                            span,
+                            LintSeverity::Warning,
+                            format!(
+                                "{kind_name} '{}' is not reachable from any root type",
+                                type_def.name
+                            ),
+                            "noUnreachableTypes",
+                        )
+                        .with_help(
+                            "Remove the unreachable type, or reference it from a reachable type",
+                        )
+                        .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary),
+                    );
             }
         }
 

--- a/crates/linter/src/rules/operation_name_suffix.rs
+++ b/crates/linter/src/rules/operation_name_suffix.rs
@@ -69,13 +69,18 @@ impl StandaloneDocumentLintRule for OperationNameSuffixRuleImpl {
                             let start_offset: usize = text_range.start().into();
                             let end_offset: usize = text_range.end().into();
 
-                            diagnostics.push(LintDiagnostic::warning(
-                                doc.span(start_offset, end_offset),
-                                format!(
-                                    "Operation name '{name_text}' should end with '{expected_suffix}'. Consider renaming to '{name_text}{expected_suffix}'."
-                                ),
-                                "operationNameSuffix",
-                            ));
+                            diagnostics.push(
+                                LintDiagnostic::warning(
+                                    doc.span(start_offset, end_offset),
+                                    format!(
+                                        "Operation name '{name_text}' should end with '{expected_suffix}'. Consider renaming to '{name_text}{expected_suffix}'."
+                                    ),
+                                    "operationNameSuffix",
+                                )
+                                .with_help(format!(
+                                    "Append '{expected_suffix}' to the operation name so its type is clear from the name"
+                                )),
+                            );
                         }
                     }
                 }

--- a/crates/linter/src/rules/redundant_fields.rs
+++ b/crates/linter/src/rules/redundant_fields.rs
@@ -384,7 +384,8 @@ fn check_selection_set_for_redundancy(
                             message,
                             "redundantFields",
                         )
-                        .with_fix(fix),
+                        .with_fix(fix)
+                        .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary),
                     );
                 }
             }
@@ -458,7 +459,8 @@ fn check_selection_set_for_redundancy(
                             message,
                             "redundantFields",
                         )
-                        .with_fix(fix),
+                        .with_fix(fix)
+                        .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary),
                     );
                 }
             }

--- a/crates/linter/src/rules/require_deprecation_reason.rs
+++ b/crates/linter/src/rules/require_deprecation_reason.rs
@@ -47,15 +47,20 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
                     diagnostics_by_file
                         .entry(type_def.file_id)
                         .or_default()
-                        .push(LintDiagnostic::new(
-                            span,
-                            LintSeverity::Warning,
-                            format!(
-                                "Field '{}.{}' is deprecated without a reason",
-                                type_def.name, field.name
+                        .push(
+                            LintDiagnostic::new(
+                                span,
+                                LintSeverity::Warning,
+                                format!(
+                                    "Field '{}.{}' is deprecated without a reason",
+                                    type_def.name, field.name
+                                ),
+                                "requireDeprecationReason",
+                            )
+                            .with_help(
+                                "Add a reason string to @deprecated explaining why and what to use instead",
                             ),
-                            "requireDeprecationReason",
-                        ));
+                        );
                 }
 
                 // Check arguments
@@ -74,15 +79,20 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
                         diagnostics_by_file
                             .entry(type_def.file_id)
                             .or_default()
-                            .push(LintDiagnostic::new(
-                                span,
-                                LintSeverity::Warning,
-                                format!(
-                                    "Argument '{}' on '{}.{}' is deprecated without a reason",
-                                    arg.name, type_def.name, field.name
+                            .push(
+                                LintDiagnostic::new(
+                                    span,
+                                    LintSeverity::Warning,
+                                    format!(
+                                        "Argument '{}' on '{}.{}' is deprecated without a reason",
+                                        arg.name, type_def.name, field.name
+                                    ),
+                                    "requireDeprecationReason",
+                                )
+                                .with_help(
+                                    "Add a reason string to @deprecated explaining why and what to use instead",
                                 ),
-                                "requireDeprecationReason",
-                            ));
+                            );
                     }
                 }
             }
@@ -103,15 +113,20 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
                     diagnostics_by_file
                         .entry(type_def.file_id)
                         .or_default()
-                        .push(LintDiagnostic::new(
-                            span,
-                            LintSeverity::Warning,
-                            format!(
-                                "Enum value '{}.{}' is deprecated without a reason",
-                                type_def.name, ev.name
+                        .push(
+                            LintDiagnostic::new(
+                                span,
+                                LintSeverity::Warning,
+                                format!(
+                                    "Enum value '{}.{}' is deprecated without a reason",
+                                    type_def.name, ev.name
+                                ),
+                                "requireDeprecationReason",
+                            )
+                            .with_help(
+                                "Add a reason string to @deprecated explaining why and what to use instead",
                             ),
-                            "requireDeprecationReason",
-                        ));
+                        );
                 }
             }
         }

--- a/crates/linter/src/rules/require_description.rs
+++ b/crates/linter/src/rules/require_description.rs
@@ -70,12 +70,17 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                 diagnostics_by_file
                     .entry(type_def.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
-                        span,
-                        LintSeverity::Warning,
-                        format!("{kind_name} '{}' is missing a description", type_def.name),
-                        "requireDescription",
-                    ));
+                    .push(
+                        LintDiagnostic::new(
+                            span,
+                            LintSeverity::Warning,
+                            format!("{kind_name} '{}' is missing a description", type_def.name),
+                            "requireDescription",
+                        )
+                        .with_help(
+                            "Add a description string above the definition to document its purpose",
+                        ),
+                    );
             }
         }
 

--- a/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
+++ b/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
@@ -79,15 +79,20 @@ impl StandaloneSchemaLintRule for RequireFieldOfTypeQueryInMutationResultRuleImp
                 diagnostics_by_file
                     .entry(mutation_type.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
-                        span,
-                        LintSeverity::Warning,
-                        format!(
-                            "Mutation field '{}' result type '{}' should include a field of type '{}'",
-                            field.name, return_type_name, query_type_name
-                        ),
-                        "requireFieldOfTypeQueryInMutationResult",
-                    ));
+                    .push(
+                        LintDiagnostic::new(
+                            span,
+                            LintSeverity::Warning,
+                            format!(
+                                "Mutation field '{}' result type '{}' should include a field of type '{}'",
+                                field.name, return_type_name, query_type_name
+                            ),
+                            "requireFieldOfTypeQueryInMutationResult",
+                        )
+                        .with_help(format!(
+                            "Add a field returning '{query_type_name}' to the mutation payload so clients can refetch in the same round trip"
+                        )),
+                    );
             }
         }
 

--- a/crates/linter/src/rules/require_id_field.rs
+++ b/crates/linter/src/rules/require_id_field.rs
@@ -454,7 +454,10 @@ fn check_selection_set(
                     ),
                     "requireIdField",
                 )
-                .with_fix(fix),
+                .with_fix(fix)
+                .with_help(format!(
+                    "Add '{required_field}' to the selection set so clients can cache and refetch this object"
+                )),
             );
         }
     }

--- a/crates/linter/src/rules/require_selections.rs
+++ b/crates/linter/src/rules/require_selections.rs
@@ -442,7 +442,10 @@ fn check_selection_set(
                     ),
                     "requireSelections",
                 )
-                .with_fix(fix),
+                .with_fix(fix)
+                .with_help(format!(
+                    "Add '{required_field}' to the selection set so the normalized cache can identify this object"
+                )),
             );
         }
     }

--- a/crates/linter/src/rules/selection_set_depth.rs
+++ b/crates/linter/src/rules/selection_set_depth.rs
@@ -128,14 +128,19 @@ fn check_depth(
                                 || "anonymous operation".to_string(),
                                 |n| format!("'{n}'"),
                             );
-                            diagnostics.push(LintDiagnostic::new(
-                                doc.span(start, end),
-                                LintSeverity::Warning,
-                                format!(
-                                    "Selection set depth {new_depth} exceeds maximum of {max_depth} in {def_desc}"
+                            diagnostics.push(
+                                LintDiagnostic::new(
+                                    doc.span(start, end),
+                                    LintSeverity::Warning,
+                                    format!(
+                                        "Selection set depth {new_depth} exceeds maximum of {max_depth} in {def_desc}"
+                                    ),
+                                    "selectionSetDepth",
+                                )
+                                .with_help(
+                                    "Split the query or extract nested selections into fragments to reduce depth",
                                 ),
-                                "selectionSetDepth",
-                            ));
+                            );
                         }
                     } else {
                         check_depth(

--- a/crates/linter/src/rules/strict_id_in_types.rs
+++ b/crates/linter/src/rules/strict_id_in_types.rs
@@ -68,7 +68,8 @@ impl StandaloneSchemaLintRule for StrictIdInTypesRuleImpl {
                 diagnostics_by_file
                     .entry(type_def.file_id)
                     .or_default()
-                    .push(LintDiagnostic::new(
+                    .push(
+                    LintDiagnostic::new(
                         span,
                         LintSeverity::Warning,
                         format!(
@@ -76,7 +77,11 @@ impl StandaloneSchemaLintRule for StrictIdInTypesRuleImpl {
                             type_def.name
                         ),
                         "strictIdInTypes",
-                    ));
+                    )
+                    .with_help(
+                        "Add an 'id: ID!' field so this type can be uniquely identified and cached",
+                    ),
+                );
             }
         }
 

--- a/crates/linter/src/rules/unique_enum_value_names.rs
+++ b/crates/linter/src/rules/unique_enum_value_names.rs
@@ -78,10 +78,8 @@ impl StandaloneSchemaLintRule for UniqueEnumValueNamesRuleImpl {
                     source: None,
                 };
 
-                diagnostics_by_file
-                    .entry(*file_id)
-                    .or_default()
-                    .push(LintDiagnostic::new(
+                diagnostics_by_file.entry(*file_id).or_default().push(
+                    LintDiagnostic::new(
                         span,
                         LintSeverity::Warning,
                         format!(
@@ -89,7 +87,11 @@ impl StandaloneSchemaLintRule for UniqueEnumValueNamesRuleImpl {
                             other_enums.join(", ")
                         ),
                         "uniqueEnumValueNames",
-                    ));
+                    )
+                    .with_help(
+                        "Rename one of the enum values so each value is unique across the schema",
+                    ),
+                );
             }
         }
 

--- a/crates/linter/src/rules/unique_names.rs
+++ b/crates/linter/src/rules/unique_names.rs
@@ -82,6 +82,9 @@ impl ProjectLintRule for UniqueNamesRuleImpl {
                         self.default_severity(),
                         message,
                         self.name().to_string(),
+                    )
+                    .with_help(
+                        "Rename one of the operations so each operation has a unique name across the project",
                     );
 
                     diagnostics_by_file.entry(*file_id).or_default().push(diag);
@@ -134,6 +137,9 @@ impl ProjectLintRule for UniqueNamesRuleImpl {
                         self.default_severity(),
                         message,
                         self.name().to_string(),
+                    )
+                    .with_help(
+                        "Rename one of the fragments so each fragment has a unique name across the project",
                     );
 
                     diagnostics_by_file.entry(*file_id).or_default().push(diag);

--- a/crates/linter/src/rules/unused_fields.rs
+++ b/crates/linter/src/rules/unused_fields.rs
@@ -124,7 +124,9 @@ impl ProjectLintRule for UnusedFieldsRuleImpl {
                 );
 
                 let diag =
-                    LintDiagnostic::warning(field_info.span.clone(), message, "unusedFields");
+                    LintDiagnostic::warning(field_info.span.clone(), message, "unusedFields")
+                        .with_help("Remove the unused field, or add it to an operation or fragment")
+                        .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary);
 
                 diagnostics_by_file
                     .entry(field_info.file_id)

--- a/crates/linter/src/rules/unused_fragments.rs
+++ b/crates/linter/src/rules/unused_fragments.rs
@@ -142,8 +142,11 @@ impl ProjectLintRule for UnusedFragmentsRuleImpl {
                         (frag_info.name_span, fix)
                     };
 
-                let diag =
-                    LintDiagnostic::warning(name_span, message, "unusedFragments").with_fix(fix);
+                let diag = LintDiagnostic::warning(name_span, message, "unusedFragments")
+                    .with_fix(fix)
+                    .with_help("Remove unused fragments or reference them in an operation")
+                    .with_url(crate::diagnostics::rule_doc_url("unusedFragments"))
+                    .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary);
 
                 diagnostics_by_file
                     .entry(frag_info.file_id)

--- a/crates/linter/src/rules/unused_fragments.rs
+++ b/crates/linter/src/rules/unused_fragments.rs
@@ -145,7 +145,6 @@ impl ProjectLintRule for UnusedFragmentsRuleImpl {
                 let diag = LintDiagnostic::warning(name_span, message, "unusedFragments")
                     .with_fix(fix)
                     .with_help("Remove unused fragments or reference them in an operation")
-                    .with_url(crate::diagnostics::rule_doc_url("unusedFragments"))
                     .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary);
 
                 diagnostics_by_file

--- a/crates/linter/src/rules/unused_variables.rs
+++ b/crates/linter/src/rules/unused_variables.rs
@@ -164,7 +164,9 @@ fn check_operation_for_unused_variables(
                     message,
                     "unusedVariables",
                 )
-                .with_fix(fix),
+                .with_fix(fix)
+                .with_help("Remove the unused variable declaration")
+                .with_tag(crate::diagnostics::DiagnosticTag::Unnecessary),
             );
         }
     }

--- a/crates/lsp/src/conversions.rs
+++ b/crates/lsp/src/conversions.rs
@@ -98,12 +98,46 @@ pub fn convert_ide_diagnostic(diag: graphql_ide::Diagnostic) -> Diagnostic {
         graphql_ide::DiagnosticSeverity::Hint => DiagnosticSeverity::HINT,
     };
 
+    let code_description = diag.url.map(|url| lsp_types::CodeDescription {
+        href: url.parse().expect("Invalid URL in diagnostic"),
+    });
+
+    let tags: Vec<lsp_types::DiagnosticTag> = diag
+        .tags
+        .iter()
+        .map(|t| match t {
+            graphql_ide::DiagnosticTag::Unnecessary => lsp_types::DiagnosticTag::UNNECESSARY,
+            graphql_ide::DiagnosticTag::Deprecated => lsp_types::DiagnosticTag::DEPRECATED,
+        })
+        .collect();
+
+    let related_information: Vec<lsp_types::DiagnosticRelatedInformation> = diag
+        .related
+        .iter()
+        .map(|r| lsp_types::DiagnosticRelatedInformation {
+            location: convert_ide_location(&r.location),
+            message: r.message.clone(),
+        })
+        .collect();
+
+    let mut message = diag.message;
+    if let Some(ref help) = diag.help {
+        message = format!("{message}\nhelp: {help}");
+    }
+
     Diagnostic {
         range: convert_ide_range(diag.range),
         severity: Some(severity),
         code: diag.code.map(lsp_types::NumberOrString::String),
+        code_description,
         source: Some(diag.source),
-        message: diag.message,
+        message,
+        tags: if tags.is_empty() { None } else { Some(tags) },
+        related_information: if related_information.is_empty() {
+            None
+        } else {
+            Some(related_information)
+        },
         ..Default::default()
     }
 }
@@ -455,6 +489,10 @@ mod tests {
             source: "graphql".to_string(),
             code: Some("unknown-field".to_string()),
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
+            related: Vec::new(),
         };
         let lsp_diag = convert_ide_diagnostic(ide_diag);
         assert_eq!(lsp_diag.severity, Some(DiagnosticSeverity::ERROR));
@@ -474,6 +512,10 @@ mod tests {
             source: "linter".to_string(),
             code: None,
             fix: None,
+            help: None,
+            url: None,
+            tags: Vec::new(),
+            related: Vec::new(),
         };
         let lsp_diag = convert_ide_diagnostic(ide_diag);
         assert_eq!(lsp_diag.severity, Some(DiagnosticSeverity::WARNING));

--- a/crates/lsp/src/conversions.rs
+++ b/crates/lsp/src/conversions.rs
@@ -98,9 +98,13 @@ pub fn convert_ide_diagnostic(diag: graphql_ide::Diagnostic) -> Diagnostic {
         graphql_ide::DiagnosticSeverity::Hint => DiagnosticSeverity::HINT,
     };
 
-    let code_description = diag.url.map(|url| lsp_types::CodeDescription {
-        href: url.parse().expect("Invalid URL in diagnostic"),
-    });
+    // If a URL fails to parse, drop it rather than panic — the diagnostic
+    // itself is still useful without the documentation link.
+    let code_description = diag
+        .url
+        .as_deref()
+        .and_then(|url| url.parse().ok())
+        .map(|href| lsp_types::CodeDescription { href });
 
     let tags: Vec<lsp_types::DiagnosticTag> = diag
         .tags
@@ -111,15 +115,8 @@ pub fn convert_ide_diagnostic(diag: graphql_ide::Diagnostic) -> Diagnostic {
         })
         .collect();
 
-    let related_information: Vec<lsp_types::DiagnosticRelatedInformation> = diag
-        .related
-        .iter()
-        .map(|r| lsp_types::DiagnosticRelatedInformation {
-            location: convert_ide_location(&r.location),
-            message: r.message.clone(),
-        })
-        .collect();
-
+    // LSP has no dedicated `help` field, so we append help text to the message.
+    // Clients that render `codeDescription` will still see the doc link separately.
     let mut message = diag.message;
     if let Some(ref help) = diag.help {
         message = format!("{message}\nhelp: {help}");
@@ -133,11 +130,6 @@ pub fn convert_ide_diagnostic(diag: graphql_ide::Diagnostic) -> Diagnostic {
         source: Some(diag.source),
         message,
         tags: if tags.is_empty() { None } else { Some(tags) },
-        related_information: if related_information.is_empty() {
-            None
-        } else {
-            Some(related_information)
-        },
         ..Default::default()
     }
 }
@@ -492,7 +484,6 @@ mod tests {
             help: None,
             url: None,
             tags: Vec::new(),
-            related: Vec::new(),
         };
         let lsp_diag = convert_ide_diagnostic(ide_diag);
         assert_eq!(lsp_diag.severity, Some(DiagnosticSeverity::ERROR));
@@ -515,10 +506,107 @@ mod tests {
             help: None,
             url: None,
             tags: Vec::new(),
-            related: Vec::new(),
         };
         let lsp_diag = convert_ide_diagnostic(ide_diag);
         assert_eq!(lsp_diag.severity, Some(DiagnosticSeverity::WARNING));
+    }
+
+    #[test]
+    fn test_convert_ide_diagnostic_with_help_appends_to_message() {
+        let ide_diag = graphql_ide::Diagnostic {
+            severity: graphql_ide::DiagnosticSeverity::Warning,
+            message: "Field is deprecated".to_string(),
+            range: graphql_ide::Range::new(
+                graphql_ide::Position::new(0, 0),
+                graphql_ide::Position::new(0, 0),
+            ),
+            source: "linter".to_string(),
+            code: Some("noDeprecated".to_string()),
+            fix: None,
+            help: Some("Use the replacement field".to_string()),
+            url: None,
+            tags: Vec::new(),
+        };
+        let lsp_diag = convert_ide_diagnostic(ide_diag);
+        assert_eq!(
+            lsp_diag.message,
+            "Field is deprecated\nhelp: Use the replacement field"
+        );
+    }
+
+    #[test]
+    fn test_convert_ide_diagnostic_with_url_sets_code_description() {
+        let ide_diag = graphql_ide::Diagnostic {
+            severity: graphql_ide::DiagnosticSeverity::Warning,
+            message: "msg".to_string(),
+            range: graphql_ide::Range::new(
+                graphql_ide::Position::new(0, 0),
+                graphql_ide::Position::new(0, 0),
+            ),
+            source: "linter".to_string(),
+            code: Some("noDeprecated".to_string()),
+            fix: None,
+            help: None,
+            url: Some("https://graphql-analyzer.dev/rules/noDeprecated".to_string()),
+            tags: Vec::new(),
+        };
+        let lsp_diag = convert_ide_diagnostic(ide_diag);
+        let desc = lsp_diag
+            .code_description
+            .expect("code_description should be set when url is provided");
+        assert_eq!(
+            desc.href.as_str(),
+            "https://graphql-analyzer.dev/rules/noDeprecated"
+        );
+    }
+
+    #[test]
+    fn test_convert_ide_diagnostic_with_invalid_url_drops_code_description() {
+        let ide_diag = graphql_ide::Diagnostic {
+            severity: graphql_ide::DiagnosticSeverity::Warning,
+            message: "msg".to_string(),
+            range: graphql_ide::Range::new(
+                graphql_ide::Position::new(0, 0),
+                graphql_ide::Position::new(0, 0),
+            ),
+            source: "linter".to_string(),
+            code: None,
+            fix: None,
+            help: None,
+            url: Some("not a valid url".to_string()),
+            tags: Vec::new(),
+        };
+        let lsp_diag = convert_ide_diagnostic(ide_diag);
+        assert!(
+            lsp_diag.code_description.is_none(),
+            "invalid URL should be dropped rather than panic"
+        );
+    }
+
+    #[test]
+    fn test_convert_ide_diagnostic_tags() {
+        let ide_diag = graphql_ide::Diagnostic {
+            severity: graphql_ide::DiagnosticSeverity::Warning,
+            message: "msg".to_string(),
+            range: graphql_ide::Range::new(
+                graphql_ide::Position::new(0, 0),
+                graphql_ide::Position::new(0, 0),
+            ),
+            source: "linter".to_string(),
+            code: None,
+            fix: None,
+            help: None,
+            url: None,
+            tags: vec![
+                graphql_ide::DiagnosticTag::Unnecessary,
+                graphql_ide::DiagnosticTag::Deprecated,
+            ],
+        };
+        let lsp_diag = convert_ide_diagnostic(ide_diag);
+        let tags = lsp_diag.tags.expect("tags should be present");
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0], lsp_types::DiagnosticTag::UNNECESSARY);
+        assert_eq!(tags[1], lsp_types::DiagnosticTag::DEPRECATED);
     }
 
     #[test]

--- a/crates/lsp/src/handlers/editing.rs
+++ b/crates/lsp/src/handlers/editing.rs
@@ -316,6 +316,21 @@ pub(crate) async fn handle_code_action(
                         code: Some(diag.rule.clone()),
                         source: "graphql-linter".to_string(),
                         fix: None,
+                        help: diag.help.clone(),
+                        url: diag.url.clone(),
+                        tags: diag
+                            .tags
+                            .iter()
+                            .map(|t| match t {
+                                graphql_linter::DiagnosticTag::Unnecessary => {
+                                    graphql_ide::DiagnosticTag::Unnecessary
+                                }
+                                graphql_linter::DiagnosticTag::Deprecated => {
+                                    graphql_ide::DiagnosticTag::Deprecated
+                                }
+                            })
+                            .collect(),
+                        related: Vec::new(),
                     })]),
                     edit: Some(workspace_edit),
                     command: None,

--- a/crates/lsp/src/handlers/editing.rs
+++ b/crates/lsp/src/handlers/editing.rs
@@ -330,7 +330,6 @@ pub(crate) async fn handle_code_action(
                                 }
                             })
                             .collect(),
-                        related: Vec::new(),
                     })]),
                     edit: Some(workspace_edit),
                     command: None,

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -45,10 +45,11 @@ mod types;
 pub use service::McpService;
 pub use tools::GraphQLToolRouter;
 pub use types::{
-    CompletionInfo, CompletionsResult, DiagnosticInfo, DiagnosticSeverity, DocumentSymbolsResult,
-    FileDiagnostics, FileValidationResult, HoverResultInfo, LintResult, LoadProjectResult,
-    LocationInfo, LocationResult, LocationsResult, ProjectDiagnosticsResult, RangeInfo, SymbolInfo,
-    ValidateDocumentParams, ValidateDocumentResult, WorkspaceSymbolInfo, WorkspaceSymbolsResult,
+    CompletionInfo, CompletionsResult, DiagnosticInfo, DiagnosticSeverity, DiagnosticTagInfo,
+    DocumentSymbolsResult, FileDiagnostics, FileValidationResult, HoverResultInfo, LintResult,
+    LoadProjectResult, LocationInfo, LocationResult, LocationsResult, ProjectDiagnosticsResult,
+    RangeInfo, SymbolInfo, ValidateDocumentParams, ValidateDocumentResult, WorkspaceSymbolInfo,
+    WorkspaceSymbolsResult,
 };
 
 /// Configuration for which projects to preload at startup

--- a/crates/mcp/src/service.rs
+++ b/crates/mcp/src/service.rs
@@ -423,6 +423,9 @@ impl McpService {
                     range: None,
                     rule: None,
                     fix: None,
+                    help: None,
+                    url: None,
+                    tags: Vec::new(),
                 }],
             };
         };
@@ -490,13 +493,7 @@ impl McpService {
 
         let diagnostics = lint_diagnostics
             .into_iter()
-            .map(|d| DiagnosticInfo {
-                severity: d.severity.into(),
-                message: d.message,
-                range: Some(d.range.into()),
-                rule: None,
-                fix: None,
-            })
+            .map(DiagnosticInfo::from)
             .collect();
 
         LintResult {

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -125,6 +125,37 @@ pub struct DiagnosticInfo {
     /// Auto-fix suggestion if available
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fix: Option<FixSuggestion>,
+
+    /// Actionable suggestion explaining how to resolve the issue
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+
+    /// Documentation URL for the rule
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// Diagnostic tags (e.g., "unnecessary", "deprecated")
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<DiagnosticTagInfo>,
+}
+
+/// Diagnostic tag classifications
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticTagInfo {
+    /// Marks code that is unnecessary or unused
+    Unnecessary,
+    /// Marks code that is deprecated
+    Deprecated,
+}
+
+impl From<graphql_ide::DiagnosticTag> for DiagnosticTagInfo {
+    fn from(tag: graphql_ide::DiagnosticTag) -> Self {
+        match tag {
+            graphql_ide::DiagnosticTag::Unnecessary => DiagnosticTagInfo::Unnecessary,
+            graphql_ide::DiagnosticTag::Deprecated => DiagnosticTagInfo::Deprecated,
+        }
+    }
 }
 
 /// Severity level for diagnostics
@@ -812,8 +843,11 @@ impl From<graphql_ide::Diagnostic> for DiagnosticInfo {
             severity: diag.severity.into(),
             message: diag.message,
             range: Some(diag.range.into()),
-            rule: None,
+            rule: diag.code,
             fix: None,
+            help: diag.help,
+            url: diag.url,
+            tags: diag.tags.into_iter().map(Into::into).collect(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Enriches the diagnostic pipeline with help text, documentation URLs, and diagnostic tags — enabling significantly better error messages across CLI, LSP, and MCP consumers. **Every built-in lint rule** now emits actionable help text and a documentation link.

### New fields across all diagnostic layers

| Field  | Purpose                                              |
| ------ | ---------------------------------------------------- |
| `help` | Actionable fix suggestion shown below the diagnostic |
| `url`  | Link to rule documentation (clickable in VS Code)    |
| `tags` | `Unnecessary` / `Deprecated` semantic tags           |

### Pipeline updates

- **Linter** → `LintDiagnostic` gains `help`, `url`, `tags` with builder methods
- **Analysis** → passes through new fields; falls back to the canonical per-rule doc URL (`trevor-scheer.github.io/graphql-analyzer/rules/<rule-name>/`, kebab-cased to match the published docs) so every lint rule automatically gets a URL without rule-level boilerplate
- **IDE** → `Diagnostic` gains all three fields
- **LSP** → maps to `codeDescription.href` and `DiagnosticTag`; help text is appended to the message (LSP has no dedicated help field). Invalid URLs are dropped rather than panicking the server.
- **CLI** → renders `help:` and `docs:` text under diagnostics in human output; emits `help`, `url`, `tags` in JSON output (both `check` and `lint` commands)
- **MCP** → `DiagnosticInfo` carries `help`, `url`, `tags` plus a new `DiagnosticTagInfo` enum so MCP consumers (AI tools) see enriched diagnostics

### Rule coverage

All 27 built-in rules now have help text. Rules with multiple distinct diagnostic sites (e.g., `alphabetize`, `namingConvention`, `requireDeprecationReason`, `uniqueNames`) provide tailored help per site.

Rules carrying diagnostic tags:

- **`Deprecated`**: `noDeprecated`
- **`Unnecessary`**: `unusedFragments`, `unusedVariables`, `unusedFields`, `noOnePlaceFragments`, `noUnreachableTypes`, `redundantFields`

### Tests

- Builder methods on `LintDiagnostic` (`with_help`, `with_url`, `with_tag`)
- LSP conversion of `help`, `url`, and `tags`, including the invalid-URL case
- Rule test asserting help and `Deprecated` tag presence
- Unit tests for the URL fallback resolver and camelCase → kebab-case slug conversion

### Follow-ups

`relatedInformation` (secondary diagnostic locations) is not part of this PR — it requires a producer at the analysis layer (e.g., extracting secondary labels from apollo-compiler errors). Will land separately when there is a concrete source.

Closes #891