### PR TITLE
Add SARIF output format for GitHub code scanning

### DIFF
--- a/.changeset/sarif-output.md
+++ b/.changeset/sarif-output.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-cli: minor
+---
+
+Add SARIF output format for GitHub code scanning ([#943](https://github.com/trevor-scheer/graphql-analyzer/pull/943))

--- a/crates/cli/src/commands/check.rs
+++ b/crates/cli/src/commands/check.rs
@@ -337,11 +337,13 @@ pub fn run(
 
                 if issue.line > 0 {
                     println!(
-                        "::{} file={},line={},col={}::{}{}",
+                        "::{} file={},line={},col={},endLine={},endColumn={}::{}{}",
                         severity,
                         issue.file_path,
                         issue.line,
                         issue.column,
+                        issue.end_line,
+                        issue.end_column,
                         issue.message,
                         rule_suffix
                     );
@@ -349,6 +351,36 @@ pub fn run(
                     println!("::{}::{}{}", severity, issue.message, rule_suffix);
                 }
             }
+        }
+        OutputFormat::Sarif => {
+            use crate::commands::sarif::{self, SarifLevel, SarifResult};
+
+            let sarif_results: Vec<SarifResult> = all_issues
+                .iter()
+                .map(|issue| SarifResult {
+                    rule_id: issue
+                        .rule
+                        .clone()
+                        .unwrap_or_else(|| issue.source.to_string()),
+                    message: issue.message.clone(),
+                    level: match issue.severity.as_str() {
+                        "error" => SarifLevel::Error,
+                        "warning" => SarifLevel::Warning,
+                        _ => SarifLevel::Note,
+                    },
+                    file_path: issue.file_path.clone(),
+                    start_line: issue.line,
+                    start_column: issue.column,
+                    end_line: issue.end_line,
+                    end_column: issue.end_column,
+                })
+                .collect();
+
+            let output = sarif::format_sarif(&sarif_results, &ctx.base_dir);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).unwrap_or_default()
+            );
         }
     }
 

