### PR TITLE
fix(lsp): make LineIndex::line_col resilient to stale offsets

### DIFF
--- a/.changeset/fix-line-col-panic-during-rapid-edits.md
+++ b/.changeset/fix-line-col-panic-during-rapid-edits.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-lsp: patch
+---
+
+Fix LSP server panics during rapid schema edits. `LineIndex::line_col` previously asserted that the byte offset was in-bounds and on a char boundary, panicking the `spawn_blocking` worker when a Salsa-cached lint diagnostic span survived a content edit and was then converted against a freshly-built `LineIndex` for the new (shorter) source. The function now clamps stale offsets to the end of source and snaps mid-character offsets to the nearest preceding boundary, emitting a `tracing::warn!` so the upstream bug stays visible without crashing the server. Also makes the `Uri::from_str` call sites in the `code_action` and `code_lens` handlers fall back to skipping the request rather than panicking, and installs a global panic hook plus a `JoinError`-payload extractor so future panics surface their actual message and backtrace in the logs instead of the useless `task N panicked`.

--- a/.changeset/fix-line-col-panic-vscode.md
+++ b/.changeset/fix-line-col-panic-vscode.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Bundle the LSP fix for panics during rapid schema edits.

--- a/.claude/skills/debug-lsp/SKILL.md
+++ b/.claude/skills/debug-lsp/SKILL.md
@@ -111,6 +111,16 @@ Look for:
 3. Test LSP directly (see above)
 4. Check for panics in logs
 
+### Panics in `spawn_blocking` workers
+
+**Symptoms**: `tracing::error!` lines like `Blocking task ended abnormally: panic: ...` or `Analysis task ended abnormally: panic: ...`. Individual requests fail but the server stays up.
+
+**What to look for**:
+
+- The improved panic logging extracts the actual panic payload (string or `&'static str`) from `JoinError::into_panic()`. The default `JoinError` Display only says `task N panicked` — useless. If you see the bare `task N panicked` form, you're on an old binary.
+- A global panic hook (installed in `install_panic_hook` in `crates/lsp/src/lib.rs`) emits `tracing::error!` with the message, source location, and a backtrace if `RUST_BACKTRACE=1` is set. Set the env var on the LSP server process to get backtraces.
+- Common offenders: stale byte offsets in cached lint diagnostics colliding with a freshly-built `LineIndex` after rapid edits. `LineIndex::line_col` clamps and warns rather than panicking, but if you see `LineIndex::line_col offset is past end of source` or `landed mid-character` warnings, that's a pre-existing bug somewhere in the diagnostics pipeline that needs investigation.
+
 ### Hangs / Deadlocks
 
 **Symptoms**: LSP stops responding, CPU stays high

--- a/crates/lsp/src/handlers/display.rs
+++ b/crates/lsp/src/handlers/display.rs
@@ -138,7 +138,20 @@ pub(crate) async fn handle_code_lens(
 
     server
         .with_analysis(&uri, move |analysis, file_path| {
-            let uri = Uri::from_str(&file_path.0).expect("valid URI from FilePath");
+            // If the FilePath doesn't round-trip through `Uri::from_str` (rare,
+            // happens for virtual / in-memory schemes), log and skip rather
+            // than panicking the spawn_blocking worker.
+            let uri = match Uri::from_str(&file_path.0) {
+                Ok(uri) => uri,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %file_path.0,
+                        error = %e,
+                        "code_lens: failed to parse FilePath as URI, skipping",
+                    );
+                    return None;
+                }
+            };
             let mut lsp_code_lenses: Vec<CodeLens> = Vec::new();
 
             // Code lenses for deprecated fields (in schema files)

--- a/crates/lsp/src/handlers/editing.rs
+++ b/crates/lsp/src/handlers/editing.rs
@@ -220,8 +220,21 @@ pub(crate) async fn handle_code_action(
             let content = analysis.file_content(&file_path)?;
 
             let file_line_index = graphql_syntax::LineIndex::new(&content);
-            // Reconstruct URI for workspace edit keys
-            let uri = Uri::from_str(&file_path.0).expect("valid URI from FilePath");
+            // Reconstruct URI for workspace edit keys. If parsing fails — which
+            // can happen for virtual paths or in-memory schemes that don't
+            // round-trip cleanly through `Uri::from_str` — log and skip rather
+            // than panicking the spawn_blocking worker.
+            let uri = match Uri::from_str(&file_path.0) {
+                Ok(uri) => uri,
+                Err(e) => {
+                    tracing::warn!(
+                        path = %file_path.0,
+                        error = %e,
+                        "code_action: failed to parse FilePath as URI, skipping",
+                    );
+                    return None;
+                }
+            };
 
             for diag in lint_diagnostics {
                 let Some(ref fix) = diag.fix else {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -145,6 +145,45 @@ pub fn init_tracing() -> Option<trace_capture::ReloadHandle> {
     init_tracing_without_otel()
 }
 
+/// Install a panic hook that routes panic info through `tracing`.
+///
+/// Without this, panics inside `spawn_blocking` are reported by the runtime as
+/// `JoinError("task N panicked")` with no location, no message, and no
+/// backtrace — useless for diagnosing bugs in IDE feature code. The hook
+/// captures the panic message, source location, and (if `RUST_BACKTRACE` is
+/// set) a backtrace, and emits them as a single `tracing::error!` event tagged
+/// with the panicking thread name. The previous panic handler still runs after
+/// the hook, so process behavior is unchanged for fatal panics and the default
+/// stderr formatting still works.
+pub fn install_panic_hook() {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = if let Some(l) = info.location() {
+            format!("{}:{}:{}", l.file(), l.line(), l.column())
+        } else {
+            "<unknown>".to_string()
+        };
+        let payload = info.payload();
+        let message = if let Some(s) = payload.downcast_ref::<String>() {
+            s.as_str()
+        } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+            *s
+        } else {
+            "<non-string panic payload>"
+        };
+        let thread = std::thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
+        let backtrace = std::backtrace::Backtrace::capture();
+        tracing::error!(
+            thread = thread_name,
+            location = %location,
+            backtrace = %backtrace,
+            "panic: {message}"
+        );
+        prev(info);
+    }));
+}
+
 /// Run the GraphQL language server over stdio.
 ///
 /// This function initializes tracing and starts the LSP server,