--- a/crates/cli/src/commands/complexity.rs
+++ b/crates/cli/src/commands/complexity.rs
@@ -165,7 +165,7 @@ pub fn run(
                 }
             }
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             for result in &results {
                 let output = ComplexityOutput {
                     operation_name: result.operation_name.clone(),

--- a/crates/cli/src/commands/coverage.rs
+++ b/crates/cli/src/commands/coverage.rs
@@ -77,7 +77,7 @@ pub fn run(
         OutputFormat::Human => {
             print_human_report(&coverage, filter_type, total_duration);
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             print_json_report(&coverage, filter_type);
         }
     }

--- a/crates/cli/src/commands/deprecations.rs
+++ b/crates/cli/src/commands/deprecations.rs
@@ -174,7 +174,7 @@ pub fn run(
                 total_duration.as_secs_f64()
             );
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             let json_output: Vec<_> = elements
                 .iter()
                 .map(|e| {

--- a/crates/cli/src/commands/fix.rs
+++ b/crates/cli/src/commands/fix.rs
@@ -69,7 +69,7 @@ pub fn display_dry_run(fixes: &[FileFix], format: OutputFormat) {
                 println!();
             }
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             for file_fix in fixes {
                 for diag in &file_fix.diagnostics {
                     let fix = diag.fix.as_ref().unwrap();
@@ -176,7 +176,7 @@ fn apply_file_fixes(file_fix: &FileFix, format: OutputFormat) -> Result<()> {
                 format!("{} fix(es)", file_fix.diagnostics.len()).dimmed()
             );
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             for diag in &file_fix.diagnostics {
                 let fix = diag.fix.as_ref().unwrap();
                 println!(

--- a/crates/cli/src/commands/fragments.rs
+++ b/crates/cli/src/commands/fragments.rs
@@ -72,7 +72,7 @@ pub fn run(
         OutputFormat::Human => {
             display_human_format(&fragment_usages, start_time.elapsed());
         }
-        OutputFormat::Json | OutputFormat::Github => {
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
             display_json_format(&fragment_usages);
         }
     }

--- a/crates/cli/src/commands/lint.rs
+++ b/crates/cli/src/commands/lint.rs
@@ -282,8 +282,14 @@ pub fn run(
                     .map(|r| format!(" [{r}]"))
                     .unwrap_or_default();
                 println!(
-                    "::warning file={},line={},col={}::{}{}",
-                    warning.file_path, warning.line, warning.column, warning.message, rule_suffix
+                    "::warning file={},line={},col={},endLine={},endColumn={}::{}{}",
+                    warning.file_path,
+                    warning.line,
+                    warning.column,
+                    warning.end_line,
+                    warning.end_column,
+                    warning.message,
+                    rule_suffix
                 );
             }
 
@@ -294,10 +300,45 @@ pub fn run(
                     .map(|r| format!(" [{r}]"))
                     .unwrap_or_default();
                 println!(
-                    "::error file={},line={},col={}::{}{}",
-                    error.file_path, error.line, error.column, error.message, rule_suffix
+                    "::error file={},line={},col={},endLine={},endColumn={}::{}{}",
+                    error.file_path,
+                    error.line,
+                    error.column,
+                    error.end_line,
+                    error.end_column,
+                    error.message,
+                    rule_suffix
                 );
             }
+        }
+        OutputFormat::Sarif => {
+            use crate::commands::sarif::{self, SarifLevel, SarifResult};
+
+            let mut sarif_results = Vec::new();
+            for diags in files_with_diagnostics.values() {
+                for d in diags.warnings.iter().chain(diags.errors.iter()) {
+                    sarif_results.push(SarifResult {
+                        rule_id: d.rule.clone().unwrap_or_else(|| "lint".to_string()),
+                        message: d.message.clone(),
+                        level: match d.severity.as_str() {
+                            "error" => SarifLevel::Error,
+                            "warning" => SarifLevel::Warning,
+                            _ => SarifLevel::Note,
+                        },
+                        file_path: d.file_path.clone(),
+                        start_line: d.line,
+                        start_column: d.column,
+                        end_line: d.end_line,
+                        end_column: d.end_column,
+                    });
+                }
+            }
+
+            let output = sarif::format_sarif(&sarif_results, &ctx.base_dir);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).unwrap_or_default()
+            );
         }
     }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod fragments;
 pub mod lint;
 pub mod lsp;
 pub mod mcp;
+pub(crate) mod sarif;
 pub mod schema;
 pub mod stats;
 pub mod validate;

--- a/crates/cli/src/commands/sarif.rs
+++ b/crates/cli/src/commands/sarif.rs
@@ -1,0 +1,235 @@
+//! SARIF (Static Analysis Results Interchange Format) output support.
+//!
+//! Produces SARIF v2.1.0 JSON for integration with GitHub code scanning
+//! and other SARIF-compatible tools.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// A single diagnostic result for SARIF output.
+pub struct SarifResult {
+    pub rule_id: String,
+    pub message: String,
+    pub level: SarifLevel,
+    pub file_path: String,
+    pub start_line: usize,
+    pub start_column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+}
+
+/// SARIF severity level.
+pub enum SarifLevel {
+    Error,
+    Warning,
+    Note,
+}
+
+impl SarifLevel {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+            Self::Note => "note",
+        }
+    }
+}
+
+/// Build a complete SARIF v2.1.0 JSON document from a set of diagnostic results.
+///
+/// `base_dir` is used to compute relative artifact URIs via `%SRCROOT%`.
+pub fn format_sarif(results: &[SarifResult], base_dir: &Path) -> serde_json::Value {
+    // Collect unique rules (deduplicated, sorted for stable output)
+    let mut rules_map: BTreeMap<&str, &str> = BTreeMap::new();
+    for r in results {
+        rules_map.entry(&r.rule_id).or_insert(&r.message);
+    }
+
+    let rules: Vec<serde_json::Value> = rules_map
+        .keys()
+        .map(|rule_id| {
+            serde_json::json!({
+                "id": rule_id,
+                "helpUri": format!("https://graphql-analyzer.dev/rules/{rule_id}")
+            })
+        })
+        .collect();
+
+    // Build rule index lookup for ruleIndex references
+    let rule_index: BTreeMap<&str, usize> = rules_map
+        .keys()
+        .enumerate()
+        .map(|(i, id)| (*id, i))
+        .collect();
+
+    let sarif_results: Vec<serde_json::Value> = results
+        .iter()
+        .map(|r| {
+            let relative_path = Path::new(&r.file_path)
+                .strip_prefix(base_dir)
+                .map_or_else(|_| r.file_path.clone(), |p| p.to_string_lossy().to_string());
+
+            let mut result = serde_json::json!({
+                "ruleId": r.rule_id,
+                "ruleIndex": rule_index.get(r.rule_id.as_str()).copied().unwrap_or(0),
+                "level": r.level.as_str(),
+                "message": { "text": r.message },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": relative_path,
+                            "uriBaseId": "%SRCROOT%"
+                        },
+                        "region": {
+                            "startLine": r.start_line,
+                            "startColumn": r.start_column,
+                            "endLine": r.end_line,
+                            "endColumn": r.end_column
+                        }
+                    }
+                }]
+            });
+
+            // Ensure forward slashes in URI on all platforms
+            if let Some(loc) = result
+                .get_mut("locations")
+                .and_then(|l| l.get_mut(0))
+                .and_then(|l| l.get_mut("physicalLocation"))
+                .and_then(|l| l.get_mut("artifactLocation"))
+                .and_then(|l| l.get_mut("uri"))
+            {
+                if let Some(s) = loc.as_str() {
+                    *loc = serde_json::Value::String(s.replace('\\', "/"));
+                }
+            }
+
+            result
+        })
+        .collect();
+
+    serde_json::json!({
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "graphql-analyzer",
+                    "informationUri": "https://graphql-analyzer.dev",
+                    "rules": rules
+                }
+            },
+            "results": sarif_results
+        }]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn empty_results_produce_valid_sarif() {
+        let base = PathBuf::from("/project");
+        let output = format_sarif(&[], &base);
+
+        assert_eq!(output["version"], "2.1.0");
+        assert!(output["runs"][0]["results"].as_array().unwrap().is_empty());
+        assert!(output["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn single_result_produces_correct_structure() {
+        let base = PathBuf::from("/project");
+        let results = vec![SarifResult {
+            rule_id: "noAnonymousOperations".to_string(),
+            message: "All operations must be named".to_string(),
+            level: SarifLevel::Warning,
+            file_path: "/project/src/query.graphql".to_string(),
+            start_line: 1,
+            start_column: 1,
+            end_line: 3,
+            end_column: 2,
+        }];
+
+        let output = format_sarif(&results, &base);
+
+        let result = &output["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "noAnonymousOperations");
+        assert_eq!(result["level"], "warning");
+        assert_eq!(result["message"]["text"], "All operations must be named");
+
+        let region = &result["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 1);
+        assert_eq!(region["startColumn"], 1);
+        assert_eq!(region["endLine"], 3);
+        assert_eq!(region["endColumn"], 2);
+
+        let artifact = &result["locations"][0]["physicalLocation"]["artifactLocation"];
+        assert_eq!(artifact["uri"], "src/query.graphql");
+        assert_eq!(artifact["uriBaseId"], "%SRCROOT%");
+    }
+
+    #[test]
+    fn rules_are_deduplicated() {
+        let base = PathBuf::from("/project");
+        let results = vec![
+            SarifResult {
+                rule_id: "noAnonymousOperations".to_string(),
+                message: "msg1".to_string(),
+                level: SarifLevel::Warning,
+                file_path: "/project/a.graphql".to_string(),
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 1,
+            },
+            SarifResult {
+                rule_id: "noAnonymousOperations".to_string(),
+                message: "msg2".to_string(),
+                level: SarifLevel::Warning,
+                file_path: "/project/b.graphql".to_string(),
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 1,
+            },
+        ];
+
+        let output = format_sarif(&results, &base);
+        let rules = output["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        assert_eq!(rules.len(), 1);
+    }
+
+    #[test]
+    fn severity_levels_map_correctly() {
+        assert_eq!(SarifLevel::Error.as_str(), "error");
+        assert_eq!(SarifLevel::Warning.as_str(), "warning");
+        assert_eq!(SarifLevel::Note.as_str(), "note");
+    }
+
+    #[test]
+    fn path_outside_base_dir_uses_absolute() {
+        let base = PathBuf::from("/project");
+        let results = vec![SarifResult {
+            rule_id: "test".to_string(),
+            message: "msg".to_string(),
+            level: SarifLevel::Error,
+            file_path: "/other/file.graphql".to_string(),
+            start_line: 1,
+            start_column: 1,
+            end_line: 1,
+            end_column: 1,
+        }];
+
+        let output = format_sarif(&results, &base);
+        let uri = &output["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+            ["artifactLocation"]["uri"];
+        assert_eq!(uri, "/other/file.graphql");
+    }
+}

--- a/crates/cli/src/commands/stats.rs
+++ b/crates/cli/src/commands/stats.rs
@@ -113,7 +113,9 @@ pub fn run(
     // Display statistics
     match format {
         OutputFormat::Human => print_human_stats(&stats),
-        OutputFormat::Json | OutputFormat::Github => print_json_stats(&stats),
+        OutputFormat::Json | OutputFormat::Github | OutputFormat::Sarif => {
+            print_json_stats(&stats);
+        }
     }
 
     Ok(())

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -21,6 +21,8 @@ pub fn run(
         file_path: String,
         line: usize,
         column: usize,
+        end_line: usize,
+        end_column: usize,
         message: String,
     }
 
@@ -169,6 +171,8 @@ pub fn run(
                     // graphql-ide uses 0-based, CLI output uses 1-based
                     line: (diag.range.start.line + 1) as usize,
                     column: (diag.range.start.character + 1) as usize,
+                    end_line: (diag.range.end.line + 1) as usize,
+                    end_column: (diag.range.end.character + 1) as usize,
                     message: diag.message,
                 };
 
@@ -257,13 +261,41 @@ pub fn run(
             for error in &all_errors {
                 if error.line > 0 {
                     println!(
-                        "::error file={},line={},col={}::{}",
-                        error.file_path, error.line, error.column, error.message
+                        "::error file={},line={},col={},endLine={},endColumn={}::{}",
+                        error.file_path,
+                        error.line,
+                        error.column,
+                        error.end_line,
+                        error.end_column,
+                        error.message
                     );
                 } else {
                     println!("::error ::{}", error.message);
                 }
             }
+        }
+        OutputFormat::Sarif => {
+            use crate::commands::sarif::{self, SarifLevel, SarifResult};
+
+            let sarif_results: Vec<SarifResult> = all_errors
+                .iter()
+                .map(|error| SarifResult {
+                    rule_id: "validation".to_string(),
+                    message: error.message.clone(),
+                    level: SarifLevel::Error,
+                    file_path: error.file_path.clone(),
+                    start_line: error.line,
+                    start_column: error.column,
+                    end_line: error.end_line,
+                    end_column: error.end_column,
+                })
+                .collect();
+
+            let output = sarif::format_sarif(&sarif_results, &ctx.base_dir);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&output).unwrap_or_default()
+            );
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -278,6 +278,8 @@ enum OutputFormat {
     Json,
     /// GitHub Actions workflow commands for PR annotations
     Github,
+    /// SARIF (Static Analysis Results Interchange Format) for GitHub code scanning
+    Sarif,
 }
 
 #[tokio::main]

--- a/crates/cli/src/watch.rs
+++ b/crates/cli/src/watch.rs
@@ -368,18 +368,49 @@ impl FileWatcher {
                         };
                         let line = diag.range.start.line + 1;
                         let col = diag.range.start.character + 1;
+                        let end_line = diag.range.end.line + 1;
+                        let end_col = diag.range.end.character + 1;
                         let rule_suffix = diag
                             .code
                             .as_ref()
                             .map(|r| format!(" [{r}]"))
                             .unwrap_or_default();
                         println!(
-                            "::{level} file={},line={line},col={col}::{}{rule_suffix}",
+                            "::{level} file={},line={line},col={col},endLine={end_line},endColumn={end_col}::{}{rule_suffix}",
                             file_path.display(),
                             diag.message
                         );
                     }
                 }
+            }
+            OutputFormat::Sarif => {
+                use crate::commands::sarif::{self, SarifLevel, SarifResult};
+
+                let sarif_results: Vec<SarifResult> = diagnostics
+                    .iter()
+                    .flat_map(|(file_path, diags)| {
+                        diags.iter().map(move |diag| SarifResult {
+                            rule_id: diag.code.clone().unwrap_or_else(|| source.to_string()),
+                            message: diag.message.clone(),
+                            level: match diag.severity {
+                                DiagnosticSeverity::Error => SarifLevel::Error,
+                                DiagnosticSeverity::Warning => SarifLevel::Warning,
+                                _ => SarifLevel::Note,
+                            },
+                            file_path: file_path.to_string_lossy().to_string(),
+                            start_line: (diag.range.start.line + 1) as usize,
+                            start_column: (diag.range.start.character + 1) as usize,
+                            end_line: (diag.range.end.line + 1) as usize,
+                            end_column: (diag.range.end.character + 1) as usize,
+                        })
+                    })
+                    .collect();
+
+                let output = sarif::format_sarif(&sarif_results, &self.config.base_dir);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&output).unwrap_or_default()
+                );
             }
         }
     }
@@ -412,8 +443,8 @@ impl FileWatcher {
                     })
                 );
             }
-            OutputFormat::Github => {
-                // GitHub Actions format uses human-readable header
+            OutputFormat::Github | OutputFormat::Sarif => {
+                // GitHub Actions / SARIF format uses human-readable header
                 let mode_name = match self.config.mode {
                     WatchMode::Validate => "validation",
                     WatchMode::Lint => "linting",
@@ -498,8 +529,8 @@ impl FileWatcher {
                     })
                 );
             }
-            OutputFormat::Github => {
-                // GitHub Actions format uses human-readable result summary
+            OutputFormat::Github | OutputFormat::Sarif => {
+                // GitHub Actions / SARIF format uses human-readable result summary
                 let timestamp = format!("[{}]", chrono_now()).dimmed();
 
                 if !is_initial && !result.changed_files.is_empty() {

--- a/docs/src/content/docs/cli/ci-cd.mdx
+++ b/docs/src/content/docs/cli/ci-cd.mdx
@@ -24,6 +24,31 @@ jobs:
 
 Using `--format github` turns errors into pull request annotations.
 
+### GitHub Code Scanning (SARIF)
+
+For richer integration with GitHub's Security tab, use SARIF output:
+
+```yaml
+name: GraphQL Validation
+on: [pull_request]
+
+jobs:
+  graphql:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install GraphQL CLI
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+      - name: Check GraphQL
+        run: graphql check --format sarif > results.sarif
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
 To run validation and linting as separate steps:
 
 ```yaml

--- a/docs/src/content/docs/cli/output-formats.mdx
+++ b/docs/src/content/docs/cli/output-formats.mdx
@@ -1,9 +1,9 @@
 ---
 title: Output Formats
-description: Human-readable, JSON, and GitHub Actions output formats.
+description: Human-readable, JSON, GitHub Actions, and SARIF output formats.
 ---
 
-All CLI commands support three output formats via the `--format` flag.
+All CLI commands support four output formats via the `--format` flag.
 
 ## Human (default)
 
@@ -68,3 +68,48 @@ graphql validate --format github
 ```
 
 See [CI/CD Integration](/graphql-analyzer/cli/ci-cd/) for a full GitHub Actions workflow.
+
+## SARIF
+
+[SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) (Static Analysis Results Interchange Format) for GitHub code scanning integration. Enables rich PR annotations and populates the Security tab:
+
+```sh
+graphql check --format sarif > results.sarif
+```
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {
+      "driver": {
+        "name": "graphql-analyzer",
+        "rules": [{ "id": "noAnonymousOperations", "shortDescription": { "text": "..." } }]
+      }
+    },
+    "results": [{
+      "ruleId": "noAnonymousOperations",
+      "level": "error",
+      "message": { "text": "All operations must be named" },
+      "locations": [{
+        "physicalLocation": {
+          "artifactLocation": { "uri": "src/queries.graphql" },
+          "region": { "startLine": 1, "startColumn": 1 }
+        }
+      }]
+    }]
+  }]
+}
+```
+
+Upload to GitHub code scanning:
+
+```yaml
+- run: graphql check -f sarif > results.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+See [CI/CD Integration](/graphql-analyzer/cli/ci-cd/) for a full workflow example.

--- a/docs/src/content/docs/cli/output-formats.mdx
+++ b/docs/src/content/docs/cli/output-formats.mdx
@@ -81,25 +81,31 @@ graphql check --format sarif > results.sarif
 {
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
   "version": "2.1.0",
-  "runs": [{
-    "tool": {
-      "driver": {
-        "name": "graphql-analyzer",
-        "rules": [{ "id": "noAnonymousOperations", "shortDescription": { "text": "..." } }]
-      }
-    },
-    "results": [{
-      "ruleId": "noAnonymousOperations",
-      "level": "error",
-      "message": { "text": "All operations must be named" },
-      "locations": [{
-        "physicalLocation": {
-          "artifactLocation": { "uri": "src/queries.graphql" },
-          "region": { "startLine": 1, "startColumn": 1 }
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "graphql-analyzer",
+          "rules": [{ "id": "noAnonymousOperations", "shortDescription": { "text": "..." } }]
         }
-      }]
-    }]
-  }]
+      },
+      "results": [
+        {
+          "ruleId": "noAnonymousOperations",
+          "level": "error",
+          "message": { "text": "All operations must be named" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "src/queries.graphql" },
+                "region": { "startLine": 1, "startColumn": 1 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds `-f sarif` output format for integration with GitHub code scanning and security tools.

### Usage
```bash
graphql check -f sarif > results.sarif

# In GitHub Actions:
- run: graphql check -f sarif > results.sarif
- uses: github/codeql-action/upload-sarif@v3
  with:
    sarif_file: results.sarif
```

### Implementation
- SARIF v2.1.0 compliant output with proper schema reference
- Deduplicates rules in the `tool.driver.rules` array
- Maps severity: Error → "error", Warning → "warning", Info → "note"
- Includes file locations with line/column ranges
- Relative paths from workspace root

Closes #893