@@ -160,6 +199,7 @@ pub fn init_tracing() -> Option<trace_capture::ReloadHandle> {
 /// ```
 pub async fn run_server() {
     let reload_handle = init_tracing();
+    install_panic_hook();
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -687,10 +687,12 @@ impl GraphQLLanguageServer {
         };
 
         let file_path = graphql_ide::FilePath::new(uri.to_string());
+        let uri_for_log = uri.to_string();
         let result = tokio::task::spawn_blocking(move || f(analysis, file_path))
             .await
-            .map_err(|e| {
-                tracing::error!("Analysis task panicked: {e}");
+            .map_err(|join_err| {
+                let payload = describe_join_error(join_err);
+                tracing::error!(uri = %uri_for_log, "Analysis task ended abnormally: {payload}");
                 Error::internal_error()
             })?;
         Ok(result)
@@ -714,8 +716,9 @@ impl GraphQLLanguageServer {
     {
         match tokio::task::spawn_blocking(f).await {
             Ok(result) => Some(result),
-            Err(e) => {
-                tracing::error!("Blocking task panicked: {e}");
+            Err(join_err) => {
+                let payload = describe_join_error(join_err);
+                tracing::error!("Blocking task ended abnormally: {payload}");
                 None
             }
         }
@@ -1404,6 +1407,33 @@ documents: "**/*.graphql"
             workspace_uri
         );
     }
+}
+
+/// Convert a `tokio::task::JoinError` into a printable description that
+/// includes the actual panic payload (string or `&'static str`) for panic
+/// errors. The default `Display` impl on `JoinError` only says "task N
+/// panicked", which is useless for diagnosing what actually went wrong —
+/// the panic location and any backtrace also need to be captured by the
+/// panic hook (see `install_panic_hook` in `lib.rs`).
+///
+/// Consumes the error because `into_panic()` requires ownership.
+fn describe_join_error(join_err: tokio::task::JoinError) -> String {
+    if join_err.is_cancelled() {
+        return "cancelled".to_string();
+    }
+    if !join_err.is_panic() {
+        return join_err.to_string();
+    }
+    // is_panic() guarantees into_panic() returns the payload.
+    let payload: Box<dyn std::any::Any + Send> = join_err.into_panic();
+    let msg = if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else {
+        "<non-string panic payload>".to_string()
+    };
+    format!("panic: {msg}")
 }
 
 impl LanguageServer for GraphQLLanguageServer {

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -581,23 +581,69 @@ impl LineIndex {
         }
     }
 
-    /// Convert a byte offset to a line/column position (0-based)
+    /// Convert a byte offset to a line/column position (0-based).
     ///
     /// Columns are measured in UTF-16 code units, matching the LSP specification.
     /// For byte-based columns (internal use), see [`line_col_bytes`](Self::line_col_bytes).
+    ///
+    /// # Resilience to stale offsets
+    ///
+    /// LSP code paths can hand this function a byte offset that was computed
+    /// against an older revision of the source — for example, a Salsa-cached
+    /// diagnostic span that survived a content edit. Rather than panicking,
+    /// we clamp the offset to the end of the source and snap to the nearest
+    /// preceding char boundary. The returned position is "the closest valid
+    /// position to where you asked", which is the right answer for downstream
+    /// LSP position conversion.
+    ///
+    /// A `tracing::warn!` is emitted whenever clamping or snapping occurs,
+    /// because it indicates a bug somewhere upstream (the offsets *should*
+    /// always be valid for the source). The warn lets us notice the bug
+    /// without crashing the server.
     #[must_use]
     pub fn line_col(&self, offset: usize) -> (usize, usize) {
-        assert!(
-            offset <= self.source.len(),
-            "byte offset {offset} is out of bounds of source ({} bytes). \
-             This is a bug — the offset likely comes from a different file than the LineIndex.",
-            self.source.len()
-        );
-        let (line, byte_col) = self.line_col_bytes(offset);
+        let safe_offset = self.clamp_offset_to_source(offset);
+        let (line, byte_col) = self.line_col_bytes(safe_offset);
         let line_start = self.line_starts[line];
         let line_text = &self.source[line_start..line_start + byte_col];
         let utf16_col: usize = line_text.chars().map(char::len_utf16).sum();
         (line, utf16_col)
+    }
+
+    /// Clamp a byte offset into a value that is guaranteed to be in-bounds and
+    /// on a char boundary of `self.source`.
+    ///
+    /// Logs a warning if the input was already invalid, since that points to
+    /// a bug in whichever upstream code produced the offset (typically a
+    /// stale diagnostic span computed against an older source revision).
+    fn clamp_offset_to_source(&self, offset: usize) -> usize {
+        let len = self.source.len();
+        if offset > len {
+            tracing::warn!(
+                offset,
+                source_len = len,
+                "LineIndex::line_col offset is past end of source — clamping. \
+                 This usually means a diagnostic span was computed against an \
+                 older revision of the file."
+            );
+            return len;
+        }
+        if !self.source.is_char_boundary(offset) {
+            // Walk backwards to the nearest char boundary. This always
+            // terminates because byte 0 is always a char boundary.
+            let mut snapped = offset;
+            while !self.source.is_char_boundary(snapped) {
+                snapped -= 1;
+            }
+            tracing::warn!(
+                offset,
+                snapped,
+                "LineIndex::line_col offset landed mid-character — snapping back to char boundary. \
+                 This usually means a diagnostic span was computed against an older revision of the file."
+            );
+            return snapped;
+        }
+        offset
     }
 
     /// Convert a byte offset to a line/column position with byte-based columns
@@ -730,6 +776,65 @@ mod tests {
         assert_eq!(index.line_count(), 1);
         assert_eq!(index.line_col(0), (0, 0));
         assert_eq!(index.line_col(3), (0, 3));
+    }
+
+    /// Regression test for the panic that crashed the LSP during rapid edits.
+    ///
+    /// `line_col` used to `assert!(offset <= self.source.len())`. When a
+    /// Salsa-cached lint diagnostic span survived a content edit and was then
+    /// converted via a freshly-built `LineIndex`, the cached offset could
+    /// point past the end of the new (shorter) source, panicking the
+    /// `spawn_blocking` worker. The host would then either deadlock (old
+    /// `RwLock` architecture) or just lose the request (new architecture).
+    ///
+    /// Defensive behavior: clamp the offset to the end of the source and
+    /// return the position there, plus a `tracing::warn!` so the upstream
+    /// bug remains visible.
+    #[test]
+    fn test_line_col_offset_past_end_does_not_panic() {
+        let text = "type Query {\n  hello: String\n}";
+        let index = LineIndex::new(text);
+        let len = text.len();
+
+        // Exactly at the end is valid (returns the end position).
+        let end_pos = index.line_col(len);
+        assert_eq!(end_pos, (2, 1));
+
+        // One past the end clamps to the end position.
+        assert_eq!(index.line_col(len + 1), end_pos);
+
+        // Way past the end (simulating a stale offset from a much-larger
+        // previous revision) also clamps.
+        assert_eq!(index.line_col(len + 100), end_pos);
+        assert_eq!(index.line_col(usize::MAX / 2), end_pos);
+    }
+
+    /// Regression test: an offset landing mid-character must not panic.
+    ///
+    /// Without the snap-to-boundary defensive code, slicing
+    /// `&source[line_start..line_start + byte_col]` panics with "byte index N
+    /// is not a char boundary" when the offset (e.g., from a stale diagnostic)
+    /// happens to fall inside a multi-byte UTF-8 sequence.
+    #[test]
+    fn test_line_col_mid_character_offset_does_not_panic() {
+        // 🚀 is 4 bytes (F0 9F 9A 80) starting at byte index 0.
+        let text = "\u{1F680}xy";
+        let index = LineIndex::new(text);
+
+        // Offset 0 is the start of the rocket — fine.
+        assert_eq!(index.line_col(0), (0, 0));
+
+        // Offsets 1, 2, 3 land *inside* the rocket's UTF-8 bytes. Without
+        // snap-to-boundary, slicing the source there panics. With the
+        // defensive snap, all three return (0, 0) — the position of the
+        // nearest preceding char boundary.
+        assert_eq!(index.line_col(1), (0, 0));
+        assert_eq!(index.line_col(2), (0, 0));
+        assert_eq!(index.line_col(3), (0, 0));
+
+        // Offset 4 is the start of 'x' — fine, returns (0, 2) because the
+        // rocket is 2 UTF-16 code units.
+        assert_eq!(index.line_col(4), (0, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stop the LSP server panicking during rapid schema edits. Holding backspace on a schema field would take down individual `spawn_blocking` workers with a panic; on the current `Arc<RwLock<FileRegistry>>` architecture this can leave the host effectively wedged because the request that should release the lock is the one that died.

The exact upstream cause of the bad offset is still under investigation, but the panic shouldn't kill requests regardless — clamping a stale byte offset to source bounds is the correct behavior for downstream LSP position conversion.

## Changes

- **`LineIndex::line_col` is now defensive.** It used to `assert!(offset <= self.source.len())` and slice `&source[line_start..line_start + byte_col]`, both of which panic when a Salsa-cached lint diagnostic span survives a content edit and is then converted against a freshly-built `LineIndex` for the new (shorter) source. Now it clamps to `source.len()`, snaps mid-character offsets to the nearest preceding char boundary, and emits `tracing::warn!` so the upstream bug stays visible. Two regression tests cover both failure modes.
- **`code_action` and `code_lens` handlers** no longer `expect("valid URI from FilePath")`. If parsing fails (rare, e.g. virtual schemes), they log and return `None` instead of panicking the worker.
- **Improved panic diagnostics.** A new `install_panic_hook` in `crates/lsp/src/lib.rs` routes panic payloads through `tracing::error!` with location and (when `RUST_BACKTRACE=1` is set) a backtrace. A new `describe_join_error` helper in `crates/lsp/src/server.rs` consumes `JoinError` and extracts the actual panic payload via `into_panic()`, so `with_analysis` and `blocking` log the real error instead of tokio's bare `task N panicked`.
- **`debug-lsp` skill** updated with a new "Panics in spawn_blocking workers" troubleshooting section covering the new logging and the `LineIndex::line_col` defensive warnings.

Changesets attached for `graphql-analyzer-lsp` (the actual fix) and `graphql-analyzer-vscode` (which bundles the LSP binary).

## Consulted SME Agents

N/A — straightforward defensive fix.

## Manual Testing Plan

- Build: \`cargo build --release -p graphql-lsp\`
- Open a large GraphQL project in VS Code with the new binary
- Hold backspace on a schema field name for several seconds
- Verify no \`Blocking task ended abnormally\` errors in the LSP output channel — or, if any do appear, that the server keeps serving requests rather than going silent
- Watch for new \`LineIndex::line_col offset is past end of source\` warnings in the logs; these point to the underlying upstream bug and should be filed as a separate follow-up

## Related

This is a **defensive fix** for the panic. It does not address the upstream cause of stale diagnostic spans surviving content edits — that's a separate investigation tracked by the warnings the new code emits.

The architectural refactor that eliminates the `Arc<RwLock<FileRegistry>>` deadlock class will be a separate PR stacked on this one (it conflicts with this PR in `crates/lsp/src/workspace.rs` and `crates/lsp/src/server.rs`).