### PR TITLE
refactor(ide): kill the FileRegistry RwLock deadlock class

### DIFF
--- a/.changeset/eliminate-registry-lock-deadlock.md
+++ b/.changeset/eliminate-registry-lock-deadlock.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-lsp: patch
+---
+
+Eliminate the `FileRegistry` parking_lot `RwLock` from `Analysis` snapshots, which removes a class of LSP deadlocks triggered by rapid schema file edits. The previous fixes (#779, #784, #949) all worked around the same root cause: snapshots reached back into the host through a side-channel `RwLock` whose writer-blocks-readers semantics created a lock-ordering cycle with Salsa's setter/snapshot protocol. URI ↔ FileId resolution now lives in Salsa as a `FilePathMap` input, so snapshots resolve paths through `&db` and never share a non-Salsa lock with the host.

--- a/.claude/agents/salsa.md
+++ b/.claude/agents/salsa.md
@@ -170,7 +170,7 @@ let result2 = {
 };
 ```
 
-### Pitfall 2: Shared Arc<RwLock<...>> in Database
+### Pitfall 2: Shared Arc<RwLock<...>> in Database (or alongside it)
 
 ```rust
 #[derive(Clone)]
@@ -180,7 +180,7 @@ struct Database {
 }
 ```
 
-This creates lock ordering issues. The config lock might be held while Salsa locks are held, causing deadlock.
+This creates lock ordering issues. The config lock might be held while Salsa locks are held, causing deadlock. The same applies to _any_ non-Salsa lock that both `Analysis` snapshots and the host can acquire — even if it lives next to the database rather than inside it.
 
 **Fix**: Use Salsa inputs for all mutable state:
 
@@ -200,6 +200,17 @@ struct Database {
     config: Arc<Config>,  // Immutable, replaced on change
 }
 ```
+
+**Real-world incident — `graphql-analyzer`, April 2026.** This project shipped exactly the broken pattern: `AnalysisHost` held a `FileRegistry` behind a `parking_lot::RwLock`, and `Analysis` snapshots cloned an `Arc` to the same lock for path lookups (`get_file_id`, `get_path`, `get_content`, `get_metadata`). PRs #779, #784, and #949 each added a workaround for a different manifestation of the same bug — DashMap shard locks across `.await`, runtime starvation when the Salsa setter ran on the async thread, and so on. None of them addressed the actual cycle:
+
+1. A `spawn_blocking` snapshot was inside `Analysis::find_affected_document_files`, holding `registry.read()` across long Salsa queries.
+2. A `did_change` writer in another `spawn_blocking` task acquired `registry.write()` and called `existing_content.set_text(db).to(...)`. The Salsa setter parked waiting for the snapshot to drop.
+3. The snapshot's next iteration of the diagnostics loop tried to take `registry.read()` again. parking_lot's writer-preferring policy parked the read.
+4. Both workers blocked forever. Two threads, each waiting on the other.
+
+The architectural fix moved URI ↔ `FileId` and `FileId` → `(FileContent, FileMetadata)` into a new `FilePathMap` Salsa input + the existing `FileEntryMap`, exposed through a `DbFiles` adapter that only takes `&dyn salsa::Database`. `Analysis` no longer has a `registry` field. No second lock = no cycle = the deadlock class is gone by construction. See `crates/CLAUDE.md` "Snapshot/Host Lock Discipline" for the rule and `crates/lsp/src/workspace.rs::test_concurrent_snapshot_lookups_during_writer` for the regression test.
+
+**Lesson**: when reviewing a Salsa-based codebase, treat any lock-ish field (`Arc<RwLock>`, `Arc<Mutex>`, etc.) that's reachable from BOTH the host AND a snapshot as a deadlock waiting to happen. The right answer is almost always "put it in a Salsa input."
 
 ### Pitfall 3: Blocking in Query Functions
 

--- a/.claude/skills/debug-lsp/SKILL.md
+++ b/.claude/skills/debug-lsp/SKILL.md
@@ -123,32 +123,37 @@ Look for:
 
 ### Hangs / Deadlocks
 
-**Symptoms**: LSP stops responding, CPU stays high
+**Symptoms**: LSP stops responding, CPU stays low (workers parked, not spinning)
 
-**Likely cause**: Salsa deadlock from concurrent access
+**Likely cause**: a Salsa setter is waiting on a snapshot to drop, and something is preventing the snapshot from dropping.
 
 **Debug steps**:
 
-1. Enable RUST_LOG=debug
-2. Look for "acquiring lock" messages without corresponding releases
-3. Check for snapshot not being dropped before setter calls
-4. Consult `salsa.md` agent for deadlock patterns
+1. Enable `RUST_LOG=debug`
+2. Find the most recent `did_change` log line and confirm `add_file_and_snapshot` started but never returned. The blocking task is parked inside the Salsa setter.
+3. Identify which task still holds an `Analysis` snapshot. Common culprits: an in-flight `diagnostics_for_change` running in `spawn_blocking`, a debounced publish-diagnostics task, a `references`/`workspace_symbols` request handler.
+4. Verify that task isn't waiting on something the writer holds. The original deadlock class — snapshot waiting on `registry.read()` while writer held `registry.write()` — was eliminated structurally by moving file lookups into Salsa (`FilePathMap`), so any new occurrence implies a fresh shared lock somewhere. Find it.
+5. Consult the `salsa.md` SME agent for the full pattern catalog and the April 2026 incident writeup.
 
-**Common fix**: Ensure snapshots are dropped before mutations:
+**The structural rule** (see `crates/CLAUDE.md` "Snapshot/Host Lock Discipline"): `Analysis` snapshots and `AnalysisHost` must not share any non-Salsa lock. If you need snapshot-visible data, put it in a Salsa input. If you find yourself adding an `Arc<RwLock<...>>` to `AnalysisHost` whose contents a snapshot would also read, **stop and reach for a `#[salsa::input]` instead**.
+
+**The lifecycle rule** still applies for code that explicitly mixes snapshots and mutations on the same task:
 
 ```rust
 // WRONG
-let snapshot = db.clone();
+let snapshot = host.snapshot();
 let result = snapshot.some_query();
-db.set_input(...); // Deadlock!
+host.add_file(...); // Hangs: snapshot still alive on this task
 
 // RIGHT
 let result = {
-    let snapshot = db.clone();
+    let snapshot = host.snapshot();
     snapshot.some_query()
 }; // snapshot dropped
-db.set_input(...); // Safe
+host.add_file(...); // Safe
 ```
+
+The regression test for the structural fix is `crates/lsp/src/workspace.rs::test_concurrent_snapshot_lookups_during_writer` — run it locally if you suspect a new shared-lock deadlock has crept in.
 
 ### Incorrect Diagnostics
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,6 @@ dependencies = [
  "graphql-introspect",
  "graphql-linter",
  "graphql-syntax",
- "parking_lot",
  "salsa",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ strsim = "0.11"
 
 # Utilities
 dashmap = "6.1"
-parking_lot = "0.12"
 
 # Logging and Tracing
 tracing = "0.1"

--- a/benches/benches/incremental_computation.rs
+++ b/benches/benches/incremental_computation.rs
@@ -2,12 +2,23 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use graphql_base_db::{
-    DocumentKind, FileContent, FileId, FileMetadata, FileUri, Language, ProjectFiles,
+    DocumentKind, FileContent, FileId, FileMetadata, FilePathMap, FileUri, Language, ProjectFiles,
 };
 use graphql_ide::AnalysisHost;
 use graphql_ide_db::RootDatabase;
 use salsa::Setter;
 use std::sync::Arc;
+
+/// Empty `FilePathMap` for bench fixtures that don't exercise path lookups.
+/// The benches operate on `FileId`s directly via Salsa queries, so the
+/// URI ↔ `FileId` map can be empty.
+fn empty_file_path_map(db: &RootDatabase) -> FilePathMap {
+    FilePathMap::new(
+        db,
+        Arc::new(std::collections::HashMap::new()),
+        Arc::new(std::collections::HashMap::new()),
+    )
+}
 
 // Sample GraphQL schema for benchmarks
 const SAMPLE_SCHEMA: &str = r"
@@ -97,7 +108,13 @@ fn create_project_files(db: &mut RootDatabase) -> ProjectFiles {
     file_entries.insert(schema_id, schema_entry);
     file_entries.insert(doc_id, doc_entry);
     let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-    ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    ProjectFiles::new(
+        db,
+        schema_file_ids,
+        document_file_ids,
+        file_entry_map,
+        empty_file_path_map(db),
+    )
 }
 
 /// Parse benchmarks
@@ -224,8 +241,13 @@ fn bench_golden_invariant(c: &mut Criterion) {
                 file_entries.insert(doc_id, doc_entry);
                 let file_entry_map =
                     graphql_base_db::FileEntryMap::new(&db, Arc::new(file_entries));
-                let project_files =
-                    ProjectFiles::new(&db, schema_file_ids, document_file_ids, file_entry_map);
+                let project_files = ProjectFiles::new(
+                    &db,
+                    schema_file_ids,
+                    document_file_ids,
+                    file_entry_map,
+                    empty_file_path_map(&db),
+                );
 
                 // Cache schema types
                 let _ = graphql_hir::schema_types(&db, project_files);
@@ -320,8 +342,13 @@ fn bench_per_file_granular_caching(c: &mut Criterion) {
                     graphql_base_db::DocumentFileIds::new(&db, Arc::new(vec![doc1_id, doc2_id]));
                 let file_entry_map = graphql_base_db::FileEntryMap::new(&db, Arc::new(entry_map));
 
-                let project_files =
-                    ProjectFiles::new(&db, schema_file_ids, document_file_ids, file_entry_map);
+                let project_files = ProjectFiles::new(
+                    &db,
+                    schema_file_ids,
+                    document_file_ids,
+                    file_entry_map,
+                    empty_file_path_map(&db),
+                );
 
                 // Warm caches for all files
                 let _ = graphql_hir::all_fragments(&db, project_files);
@@ -387,8 +414,13 @@ fn bench_fragment_resolution_cold(c: &mut Criterion) {
                 file_entries.insert(doc_id, doc_entry);
                 let file_entry_map =
                     graphql_base_db::FileEntryMap::new(&db, Arc::new(file_entries));
-                let project_files =
-                    ProjectFiles::new(&db, schema_file_ids, document_file_ids, file_entry_map);
+                let project_files = ProjectFiles::new(
+                    &db,
+                    schema_file_ids,
+                    document_file_ids,
+                    file_entry_map,
+                    empty_file_path_map(&db),
+                );
 
                 (db, project_files)
             },
@@ -435,8 +467,13 @@ fn bench_fragment_resolution_warm(c: &mut Criterion) {
         file_entries.insert(schema_id, schema_entry);
         file_entries.insert(doc_id, doc_entry);
         let file_entry_map = graphql_base_db::FileEntryMap::new(&db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(&db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            &db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            empty_file_path_map(&db),
+        );
 
         let _ = graphql_hir::all_fragments(&db, project_files);
 

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -72,3 +72,20 @@ These features must NOT be removed or degraded:
 - Prefer typed accessor methods on `WorkspaceManager` (e.g., `get_host`, `all_hosts`, `projects_for_workspace`) over direct field access — these enforce the clone-before-await contract by returning owned values
 - The `hosts` field on `WorkspaceManager` is private for this reason; all callers must go through the typed API
 - Same applies to `std::sync::Mutex`, `parking_lot::RwLock`, and any other non-`tokio::sync` lock type
+
+## Snapshot/Host Lock Discipline
+
+**`Analysis` snapshots and `AnalysisHost` MUST NOT share any non-Salsa lock.**
+
+Salsa setters block until all outstanding `db.clone()` snapshots are dropped. If a snapshot reaches back into the host through any other lock (parking_lot, std::sync, tokio::sync — doesn't matter), you have a lock-ordering cycle waiting to happen:
+
+1. Snapshot holds a Salsa db clone, acquires the side-channel lock for a lookup.
+2. Host writer wants the side-channel lock for write, parks behind the snapshot.
+3. Eventually the snapshot tries to reacquire the side-channel lock for its next lookup; with a writer queued, it parks too.
+4. Writer's Salsa setter is now waiting on the snapshot to drop. Snapshot is waiting on the writer to release the lock. **Deadlock between two `spawn_blocking` workers.**
+
+The fix is structural: any state that snapshots need to read must live **inside Salsa** as an input or tracked query, not behind a side-channel lock. URI ↔ FileId resolution lives in the `FilePathMap` Salsa input (`crates/base-db/src/lib.rs`); file content + metadata live in `FileEntryMap`. Snapshots access both through the `DbFiles` adapter (`crates/ide/src/db_files.rs`), which only takes a `&dyn salsa::Database`. There is no `FileRegistry` reference, no `Arc<RwLock<...>>`, nothing the snapshot can park on except Salsa itself.
+
+**If you find yourself wanting to add an `Arc<RwLock<X>>` field to `AnalysisHost` that snapshots will also read, stop and put `X` in a Salsa input instead.** This was the root cause of #779, #784, #949, and the architectural fix that finally killed the class. The historical incident is documented in the `salsa.md` SME agent under "Pitfall 2".
+
+The `tokio::sync::Mutex<AnalysisHost>` in `ProjectHost` is fine and required — it serializes writers and is on the async side, so snapshots never touch it. The bad pattern is a _parking_lot_ (or any sync) lock that both sides hold.

--- a/crates/analysis/src/project_lints.rs
+++ b/crates/analysis/src/project_lints.rs
@@ -654,7 +654,18 @@ mod tests {
         let document_file_ids = DocumentFileIds::new(db, Arc::new(doc_ids));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
 
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        let file_path_map = graphql_base_db::FilePathMap::new(
+            db,
+            Arc::new(std::collections::HashMap::new()),
+            Arc::new(std::collections::HashMap::new()),
+        );
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            file_path_map,
+        )
     }
 
     #[test]

--- a/crates/analysis/tests/analysis_tests.rs
+++ b/crates/analysis/tests/analysis_tests.rs
@@ -1941,7 +1941,17 @@ fn create_tracked_project_files(
     let document_file_ids = DocumentFileIds::new(db, Arc::new(doc_ids));
     let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
 
-    graphql_base_db::ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    graphql_base_db::ProjectFiles::new(
+        db,
+        schema_file_ids,
+        document_file_ids,
+        file_entry_map,
+        graphql_base_db::FilePathMap::new(
+            db,
+            std::sync::Arc::new(std::collections::HashMap::new()),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        ),
+    )
 }
 
 #[test]

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -99,12 +99,31 @@ pub struct FileEntryMap {
     pub entries: Arc<HashMap<FileId, FileEntry>>,
 }
 
+/// Input: Bidirectional URI ↔ FileId map.
+///
+/// Lives in Salsa rather than behind a side-channel `RwLock` so that snapshots
+/// can resolve paths through `&db` instead of reaching back into the host. This
+/// is what makes `Analysis` snapshots truly immutable: they observe the path
+/// table at their snapshot revision, not the host's live state.
+///
+/// This input changes ONLY when files are added or removed. Content edits do
+/// not bump it, so path-lookup queries stay cached across keystroke edits.
+#[salsa::input]
+pub struct FilePathMap {
+    /// URI string → FileId. Keys are `Arc<str>` so we can interchange with
+    /// `FileUri` / the IDE's `FilePath` without copying.
+    pub uri_to_id: Arc<HashMap<Arc<str>, FileId>>,
+    /// FileId → URI string (reverse direction).
+    pub id_to_uri: Arc<HashMap<FileId, Arc<str>>>,
+}
+
 /// Input: Project file tracking with granular inputs
 /// This struct provides access to both file identity (stable) and file content (dynamic).
 ///
 /// Queries should choose their dependencies carefully:
 /// - Depend on `schema_file_ids` or `document_file_ids` for "what files exist" (stable)
 /// - Depend on `file_entry_map` for per-file granular lookup
+/// - Depend on `file_path_map` for URI ↔ FileId resolution
 /// - Call per-file queries with specific `FileContent` to get per-file caching
 #[salsa::input]
 pub struct ProjectFiles {
@@ -115,6 +134,8 @@ pub struct ProjectFiles {
     /// Per-file entry map for granular invalidation
     /// Each `FileEntry` can be updated independently without invalidating other files
     pub file_entry_map: FileEntryMap,
+    /// URI ↔ FileId resolution. Stable across content edits.
+    pub file_path_map: FilePathMap,
 }
 
 /// Query to look up a single file's content and metadata.
@@ -133,6 +154,45 @@ pub fn file_lookup(
     let entries = file_entry_map.entries(db);
     let entry = entries.get(&file_id)?;
     Some((entry.content(db), entry.metadata(db)))
+}
+
+/// Resolve a URI string to its `FileId`, if any.
+///
+/// Backed by the `FilePathMap` Salsa input. Returns `None` if the file is not
+/// in the project. Cached against `FilePathMap`, so unaffected by content edits.
+#[salsa::tracked]
+pub fn file_id_for_uri(
+    db: &dyn salsa::Database,
+    project_files: ProjectFiles,
+    uri: Arc<str>,
+) -> Option<FileId> {
+    let path_map = project_files.file_path_map(db);
+    path_map.uri_to_id(db).get(&uri).copied()
+}
+
+/// Resolve a `FileId` back to its URI string, if any.
+#[salsa::tracked]
+pub fn uri_for_file_id(
+    db: &dyn salsa::Database,
+    project_files: ProjectFiles,
+    file_id: FileId,
+) -> Option<Arc<str>> {
+    let path_map = project_files.file_path_map(db);
+    path_map.id_to_uri(db).get(&file_id).cloned()
+}
+
+/// Return all `FileId`s currently registered in the project.
+///
+/// Cheaper than iterating `schema_file_ids` and `document_file_ids` separately
+/// when the caller doesn't care about the kind split.
+#[salsa::tracked]
+pub fn all_file_ids(
+    db: &dyn salsa::Database,
+    project_files: ProjectFiles,
+) -> Arc<Vec<FileId>> {
+    let path_map = project_files.file_path_map(db);
+    let ids: Vec<FileId> = path_map.id_to_uri(db).keys().copied().collect();
+    Arc::new(ids)
 }
 
 #[cfg(test)]

--- a/crates/base-db/src/lib.rs
+++ b/crates/base-db/src/lib.rs
@@ -160,7 +160,11 @@ pub fn file_lookup(
 ///
 /// Backed by the `FilePathMap` Salsa input. Returns `None` if the file is not
 /// in the project. Cached against `FilePathMap`, so unaffected by content edits.
+///
+/// Salsa tracked queries require owned key arguments, so `uri` is taken by
+/// value even though we only borrow it for the lookup.
 #[salsa::tracked]
+#[allow(clippy::needless_pass_by_value)]
 pub fn file_id_for_uri(
     db: &dyn salsa::Database,
     project_files: ProjectFiles,
@@ -186,10 +190,7 @@ pub fn uri_for_file_id(
 /// Cheaper than iterating `schema_file_ids` and `document_file_ids` separately
 /// when the caller doesn't care about the kind split.
 #[salsa::tracked]
-pub fn all_file_ids(
-    db: &dyn salsa::Database,
-    project_files: ProjectFiles,
-) -> Arc<Vec<FileId>> {
+pub fn all_file_ids(db: &dyn salsa::Database, project_files: ProjectFiles) -> Arc<Vec<FileId>> {
     let path_map = project_files.file_path_map(db);
     let ids: Vec<FileId> = path_map.id_to_uri(db).keys().copied().collect();
     Arc::new(ids)

--- a/crates/hir/tests/hir_tests.rs
+++ b/crates/hir/tests/hir_tests.rs
@@ -717,7 +717,17 @@ mod caching_tests {
         let document_file_ids = DocumentFileIds::new(db, Arc::new(doc_ids));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
 
-        graphql_base_db::ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        graphql_base_db::ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                std::sync::Arc::new(std::collections::HashMap::new()),
+                std::sync::Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]
@@ -1744,7 +1754,17 @@ mod issue_646_per_file_linting {
         let document_file_ids = DocumentFileIds::new(db, Arc::new(doc_ids));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
 
-        graphql_base_db::ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        graphql_base_db::ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                std::sync::Arc::new(std::collections::HashMap::new()),
+                std::sync::Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -28,9 +28,6 @@ glob = { workspace = true }
 # Error handling
 anyhow = { workspace = true }
 
-# Concurrency - parking_lot::RwLock never poisons, preventing cascading panics
-parking_lot = { workspace = true }
-
 # Internal crates (query-based layers)
 graphql-base-db = { path = "../base-db" }
 graphql-syntax = { path = "../syntax" }

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -71,6 +71,24 @@ impl Drop for Analysis {
 }
 
 impl Analysis {
+    /// Resolve a `FilePath` to its `(FileContent, FileMetadata)` via Salsa.
+    ///
+    /// Returns `None` if the file is not in the project. Goes through the
+    /// `FilePathMap` salsa input rather than `self.registry.read()` so that
+    /// snapshots never take a parking_lot lock — the lock-ordering deadlock
+    /// against the host's Salsa setter cannot occur.
+    fn lookup_file(
+        &self,
+        path: &FilePath,
+    ) -> Option<(graphql_base_db::FileId, graphql_base_db::FileContent, graphql_base_db::FileMetadata)>
+    {
+        let project_files = self.project_files?;
+        let uri: std::sync::Arc<str> = std::sync::Arc::from(path.as_str());
+        let file_id = graphql_base_db::file_id_for_uri(&self.db, project_files, uri)?;
+        let (content, metadata) = graphql_base_db::file_lookup(&self.db, project_files, file_id)?;
+        Some((file_id, content, metadata))
+    }
+
     /// Get diagnostics for a file
     ///
     /// Returns syntax errors, validation errors, and lint warnings.
@@ -81,22 +99,8 @@ impl Analysis {
         fields(uri = %file.as_str())
     )]
     pub fn diagnostics(&self, file: &FilePath) -> Vec<Diagnostic> {
-        let (content, metadata) = {
-            let registry = self.registry.read();
-
-            let Some(file_id) = registry.get_file_id(file) else {
-                return Vec::new();
-            };
-
-            let Some(content) = registry.get_content(file_id) else {
-                return Vec::new();
-            };
-            let Some(metadata) = registry.get_metadata(file_id) else {
-                return Vec::new();
-            };
-            drop(registry);
-
-            (content, metadata)
+        let Some((_, content, metadata)) = self.lookup_file(file) else {
+            return Vec::new();
         };
 
         let analysis_diagnostics =
@@ -139,11 +143,7 @@ impl Analysis {
         };
 
         let (is_schema, is_document, changed_file_id) = {
-            let registry = self.registry.read();
-            let Some(file_id) = registry.get_file_id(changed_file) else {
-                return result;
-            };
-            let Some(metadata) = registry.get_metadata(file_id) else {
+            let Some((file_id, _, metadata)) = self.lookup_file(changed_file) else {
                 return result;
             };
             (
@@ -353,22 +353,8 @@ impl Analysis {
     /// Returns only GraphQL spec validation errors, not custom lint rule violations.
     /// Use this for the `validate` command to avoid duplicating lint checks.
     pub fn validation_diagnostics(&self, file: &FilePath) -> Vec<Diagnostic> {
-        let (content, metadata) = {
-            let registry = self.registry.read();
-
-            let Some(file_id) = registry.get_file_id(file) else {
-                return Vec::new();
-            };
-
-            let Some(content) = registry.get_content(file_id) else {
-                return Vec::new();
-            };
-            let Some(metadata) = registry.get_metadata(file_id) else {
-                return Vec::new();
-            };
-            drop(registry);
-
-            (content, metadata)
+        let Some((_, content, metadata)) = self.lookup_file(file) else {
+            return Vec::new();
         };
 
         let analysis_diagnostics = graphql_analysis::file_validation_diagnostics(
@@ -388,22 +374,8 @@ impl Analysis {
     ///
     /// Returns only custom lint rule violations, not GraphQL spec validation errors.
     pub fn lint_diagnostics(&self, file: &FilePath) -> Vec<Diagnostic> {
-        let (content, metadata) = {
-            let registry = self.registry.read();
-
-            let Some(file_id) = registry.get_file_id(file) else {
-                return Vec::new();
-            };
-
-            let Some(content) = registry.get_content(file_id) else {
-                return Vec::new();
-            };
-            let Some(metadata) = registry.get_metadata(file_id) else {
-                return Vec::new();
-            };
-            drop(registry);
-
-            (content, metadata)
+        let Some((_, content, metadata)) = self.lookup_file(file) else {
+            return Vec::new();
         };
 
         let lint_diagnostics = graphql_analysis::lint_integration::lint_file(
@@ -570,22 +542,8 @@ impl Analysis {
         &self,
         file: &FilePath,
     ) -> Vec<graphql_linter::LintDiagnostic> {
-        let (content, metadata) = {
-            let registry = self.registry.read();
-
-            let Some(file_id) = registry.get_file_id(file) else {
-                return Vec::new();
-            };
-
-            let Some(content) = registry.get_content(file_id) else {
-                return Vec::new();
-            };
-            let Some(metadata) = registry.get_metadata(file_id) else {
-                return Vec::new();
-            };
-            drop(registry);
-
-            (content, metadata)
+        let Some((_, content, metadata)) = self.lookup_file(file) else {
+            return Vec::new();
         };
 
         graphql_analysis::lint_integration::lint_file_with_fixes(

--- a/crates/ide/src/analysis.rs
+++ b/crates/ide/src/analysis.rs
@@ -2,13 +2,11 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-
 /// Global counter for cloned snapshot IDs.
 static CLONE_SNAPSHOT_ID: AtomicU64 = AtomicU64::new(1_000_000);
 
 use crate::database::IdeDatabase;
-use crate::file_registry::FileRegistry;
+use crate::db_files::DbFiles;
 use crate::helpers::{adjust_range_for_line_offset, convert_diagnostic, offset_range_to_range};
 use crate::symbol::{find_fragment_definition_full_range, find_operation_definition_ranges};
 use crate::types::{
@@ -23,22 +21,23 @@ use crate::{
     SemanticToken,
 };
 
-/// Immutable snapshot of the analysis state
+/// Immutable snapshot of the analysis state.
 ///
-/// Can be cheaply cloned and used from multiple threads.
-/// All IDE feature queries go through this.
+/// Cheap to clone and safe to use from multiple threads. All IDE feature
+/// queries go through this. Lookups (path → `FileId`, `FileId` → content,
+/// etc.) resolve through Salsa inputs (`FilePathMap`, `FileEntryMap`); the
+/// snapshot never reaches back into the host through a side-channel lock.
 ///
 /// # Lifecycle Warning
 ///
-/// This snapshot shares Salsa storage with its parent [`AnalysisHost`](crate::AnalysisHost).
-/// **You must drop all `Analysis` instances before calling any mutating method**
-/// on the host (like `add_file`, `remove_file`, etc.). Failure to do so will
-/// cause a hang/deadlock due to Salsa's single-writer, multi-reader model.
+/// This snapshot shares Salsa storage with its parent
+/// [`AnalysisHost`](crate::AnalysisHost). **You must drop all `Analysis`
+/// instances before calling any mutating method on the host.** Salsa setters
+/// block until all outstanding snapshots have been dropped.
 pub struct Analysis {
     pub(crate) db: IdeDatabase,
-    pub(crate) registry: Arc<RwLock<FileRegistry>>,
-    /// Cached `ProjectFiles` for HIR queries
-    /// This is fetched from the registry when the snapshot is created
+    /// Cached `ProjectFiles` snapshot, captured at the moment this `Analysis`
+    /// was created. Drives all file lookups via Salsa-tracked queries.
     pub(crate) project_files: Option<graphql_base_db::ProjectFiles>,
     /// Unique ID for tracking snapshot lifecycle in logs
     pub(crate) snapshot_id: u64,
@@ -54,7 +53,6 @@ impl Clone for Analysis {
         );
         Self {
             db: self.db.clone(),
-            registry: Arc::clone(&self.registry),
             project_files: self.project_files,
             snapshot_id: clone_id,
         }
@@ -75,13 +73,16 @@ impl Analysis {
     ///
     /// Returns `None` if the file is not in the project. Goes through the
     /// `FilePathMap` salsa input rather than `self.registry.read()` so that
-    /// snapshots never take a parking_lot lock — the lock-ordering deadlock
+    /// snapshots never take a `parking_lot` lock — the lock-ordering deadlock
     /// against the host's Salsa setter cannot occur.
     fn lookup_file(
         &self,
         path: &FilePath,
-    ) -> Option<(graphql_base_db::FileId, graphql_base_db::FileContent, graphql_base_db::FileMetadata)>
-    {
+    ) -> Option<(
+        graphql_base_db::FileId,
+        graphql_base_db::FileContent,
+        graphql_base_db::FileMetadata,
+    )> {
         let project_files = self.project_files?;
         let uri: std::sync::Arc<str> = std::sync::Arc::from(path.as_str());
         let file_id = graphql_base_db::file_id_for_uri(&self.db, project_files, uri)?;
@@ -156,7 +157,7 @@ impl Analysis {
         if is_schema {
             // Schema change: re-validate all document files
             let document_files: Vec<FilePath> = {
-                let registry = self.registry.read();
+                let registry = DbFiles::new(&self.db, self.project_files);
                 registry
                     .all_file_ids()
                     .into_iter()
@@ -225,7 +226,7 @@ impl Analysis {
         changed_file_id: graphql_base_db::FileId,
         project_files: graphql_base_db::ProjectFiles,
     ) -> Vec<FilePath> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
 
         // Get fragments and operations defined in the changed file
         let (content, metadata) = {
@@ -393,8 +394,8 @@ impl Analysis {
     /// Returns tokens for syntax highlighting with semantic information,
     /// including deprecation status for fields.
     pub fn semantic_tokens(&self, file: &FilePath) -> Vec<SemanticToken> {
-        let registry = self.registry.read();
-        semantic_tokens::semantic_tokens(&self.db, &registry, self.project_files, file)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        semantic_tokens::semantic_tokens(&self.db, registry, self.project_files, file)
     }
 
     /// Get folding ranges for a file
@@ -405,8 +406,8 @@ impl Analysis {
     /// - Selection sets
     /// - Block comments
     pub fn folding_ranges(&self, file: &FilePath) -> Vec<FoldingRange> {
-        let registry = self.registry.read();
-        folding_ranges::folding_ranges(&self.db, &registry, file)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        folding_ranges::folding_ranges(&self.db, registry, file)
     }
 
     /// Get inlay hints for a file within an optional range.
@@ -416,8 +417,8 @@ impl Analysis {
     ///
     /// If `range` is provided, only returns hints within that range for efficiency.
     pub fn inlay_hints(&self, file: &FilePath, range: Option<Range>) -> Vec<InlayHint> {
-        let registry = self.registry.read();
-        inlay_hints::inlay_hints(&self.db, &registry, self.project_files, file, range)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        inlay_hints::inlay_hints(&self.db, registry, self.project_files, file, range)
     }
 
     /// Get project-wide lint diagnostics (e.g., unused fields, unique names)
@@ -431,7 +432,7 @@ impl Analysis {
         );
 
         let mut results = HashMap::new();
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
 
         for (file_id, diagnostics) in diagnostics_by_file_id.iter() {
             if let Some(file_path) = registry.get_path(*file_id) {
@@ -460,7 +461,7 @@ impl Analysis {
 
         // Get all registered files
         let all_file_paths: Vec<FilePath> = {
-            let registry = self.registry.read();
+            let registry = DbFiles::new(&self.db, self.project_files);
             registry
                 .all_file_ids()
                 .into_iter()
@@ -567,7 +568,7 @@ impl Analysis {
             );
 
         let mut results = HashMap::new();
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
 
         for (file_id, diagnostics) in diagnostics_by_file_id {
             if let Some(file_path) = registry.get_path(file_id) {
@@ -584,7 +585,7 @@ impl Analysis {
     ///
     /// Returns the text content of the file if it exists in the registry.
     pub fn file_content(&self, file: &FilePath) -> Option<String> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         let file_id = registry.get_file_id(file)?;
         let content = registry.get_content(file_id)?;
         Some(content.text(&self.db).to_string())
@@ -658,7 +659,7 @@ impl Analysis {
 
         for operation in operations.iter() {
             // Get file information for this operation
-            let registry = self.registry.read();
+            let registry = DbFiles::new(&self.db, self.project_files);
             let Some(file_path) = registry.get_path(operation.file_id) else {
                 continue;
             };
@@ -668,7 +669,6 @@ impl Analysis {
             let Some(metadata) = registry.get_metadata(operation.file_id) else {
                 continue;
             };
-            drop(registry);
 
             // Get operation body
             let body = graphql_hir::operation_body(&self.db, content, metadata, operation.index);
@@ -744,32 +744,32 @@ impl Analysis {
     ///
     /// Returns a list of completion items appropriate for the context.
     pub fn completions(&self, file: &FilePath, position: Position) -> Option<Vec<CompletionItem>> {
-        let registry = self.registry.read();
-        completion::completions(&self.db, &registry, self.project_files, file, position)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        completion::completions(&self.db, registry, self.project_files, file, position)
     }
 
     /// Get hover information at a position
     ///
     /// Returns documentation, type information, etc.
     pub fn hover(&self, file: &FilePath, position: Position) -> Option<HoverResult> {
-        let registry = self.registry.read();
-        hover::hover(&self.db, &registry, self.project_files, file, position)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        hover::hover(&self.db, registry, self.project_files, file, position)
     }
 
     /// Get signature help at a position
     ///
     /// Returns argument information when inside a field or directive argument list.
     pub fn signature_help(&self, file: &FilePath, position: Position) -> Option<SignatureHelp> {
-        let registry = self.registry.read();
-        signature_help::signature_help(&self.db, &registry, self.project_files, file, position)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        signature_help::signature_help(&self.db, registry, self.project_files, file, position)
     }
 
     /// Get goto definition locations for the symbol at a position
     ///
     /// Returns the definition location(s) for types, fields, fragments, etc.
     pub fn goto_definition(&self, file: &FilePath, position: Position) -> Option<Vec<Location>> {
-        let registry = self.registry.read();
-        goto_definition::goto_definition(&self.db, &registry, self.project_files, file, position)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        goto_definition::goto_definition(&self.db, registry, self.project_files, file, position)
     }
 
     /// Find all references to the symbol at a position
@@ -781,10 +781,10 @@ impl Analysis {
         position: Position,
         include_declaration: bool,
     ) -> Option<Vec<Location>> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         references::find_references(
             &self.db,
-            &registry,
+            registry,
             self.project_files,
             file,
             position,
@@ -794,8 +794,8 @@ impl Analysis {
 
     /// Check if the symbol at a position can be renamed, returning its range.
     pub fn prepare_rename(&self, file: &FilePath, position: Position) -> Option<Range> {
-        let registry = self.registry.read();
-        rename::prepare_rename(&self.db, &registry, file, position)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        rename::prepare_rename(&self.db, registry, file, position)
     }
 
     /// Rename the symbol at a position to a new name.
@@ -805,10 +805,10 @@ impl Analysis {
         position: Position,
         new_name: &str,
     ) -> Option<RenameResult> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         rename::rename(
             &self.db,
-            &registry,
+            registry,
             self.project_files,
             file,
             position,
@@ -822,10 +822,10 @@ impl Analysis {
         fragment_name: &str,
         include_declaration: bool,
     ) -> Vec<Location> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         references::find_fragment_references(
             &self.db,
-            &registry,
+            registry,
             self.project_files,
             fragment_name,
             include_declaration,
@@ -843,8 +843,8 @@ impl Analysis {
         file: &FilePath,
         positions: &[Position],
     ) -> Vec<Option<SelectionRange>> {
-        let registry = self.registry.read();
-        selection_range::selection_ranges(&self.db, &registry, file, positions)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        selection_range::selection_ranges(&self.db, registry, file, positions)
     }
 
     /// Get code lenses for deprecated fields in a schema file
@@ -852,8 +852,8 @@ impl Analysis {
     /// Returns code lens information for each deprecated field definition,
     /// including the usage count and locations for navigation.
     pub fn deprecated_field_code_lenses(&self, file: &FilePath) -> Vec<CodeLensInfo> {
-        let registry = self.registry.read();
-        code_lenses::deprecated_field_code_lenses(&self.db, &registry, self.project_files, file)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        code_lenses::deprecated_field_code_lenses(&self.db, registry, self.project_files, file)
     }
 
     /// Get document symbols for a file (hierarchical outline)
@@ -861,8 +861,8 @@ impl Analysis {
     /// Returns types, operations, and fragments with their fields as children.
     /// This powers the "Go to Symbol in Editor" (Cmd+Shift+O) feature.
     pub fn document_symbols(&self, file: &FilePath) -> Vec<DocumentSymbol> {
-        let registry = self.registry.read();
-        symbols::document_symbols(&self.db, &registry, file)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        symbols::document_symbols(&self.db, registry, file)
     }
 
     /// Search for workspace symbols matching a query
@@ -870,8 +870,8 @@ impl Analysis {
     /// Returns matching types, operations, and fragments across all files.
     /// This powers the "Go to Symbol in Workspace" (Cmd+T) feature.
     pub fn workspace_symbols(&self, query: &str) -> Vec<WorkspaceSymbol> {
-        let registry = self.registry.read();
-        symbols::workspace_symbols(&self.db, &registry, self.project_files, query)
+        let registry = DbFiles::new(&self.db, self.project_files);
+        symbols::workspace_symbols(&self.db, registry, self.project_files, query)
     }
 
     /// Get schema statistics
@@ -910,15 +910,13 @@ impl Analysis {
             };
 
             // Skip built-in directive files
-            let registry = self.registry.read();
+            let registry = DbFiles::new(&self.db, self.project_files);
             if let Some(path) = registry.get_path(*file_id) {
                 let path_str = path.as_str();
                 if path_str == "client_builtins.graphql" || path_str == "schema_builtins.graphql" {
-                    drop(registry);
                     continue;
                 }
             }
-            drop(registry);
 
             let parse = graphql_syntax::parse(&self.db, content, metadata);
             // Count directive definitions by checking if the definition is a directive
@@ -982,11 +980,10 @@ impl Analysis {
         &self,
         fragment: &graphql_hir::FragmentStructure,
     ) -> Option<(FilePath, Range)> {
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         let file_path = registry.get_path(fragment.file_id)?;
         let content = registry.get_content(fragment.file_id)?;
         let metadata = registry.get_metadata(fragment.file_id)?;
-        drop(registry);
 
         let parse = graphql_syntax::parse(&self.db, content, metadata);
 
@@ -1045,10 +1042,10 @@ impl Analysis {
     /// Returns code lenses for fragment definitions showing reference counts.
     pub fn code_lenses(&self, file: &FilePath) -> Vec<CodeLens> {
         let fragment_usages = self.fragment_usages();
-        let registry = self.registry.read();
+        let registry = DbFiles::new(&self.db, self.project_files);
         code_lenses::code_lenses(
             &self.db,
-            &registry,
+            registry,
             self.project_files,
             file,
             &fragment_usages,

--- a/crates/ide/src/code_lenses.rs
+++ b/crates/ide/src/code_lenses.rs
@@ -8,14 +8,14 @@ use crate::helpers::{adjust_range_for_line_offset, offset_range_to_range};
 use crate::references::find_field_references;
 use crate::symbol::find_fragment_definition_full_range;
 use crate::types::{CodeLens, CodeLensCommand, CodeLensInfo, FilePath, FragmentUsage};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get code lenses for a file.
 ///
 /// Returns code lenses for fragment definitions showing reference counts.
 pub fn code_lenses(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     fragment_usages: &[FragmentUsage],
@@ -87,7 +87,7 @@ pub fn code_lenses(
 /// including the usage count and locations for navigation.
 pub fn deprecated_field_code_lenses(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
 ) -> Vec<CodeLensInfo> {

--- a/crates/ide/src/completion.rs
+++ b/crates/ide/src/completion.rs
@@ -17,14 +17,14 @@ use crate::symbol::{
     find_parent_type_at_offset, find_symbol_at_offset, is_in_selection_set, Symbol,
 };
 use crate::types::{CompletionItem, CompletionKind, FilePath, InsertTextFormat, Position};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get completions at a position.
 ///
 /// Returns a list of completion items appropriate for the context.
 pub fn completions(
     db: &dyn graphql_hir::GraphQLHirDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,

--- a/crates/ide/src/db_files.rs
+++ b/crates/ide/src/db_files.rs
@@ -1,0 +1,62 @@
+//! Salsa-backed view over project files for IDE feature modules.
+//!
+//! Replaces the old `&FileRegistry` parameter that feature modules took. Every
+//! lookup goes through `&dyn salsa::Database` and the `FilePathMap` /
+//! `FileEntryMap` salsa inputs, so `Analysis` snapshots no longer need to
+//! reach back into the host through a `parking_lot` `RwLock` to resolve URIs.
+//!
+//! This is what makes the deadlock cycle structurally impossible: there is no
+//! second lock that a snapshot can park on while the host's Salsa setter waits
+//! for the snapshot to drop.
+
+use std::sync::Arc;
+
+use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
+
+use crate::FilePath;
+
+/// Read-only view over the project's files, backed entirely by Salsa.
+///
+/// Exposes the same `get_file_id` / `get_path` / `get_content` / `get_metadata`
+/// / `all_file_ids` surface that feature modules previously accessed via
+/// `&FileRegistry`. Cheap to construct and `Copy`.
+#[derive(Copy, Clone)]
+pub struct DbFiles<'a> {
+    db: &'a dyn salsa::Database,
+    project_files: Option<ProjectFiles>,
+}
+
+impl<'a> DbFiles<'a> {
+    pub fn new(db: &'a dyn salsa::Database, project_files: Option<ProjectFiles>) -> Self {
+        Self { db, project_files }
+    }
+
+    pub fn get_file_id(&self, path: &FilePath) -> Option<FileId> {
+        let pf = self.project_files?;
+        let uri: Arc<str> = Arc::from(path.as_str());
+        graphql_base_db::file_id_for_uri(self.db, pf, uri)
+    }
+
+    pub fn get_path(&self, file_id: FileId) -> Option<FilePath> {
+        let pf = self.project_files?;
+        let uri = graphql_base_db::uri_for_file_id(self.db, pf, file_id)?;
+        Some(FilePath::new(uri.as_ref().to_string()))
+    }
+
+    pub fn get_content(&self, file_id: FileId) -> Option<FileContent> {
+        let pf = self.project_files?;
+        graphql_base_db::file_lookup(self.db, pf, file_id).map(|(c, _)| c)
+    }
+
+    pub fn get_metadata(&self, file_id: FileId) -> Option<FileMetadata> {
+        let pf = self.project_files?;
+        graphql_base_db::file_lookup(self.db, pf, file_id).map(|(_, m)| m)
+    }
+
+    pub fn all_file_ids(&self) -> Vec<FileId> {
+        match self.project_files {
+            Some(pf) => graphql_base_db::all_file_ids(self.db, pf).as_ref().clone(),
+            None => Vec::new(),
+        }
+    }
+}

--- a/crates/ide/src/file_registry.rs
+++ b/crates/ide/src/file_registry.rs
@@ -46,7 +46,7 @@ pub struct FileRegistry {
     document_file_ids: Option<DocumentFileIds>,
     /// Per-file entry map for granular invalidation
     file_entry_map: Option<FileEntryMap>,
-    /// URI ↔ FileId resolution stored in Salsa so snapshots can resolve paths
+    /// URI ↔ `FileId` resolution stored in Salsa so snapshots can resolve paths
     /// without taking any side-channel lock.
     file_path_map: Option<FilePathMap>,
     /// The `ProjectFiles` input that tracks all files in the project
@@ -147,18 +147,6 @@ impl FileRegistry {
         self.id_to_uri
             .get(&file_id)
             .map(|s| FilePath::new(s.clone()))
-    }
-
-    /// Get `FileContent` for a file ID
-    #[must_use]
-    pub fn get_content(&self, file_id: FileId) -> Option<FileContent> {
-        self.id_to_content.get(&file_id).copied()
-    }
-
-    /// Get `FileMetadata` for a file ID
-    #[must_use]
-    pub fn get_metadata(&self, file_id: FileId) -> Option<FileMetadata> {
-        self.id_to_metadata.get(&file_id).copied()
     }
 
     /// Remove a file from the registry
@@ -327,12 +315,6 @@ impl FileRegistry {
             ));
         }
     }
-
-    /// Get the `FileEntry` for a file ID
-    #[must_use]
-    pub fn get_entry(&self, file_id: FileId) -> Option<FileEntry> {
-        self.id_to_entry.get(&file_id).copied()
-    }
 }
 
 #[cfg(test)]
@@ -362,10 +344,6 @@ mod tests {
 
         // Should be able to look up by file ID
         assert_eq!(registry.get_path(file_id), Some(path.clone()));
-
-        // Should have content and metadata
-        assert!(registry.get_content(file_id).is_some());
-        assert!(registry.get_metadata(file_id).is_some());
     }
 
     #[test]
@@ -386,7 +364,7 @@ mod tests {
         assert!(is_new1);
 
         // Update same file
-        let (file_id2, _content2, _, is_new2) = registry.add_file(
+        let (file_id2, content2, _, is_new2) = registry.add_file(
             &mut db,
             &path,
             "type Query { world: String }",
@@ -400,12 +378,8 @@ mod tests {
         // Should reuse the same file ID
         assert_eq!(file_id1, file_id2);
 
-        // Content should be updated
-        let updated_content = registry.get_content(file_id2).unwrap();
-        assert_eq!(
-            updated_content.text(&db).as_ref(),
-            "type Query { world: String }"
-        );
+        // Content should be updated (returned FileContent reflects the new text)
+        assert_eq!(content2.text(&db).as_ref(), "type Query { world: String }");
     }
 
     #[test]

--- a/crates/ide/src/file_registry.rs
+++ b/crates/ide/src/file_registry.rs
@@ -17,7 +17,7 @@
 
 use graphql_base_db::{
     DocumentFileIds, DocumentKind, FileContent, FileEntry, FileEntryMap, FileId, FileMetadata,
-    FileUri, Language, ProjectFiles, SchemaFileIds,
+    FilePathMap, FileUri, Language, ProjectFiles, SchemaFileIds,
 };
 use salsa::Setter;
 use std::collections::HashMap;
@@ -46,6 +46,9 @@ pub struct FileRegistry {
     document_file_ids: Option<DocumentFileIds>,
     /// Per-file entry map for granular invalidation
     file_entry_map: Option<FileEntryMap>,
+    /// URI ↔ FileId resolution stored in Salsa so snapshots can resolve paths
+    /// without taking any side-channel lock.
+    file_path_map: Option<FilePathMap>,
     /// The `ProjectFiles` input that tracks all files in the project
     project_files: Option<ProjectFiles>,
 }
@@ -265,6 +268,39 @@ impl FileRegistry {
         };
         self.file_entry_map = Some(file_entry_map);
 
+        // Build the URI ↔ FileId tables. Snapshots will resolve paths via these
+        // through Salsa, never through the registry parking_lot lock.
+        let uri_to_id_map: HashMap<Arc<str>, FileId> = self
+            .uri_to_id
+            .iter()
+            .map(|(k, v)| (Arc::<str>::from(k.as_str()), *v))
+            .collect();
+        let id_to_uri_map: HashMap<FileId, Arc<str>> = self
+            .id_to_uri
+            .iter()
+            .map(|(k, v)| (*k, Arc::<str>::from(v.as_str())))
+            .collect();
+
+        // Create or update the FilePathMap input.
+        // Only bump it when the key set actually changes (file add/remove); pure
+        // content edits leave the URI ↔ FileId mapping untouched and must not
+        // invalidate path-lookup queries.
+        let file_path_map = if let Some(existing) = self.file_path_map {
+            let existing_id_to_uri = existing.id_to_uri(db);
+            let keys_match = existing_id_to_uri.len() == id_to_uri_map.len()
+                && existing_id_to_uri
+                    .keys()
+                    .all(|k| id_to_uri_map.contains_key(k));
+            if !keys_match {
+                existing.set_uri_to_id(db).to(Arc::new(uri_to_id_map));
+                existing.set_id_to_uri(db).to(Arc::new(id_to_uri_map));
+            }
+            existing
+        } else {
+            FilePathMap::new(db, Arc::new(uri_to_id_map), Arc::new(id_to_uri_map))
+        };
+        self.file_path_map = Some(file_path_map);
+
         // Create or update the ProjectFiles input
         // Only update child references if they actually changed
         if let Some(existing) = self.project_files {
@@ -277,6 +313,9 @@ impl FileRegistry {
             if existing.file_entry_map(db) != file_entry_map {
                 existing.set_file_entry_map(db).to(file_entry_map);
             }
+            if existing.file_path_map(db) != file_path_map {
+                existing.set_file_path_map(db).to(file_path_map);
+            }
             self.project_files = Some(existing);
         } else {
             self.project_files = Some(ProjectFiles::new(
@@ -284,6 +323,7 @@ impl FileRegistry {
                 schema_file_ids,
                 document_file_ids,
                 file_entry_map,
+                file_path_map,
             ));
         }
     }

--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -8,7 +8,7 @@
 
 use crate::helpers::{adjust_range_for_line_offset, offset_range_to_range};
 use crate::types::{FilePath, FoldingRange, FoldingRangeKind};
-use crate::FileRegistry;
+use crate::DbFiles;
 use apollo_parser::cst::{CstNode, Definition};
 
 /// Get folding ranges for a file.
@@ -20,7 +20,7 @@ use apollo_parser::cst::{CstNode, Definition};
 /// - Block comments
 pub fn folding_ranges(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
 ) -> Vec<FoldingRange> {
     let Some(file_id) = registry.get_file_id(file) else {

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -14,14 +14,14 @@ use crate::helpers::{
 };
 use crate::symbol::{find_parent_type_at_offset, find_symbol_at_offset, Symbol};
 use crate::types::{FilePath, Location, Position};
-use crate::{helpers::find_block_for_position, symbol, FileRegistry};
+use crate::{helpers::find_block_for_position, symbol, DbFiles};
 
 /// Get goto definition locations for the symbol at a position.
 ///
 /// Returns the definition location(s) for types, fields, fragments, etc.
 pub fn goto_definition(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,

--- a/crates/ide/src/host.rs
+++ b/crates/ide/src/host.rs
@@ -1,19 +1,12 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use parking_lot::RwLock;
 use salsa::Setter;
 
 use graphql_base_db::{DocumentKind, Language};
 
-/// Global counter for unique lock/snapshot IDs in the IDE layer.
-static IDE_LOCK_ID: AtomicU64 = AtomicU64::new(1);
-/// Global counter for snapshot IDs to track creation and drop.
+/// Global counter for snapshot IDs to track creation and drop in logs.
 static SNAPSHOT_ID: AtomicU64 = AtomicU64::new(1);
-
-fn next_ide_lock_id() -> u64 {
-    IDE_LOCK_ID.fetch_add(1, Ordering::Relaxed)
-}
 
 fn next_snapshot_id() -> u64 {
     SNAPSHOT_ID.fetch_add(1, Ordering::Relaxed)
@@ -57,9 +50,13 @@ use crate::types::{
 /// ```
 pub struct AnalysisHost {
     db: IdeDatabase,
-    /// File registry for mapping paths to file IDs
-    /// Wrapped in Arc<RwLock> so snapshots can share it
-    registry: Arc<RwLock<FileRegistry>>,
+    /// File registry for mapping paths to file IDs.
+    ///
+    /// Owned directly (no inner lock) because the outer `tokio::sync::Mutex`
+    /// in `ProjectHost` already serializes mutators, and snapshots no longer
+    /// reach back into the registry — they read everything via Salsa inputs
+    /// (`FilePathMap`, `FileEntryMap`).
+    registry: FileRegistry,
 }
 
 impl AnalysisHost {
@@ -68,18 +65,15 @@ impl AnalysisHost {
     pub fn new() -> Self {
         Self {
             db: IdeDatabase::default(),
-            registry: Arc::new(RwLock::new(FileRegistry::new())),
+            registry: FileRegistry::new(),
         }
     }
 
-    /// Add or update a file in the host
+    /// Add or update a file in the host.
     ///
-    /// This is a convenience method for adding files to the registry and database.
-    ///
-    /// Returns `true` if this is a new file, `false` if it's an update to an existing file.
-    ///
-    /// **IMPORTANT**: Only call `rebuild_project_files()` when this returns `true` (new file).
-    /// Content-only updates do NOT require rebuilding the project index.
+    /// Returns `true` if this is a new file, `false` if it's an update to an
+    /// existing file. New files automatically trigger a `ProjectFiles` rebuild
+    /// so that subsequent `snapshot()` calls observe the new file.
     pub fn add_file(
         &mut self,
         path: &FilePath,
@@ -87,45 +81,32 @@ impl AnalysisHost {
         language: Language,
         document_kind: DocumentKind,
     ) -> bool {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(lock_id, path = %path.as_str(), "add_file: acquiring registry write lock");
-        let mut registry = self.registry.write();
-        tracing::debug!(lock_id, "add_file: acquired registry write lock");
         let (_, _, _, is_new) =
-            registry.add_file(&mut self.db, path, content, language, document_kind);
-        tracing::debug!(lock_id, is_new, "add_file: releasing registry write lock");
+            self.registry
+                .add_file(&mut self.db, path, content, language, document_kind);
+        if is_new {
+            self.sync_project_files();
+        }
         is_new
     }
 
     /// Batch-add pre-discovered files to the host.
     ///
-    /// This is more efficient than calling `add_file` in a loop because
-    /// file I/O has already been done. The lock is only held briefly
-    /// for registration, not during disk reads.
-    ///
-    /// Returns the list of `LoadedFile` structs for building indexes.
+    /// More efficient than calling `add_file` in a loop because the project
+    /// index is rebuilt once at the end instead of after every file.
     pub fn add_discovered_files(&mut self, files: &[DiscoveredFile]) -> Vec<LoadedFile> {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(
-            lock_id,
-            count = files.len(),
-            "add_discovered_files: acquiring registry write lock"
-        );
-        let mut registry = self.registry.write();
-        tracing::debug!(
-            lock_id,
-            "add_discovered_files: acquired registry write lock"
-        );
         let mut loaded = Vec::with_capacity(files.len());
+        let mut any_new = false;
 
         for file in files {
-            registry.add_file(
+            let (_, _, _, is_new) = self.registry.add_file(
                 &mut self.db,
                 &file.path,
                 &file.content,
                 file.language,
                 file.document_kind,
             );
+            any_new = any_new || is_new;
             loaded.push(LoadedFile {
                 path: file.path.clone(),
                 language: file.language,
@@ -133,105 +114,56 @@ impl AnalysisHost {
             });
         }
 
-        tracing::debug!(
-            lock_id,
-            count = loaded.len(),
-            "add_discovered_files: releasing registry write lock"
-        );
+        if any_new {
+            self.sync_project_files();
+        }
         loaded
     }
 
-    /// Rebuild the `ProjectFiles` index after adding/removing files
+    /// Rebuild the `ProjectFiles` Salsa input from the current registry state.
     ///
-    /// This should be called after batch adding files to avoid O(n^2) performance.
-    /// It's relatively expensive as it iterates through all files, so avoid calling
-    /// it in a loop.
-    ///
-    /// This method also syncs the `ProjectFiles` to the database so queries can
-    /// access it via `db.project_files()`.
+    /// Most callers do NOT need to invoke this directly — `add_file`,
+    /// `add_files_batch`, `add_discovered_files`, `remove_file`, and
+    /// `update_file_and_snapshot` all maintain the index automatically. It is
+    /// kept on the public API for backwards compatibility and for the rare
+    /// "I mutated the registry through some other path, please refresh"
+    /// scenario.
     pub fn rebuild_project_files(&mut self) {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(
-            lock_id,
-            "rebuild_project_files: acquiring registry write lock"
-        );
-        let mut registry = self.registry.write();
-        tracing::debug!(
-            lock_id,
-            "rebuild_project_files: acquired registry write lock"
-        );
-        registry.rebuild_project_files(&mut self.db);
-
-        // Sync project_files from registry to database
-        // This enables queries to access project_files via db.project_files()
-        self.db.project_files_input = registry.project_files();
-        tracing::debug!(
-            lock_id,
-            "rebuild_project_files: releasing registry write lock"
-        );
+        self.sync_project_files();
     }
 
-    /// Add multiple files in batch, then rebuild the project index once
-    ///
-    /// This is the recommended way to load multiple files at once. It:
-    /// 1. Adds all files to the registry without rebuilding
-    /// 2. Rebuilds the project index once at the end
-    ///
-    /// This is O(n) instead of O(n^2) compared to calling `add_file` + `rebuild_project_files`
-    /// for each file individually.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// use graphql_ide::{AnalysisHost, FilePath, Language, DocumentKind};
-    ///
-    /// let mut host = AnalysisHost::new();
-    /// let files = vec![
-    ///     (FilePath::new("file:///schema.graphql"), "type Query { hello: String }", Language::GraphQL, DocumentKind::Schema),
-    ///     (FilePath::new("file:///query.graphql"), "query { hello }", Language::GraphQL, DocumentKind::Executable),
-    /// ];
-    /// host.add_files_batch(&files);
-    /// ```
-    pub fn add_files_batch(&mut self, files: &[(FilePath, &str, Language, DocumentKind)]) {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(
-            lock_id,
-            count = files.len(),
-            "add_files_batch: acquiring registry write lock"
-        );
-        let mut registry = self.registry.write();
-        tracing::debug!(lock_id, "add_files_batch: acquired registry write lock");
-        let mut any_new = false;
+    /// Internal: rebuild the `ProjectFiles` index and sync the cached input
+    /// reference on the database.
+    fn sync_project_files(&mut self) {
+        self.registry.rebuild_project_files(&mut self.db);
+        self.db.project_files_input = self.registry.project_files();
+    }
 
+    /// Add multiple files in batch, then rebuild the project index once.
+    ///
+    /// This is O(n) instead of O(n^2) compared to calling `add_file` repeatedly,
+    /// because the `ProjectFiles` Salsa input is rebuilt only once at the end.
+    pub fn add_files_batch(&mut self, files: &[(FilePath, &str, Language, DocumentKind)]) {
+        let mut any_new = false;
         for (path, content, language, document_kind) in files {
             let (_, _, _, is_new) =
-                registry.add_file(&mut self.db, path, content, *language, *document_kind);
+                self.registry
+                    .add_file(&mut self.db, path, content, *language, *document_kind);
             any_new = any_new || is_new;
         }
-
-        // Only rebuild if at least one file was new
         if any_new {
-            registry.rebuild_project_files(&mut self.db);
-            // Sync project_files from registry to database
-            self.db.project_files_input = registry.project_files();
+            self.sync_project_files();
         }
-        tracing::debug!(
-            lock_id,
-            any_new,
-            "add_files_batch: releasing registry write lock"
-        );
     }
 
-    /// Update a file and optionally create a snapshot in a single lock acquisition
+    /// Update a file and create a snapshot in one shot.
     ///
-    /// This is optimized for the common case of editing an existing file. It:
-    /// 1. Updates the file content (cheap operation)
-    /// 2. Returns a snapshot for immediate analysis
+    /// Optimized for `did_change`: if the file already exists, this only bumps
+    /// the file's `FileContent` (no project index rebuild). For a new file
+    /// (`did_open`) it rebuilds the index before snapshotting so the snapshot
+    /// observes the new file.
     ///
-    /// This avoids the overhead of multiple lock acquisitions per keystroke.
-    /// For new files, call `add_file()` followed by `rebuild_project_files()` instead.
-    ///
-    /// Returns `(is_new_file, Analysis)` tuple.
+    /// Returns `(is_new_file, Analysis)`.
     pub fn update_file_and_snapshot(
         &mut self,
         path: &FilePath,
@@ -239,81 +171,27 @@ impl AnalysisHost {
         language: Language,
         document_kind: DocumentKind,
     ) -> (bool, Analysis) {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(lock_id, path = %path.as_str(), "update_file_and_snapshot: acquiring registry write lock");
-        // Single lock acquisition for both operations
-        let mut registry = self.registry.write();
-        tracing::debug!(
-            lock_id,
-            "update_file_and_snapshot: acquired registry write lock"
-        );
         let (_, _, _, is_new) =
-            registry.add_file(&mut self.db, path, content, language, document_kind);
-
-        // If this is a new file, rebuild the index before creating snapshot
-        // This also syncs project_files to self.db.project_files_input
+            self.registry
+                .add_file(&mut self.db, path, content, language, document_kind);
         if is_new {
-            tracing::debug!(
-                lock_id,
-                "update_file_and_snapshot: new file, rebuilding project files"
-            );
-            registry.rebuild_project_files(&mut self.db);
-            // Sync project_files from registry to database
-            self.db.project_files_input = registry.project_files();
+            self.sync_project_files();
         }
-
-        let project_files = self.db.project_files_input;
-        // Release the lock before creating the snapshot (no longer needed)
-        tracing::debug!(
-            lock_id,
-            is_new,
-            "update_file_and_snapshot: releasing registry write lock"
-        );
-        drop(registry);
-
-        let snapshot_id = next_snapshot_id();
-        tracing::debug!(
-            lock_id,
-            snapshot_id,
-            "update_file_and_snapshot: creating Salsa snapshot (db.clone)"
-        );
-        let snapshot = Analysis {
-            db: self.db.clone(),
-            registry: Arc::clone(&self.registry),
-            project_files,
-            snapshot_id,
-        };
-
-        (is_new, snapshot)
+        (is_new, self.snapshot())
     }
 
     /// Check if a file exists in this host's registry
     #[must_use]
     pub fn contains_file(&self, path: &FilePath) -> bool {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(lock_id, path = %path.as_str(), "contains_file: acquiring registry read lock");
-        let registry = self.registry.read();
-        tracing::debug!(lock_id, "contains_file: acquired registry read lock");
-        let result = registry.get_file_id(path).is_some();
-        tracing::debug!(
-            lock_id,
-            result,
-            "contains_file: releasing registry read lock"
-        );
-        result
+        self.registry.get_file_id(path).is_some()
     }
 
     /// Remove a file from the host
     pub fn remove_file(&mut self, path: &FilePath) {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(lock_id, path = %path.as_str(), "remove_file: acquiring registry write lock");
-        let mut registry = self.registry.write();
-        tracing::debug!(lock_id, "remove_file: acquired registry write lock");
-        if let Some(file_id) = registry.get_file_id(path) {
-            registry.remove_file(file_id);
-            registry.rebuild_project_files(&mut self.db);
+        if let Some(file_id) = self.registry.get_file_id(path) {
+            self.registry.remove_file(file_id);
+            self.sync_project_files();
         }
-        tracing::debug!(lock_id, "remove_file: releasing registry write lock");
     }
 
     /// Load schema files from a project configuration
@@ -814,60 +692,31 @@ impl AnalysisHost {
         (loaded_files, result)
     }
 
-    /// Iterate over all files in the host
-    ///
-    /// Returns an iterator of `FilePath` for all registered files.
+    /// Iterate over all files in the host.
     pub fn files(&self) -> Vec<FilePath> {
-        let lock_id = next_ide_lock_id();
-        tracing::debug!(lock_id, "files: acquiring registry read lock");
-        let registry = self.registry.read();
-        tracing::debug!(lock_id, "files: acquired registry read lock");
-        let result: Vec<FilePath> = registry
+        self.registry
             .all_file_ids()
             .into_iter()
-            .filter_map(|file_id| registry.get_path(file_id))
-            .collect();
-        tracing::debug!(
-            lock_id,
-            count = result.len(),
-            "files: releasing registry read lock"
-        );
-        result
+            .filter_map(|file_id| self.registry.get_path(file_id))
+            .collect()
     }
 
-    /// Get an immutable snapshot for analysis
+    /// Get an immutable snapshot for analysis.
     ///
-    /// This snapshot can be used from multiple threads and provides all IDE features.
-    /// It's cheap to create and clone (`RootDatabase` implements Clone via salsa).
+    /// Cheap: creates a Salsa db clone and copies the cached `ProjectFiles`
+    /// handle. The snapshot resolves all file lookups through Salsa, never
+    /// reaching back into the host's `FileRegistry`.
     ///
-    /// # Lifecycle Warning
+    /// # Lifecycle
     ///
-    /// The returned `Analysis` **must be dropped before calling any mutating method**
-    /// on this `AnalysisHost`. This is required by Salsa's single-writer model.
-    /// See the struct-level documentation for details and examples.
+    /// The returned `Analysis` must be dropped before any host mutation. This
+    /// is enforced by Salsa's single-writer model: setters block until all
+    /// outstanding snapshots have been dropped.
     pub fn snapshot(&self) -> Analysis {
-        // project_files is already synced to the database in rebuild_project_files()
-        // Queries access it via db.project_files()
-        let project_files = self.db.project_files_input;
-
-        if let Some(ref pf) = project_files {
-            let doc_count = pf.document_file_ids(&self.db).ids(&self.db).len();
-            let schema_count = pf.schema_file_ids(&self.db).ids(&self.db).len();
-            tracing::debug!(
-                "Snapshot project_files: {} schema files, {} document files",
-                schema_count,
-                doc_count
-            );
-        } else {
-            tracing::warn!("Snapshot project_files is None!");
-        }
-
         let snapshot_id = next_snapshot_id();
-        tracing::debug!(snapshot_id, "snapshot: creating Salsa snapshot (db.clone)");
         Analysis {
             db: self.db.clone(),
-            registry: Arc::clone(&self.registry),
-            project_files,
+            project_files: self.db.project_files_input,
             snapshot_id,
         }
     }

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -12,14 +12,14 @@ use std::sync::Arc;
 use crate::helpers::{find_block_for_position, format_type_ref, position_to_offset};
 use crate::symbol::{find_parent_type_at_offset, find_symbol_at_offset, Symbol};
 use crate::types::{FilePath, HoverResult, Position};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get hover information at a position.
 ///
 /// Returns documentation, type information, etc.
 pub fn hover(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -13,7 +13,7 @@ use apollo_parser::cst::{CstNode, Definition, Selection};
 
 use crate::helpers::{format_type_ref, offset_to_position};
 use crate::types::{FilePath, InlayHint, InlayHintKind, Position, Range};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get inlay hints for a file.
 ///
@@ -24,7 +24,7 @@ use crate::FileRegistry;
 /// If `range` is provided, only returns hints within that range for efficiency.
 pub fn inlay_hints(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     range: Option<Range>,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -40,6 +40,7 @@ mod diagnostics_for_change_tests;
 
 // Infrastructure modules
 mod database;
+mod db_files;
 mod discovery;
 mod file_registry;
 mod helpers;
@@ -76,8 +77,9 @@ pub use types::{
     TextEdit, TypeCoverageInfo, WorkspaceSymbol,
 };
 
-// Re-export file registry
-pub use file_registry::FileRegistry;
+// `FileRegistry` is owned by `AnalysisHost` and not exposed publicly. Snapshots
+// access file lookups through the `DbFiles` Salsa-backed view.
+pub(crate) use db_files::DbFiles;
 
 // Re-export for use in symbol module and LSP
 pub use helpers::{path_to_file_uri, unwrap_type_to_name};

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -14,14 +14,14 @@ use crate::helpers::{
 };
 use crate::symbol::{find_schema_field_parent_type, find_symbol_at_offset, Symbol};
 use crate::types::{FilePath, Location, Position};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Find all references to the symbol at a position.
 ///
 /// Returns locations of all usages of types, fields, fragments, etc.
 pub fn find_references(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,
@@ -83,7 +83,7 @@ pub fn find_references(
 /// Find all references to a fragment.
 pub fn find_fragment_references(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     fragment_name: &str,
     include_declaration: bool,
@@ -151,7 +151,7 @@ pub fn find_fragment_references(
 /// Find all references to a type.
 fn find_type_references(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     type_name: &str,
     include_declaration: bool,
@@ -217,7 +217,7 @@ fn find_type_references(
 /// Find all references to a field on a specific type.
 pub fn find_field_references(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     type_name: &str,
     field_name: &str,

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -12,12 +12,12 @@ use apollo_parser::cst::CstNode;
 use crate::helpers::{find_block_for_position, offset_range_to_range, position_to_offset};
 use crate::symbol::{find_symbol_at_offset, Symbol};
 use crate::types::{FilePath, Location, Position, Range, RenameResult, TextEdit};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Check if the symbol at a position can be renamed, returning its range.
 pub fn prepare_rename(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
     position: Position,
 ) -> Option<Range> {
@@ -52,7 +52,7 @@ pub fn prepare_rename(
 /// Rename the symbol at a position to a new name.
 pub fn rename(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,
@@ -84,7 +84,7 @@ pub fn rename(
 /// Rename a fragment across all files in the project.
 fn rename_fragment(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     old_name: &str,
     new_name: &str,
@@ -108,7 +108,7 @@ fn rename_fragment(
 /// Rename an operation name within a single file.
 fn rename_operation(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
     old_name: &str,
     new_name: &str,
@@ -143,7 +143,7 @@ fn rename_operation(
 /// Rename a variable within the containing operation (definition + all usages).
 fn rename_variable(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
     old_name: &str,
     new_name: &str,

--- a/crates/ide/src/selection_range.rs
+++ b/crates/ide/src/selection_range.rs
@@ -8,7 +8,7 @@ use apollo_parser::cst::{self, CstNode};
 
 use crate::helpers::{find_block_for_position, offset_range_to_range, position_to_offset};
 use crate::types::{FilePath, Position, Range, SelectionRange};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get selection ranges at multiple positions in a file.
 ///
@@ -16,7 +16,7 @@ use crate::FileRegistry;
 /// from the innermost syntax element to the outermost (document).
 pub fn selection_ranges(
     db: &dyn graphql_syntax::GraphQLSyntaxDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
     positions: &[Position],
 ) -> Vec<Option<SelectionRange>> {

--- a/crates/ide/src/semantic_tokens.rs
+++ b/crates/ide/src/semantic_tokens.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::types::Position;
-use crate::FileRegistry;
+use crate::DbFiles;
 use crate::{SemanticToken, SemanticTokenModifiers, SemanticTokenType};
 
 /// Get semantic tokens for a file.
@@ -17,7 +17,7 @@ use crate::{SemanticToken, SemanticTokenModifiers, SemanticTokenType};
 /// including deprecation status for fields.
 pub fn semantic_tokens(
     db: &dyn graphql_hir::GraphQLHirDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &crate::FilePath,
 ) -> Vec<SemanticToken> {

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -10,7 +10,7 @@ use crate::helpers::{
 };
 use crate::symbol::find_parent_type_at_offset;
 use crate::types::{FilePath, ParameterInformation, Position, SignatureHelp, SignatureInformation};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get signature help at a position.
 ///
@@ -18,7 +18,7 @@ use crate::FileRegistry;
 /// directive argument list.
 pub fn signature_help(
     db: &dyn graphql_hir::GraphQLHirDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     file: &FilePath,
     position: Position,

--- a/crates/ide/src/symbols.rs
+++ b/crates/ide/src/symbols.rs
@@ -12,7 +12,7 @@ use crate::symbol::{
     find_type_definition_full_range, SymbolRanges,
 };
 use crate::types::{DocumentSymbol, FilePath, Location, SymbolKind, WorkspaceSymbol};
-use crate::FileRegistry;
+use crate::DbFiles;
 
 /// Get document symbols for a file (hierarchical outline).
 ///
@@ -20,7 +20,7 @@ use crate::FileRegistry;
 /// This powers the "Go to Symbol in Editor" (Cmd+Shift+O) feature.
 pub fn document_symbols(
     db: &dyn graphql_hir::GraphQLHirDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     file: &FilePath,
 ) -> Vec<DocumentSymbol> {
     let (content, metadata, file_id) = {
@@ -117,7 +117,7 @@ pub fn document_symbols(
 /// This powers the "Go to Symbol in Workspace" (Cmd+T) feature.
 pub fn workspace_symbols(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     project_files: Option<graphql_base_db::ProjectFiles>,
     query: &str,
 ) -> Vec<WorkspaceSymbol> {
@@ -327,7 +327,7 @@ fn get_field_children_from_map(
 /// Get location for a type definition.
 fn get_type_location(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     type_def: &graphql_hir::TypeDef,
 ) -> Option<Location> {
     let file_path = registry.get_path(type_def.file_id)?;
@@ -353,7 +353,7 @@ fn get_type_location(
 /// Get location for a fragment definition.
 fn get_fragment_location(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     fragment: &graphql_hir::FragmentStructure,
 ) -> Option<Location> {
     let file_path = registry.get_path(fragment.file_id)?;
@@ -379,7 +379,7 @@ fn get_fragment_location(
 /// Get location for an operation definition.
 fn get_operation_location(
     db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
-    registry: &FileRegistry,
+    registry: DbFiles<'_>,
     operation: &graphql_hir::OperationStructure,
 ) -> Option<Location> {
     let op_name = operation.name.as_ref()?;

--- a/crates/linter/src/rules/alphabetize.rs
+++ b/crates/linter/src/rules/alphabetize.rs
@@ -262,7 +262,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn check(source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/description_style.rs
+++ b/crates/linter/src/rules/description_style.rs
@@ -180,7 +180,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/input_name.rs
+++ b/crates/linter/src/rules/input_name.rs
@@ -122,7 +122,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/lone_executable_definition.rs
+++ b/crates/linter/src/rules/lone_executable_definition.rs
@@ -142,7 +142,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn check(source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/naming_convention.rs
+++ b/crates/linter/src/rules/naming_convention.rs
@@ -228,7 +228,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn check(source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/no_anonymous_operations.rs
+++ b/crates/linter/src/rules/no_anonymous_operations.rs
@@ -149,7 +149,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/no_deprecated.rs
+++ b/crates/linter/src/rules/no_deprecated.rs
@@ -377,8 +377,17 @@ mod tests {
         file_entries.insert(schema_file_id, schema_entry);
         file_entries.insert(doc_file_id, doc_entry);
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
 
         (doc_file_id, doc_content, doc_metadata, project_files)
     }

--- a/crates/linter/src/rules/no_duplicate_fields.rs
+++ b/crates/linter/src/rules/no_duplicate_fields.rs
@@ -160,7 +160,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn check(source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/no_hashtag_description.rs
+++ b/crates/linter/src/rules/no_hashtag_description.rs
@@ -144,7 +144,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/no_one_place_fragments.rs
+++ b/crates/linter/src/rules/no_one_place_fragments.rs
@@ -224,7 +224,17 @@ mod tests {
             Arc::new(doc_files.iter().map(|(id, _, _)| *id).collect()),
         );
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
+++ b/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
@@ -119,7 +119,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/no_typename_prefix.rs
+++ b/crates/linter/src/rules/no_typename_prefix.rs
@@ -109,7 +109,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/no_unreachable_types.rs
+++ b/crates/linter/src/rules/no_unreachable_types.rs
@@ -164,7 +164,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/operation_name_suffix.rs
+++ b/crates/linter/src/rules/operation_name_suffix.rs
@@ -99,7 +99,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn run_rule(db: &RootDatabase, source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/require_deprecation_reason.rs
+++ b/crates/linter/src/rules/require_deprecation_reason.rs
@@ -147,7 +147,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/require_description.rs
+++ b/crates/linter/src/rules/require_description.rs
@@ -111,7 +111,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
+++ b/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
@@ -122,7 +122,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/require_id_field.rs
+++ b/crates/linter/src/rules/require_id_field.rs
@@ -691,8 +691,17 @@ mod tests {
         file_entries.insert(schema_file_id, schema_entry);
         file_entries.insert(doc_file_id, doc_entry);
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
 
         (doc_file_id, doc_content, doc_metadata, project_files)
     }
@@ -1140,8 +1149,17 @@ query GetUser {
             graphql_base_db::SchemaFileIds::new(db, Arc::new(vec![schema_file_id]));
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(doc_file_ids));
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
 
         let (file_id, content, metadata) = first_doc.expect("At least one document required");
         (file_id, content, metadata, project_files)

--- a/crates/linter/src/rules/require_selections.rs
+++ b/crates/linter/src/rules/require_selections.rs
@@ -647,8 +647,17 @@ mod tests {
         file_entries.insert(schema_file_id, schema_entry);
         file_entries.insert(doc_file_id, doc_entry);
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
 
         (doc_file_id, doc_content, doc_metadata, project_files)
     }
@@ -698,8 +707,17 @@ mod tests {
         let document_file_ids =
             graphql_base_db::DocumentFileIds::new(db, Arc::new(doc_file_ids_vec));
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
-        let project_files =
-            ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map);
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
 
         doc_infos
             .into_iter()

--- a/crates/linter/src/rules/selection_set_depth.rs
+++ b/crates/linter/src/rules/selection_set_depth.rs
@@ -182,7 +182,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn check(source: &str) -> Vec<LintDiagnostic> {

--- a/crates/linter/src/rules/strict_id_in_types.rs
+++ b/crates/linter/src/rules/strict_id_in_types.rs
@@ -111,7 +111,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/unique_enum_value_names.rs
+++ b/crates/linter/src/rules/unique_enum_value_names.rs
@@ -124,7 +124,17 @@ mod tests {
         let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![file_id]));
         let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/unique_names.rs
+++ b/crates/linter/src/rules/unique_names.rs
@@ -182,7 +182,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(doc_file_ids));
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
 
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     fn create_single_file_project(

--- a/crates/linter/src/rules/unused_fields.rs
+++ b/crates/linter/src/rules/unused_fields.rs
@@ -281,7 +281,17 @@ mod tests {
         file_entries.insert(doc_file_id, doc_entry);
         let file_entry_map = graphql_base_db::FileEntryMap::new(db, Arc::new(file_entries));
 
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/unused_fragments.rs
+++ b/crates/linter/src/rules/unused_fragments.rs
@@ -182,7 +182,17 @@ mod tests {
             Arc::new(doc_files.iter().map(|(id, _, _)| *id).collect()),
         );
         let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/src/rules/unused_variables.rs
+++ b/crates/linter/src/rules/unused_variables.rs
@@ -190,7 +190,17 @@ mod tests {
         let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
         let file_entry_map =
             graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-        ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+        ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        )
     }
 
     #[test]

--- a/crates/linter/tests/lint_integration.rs
+++ b/crates/linter/tests/lint_integration.rs
@@ -14,7 +14,17 @@ fn create_empty_project_files(db: &RootDatabase) -> graphql_base_db::ProjectFile
     let document_file_ids = graphql_base_db::DocumentFileIds::new(db, Arc::new(vec![]));
     let file_entry_map =
         graphql_base_db::FileEntryMap::new(db, Arc::new(std::collections::HashMap::new()));
-    graphql_base_db::ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    graphql_base_db::ProjectFiles::new(
+        db,
+        schema_file_ids,
+        document_file_ids,
+        file_entry_map,
+        graphql_base_db::FilePathMap::new(
+            db,
+            std::sync::Arc::new(std::collections::HashMap::new()),
+            std::sync::Arc::new(std::collections::HashMap::new()),
+        ),
+    )
 }
 
 /// Run all standalone document rules on a source

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -1417,7 +1417,7 @@ documents: "**/*.graphql"
 /// panic hook (see `install_panic_hook` in `lib.rs`).
 ///
 /// Consumes the error because `into_panic()` requires ownership.
-fn describe_join_error(join_err: tokio::task::JoinError) -> String {
+pub(crate) fn describe_join_error(join_err: tokio::task::JoinError) -> String {
     if join_err.is_cancelled() {
         return "cancelled".to_string();
     }

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tower_lsp_server::ls_types as lsp_types;
 
+use crate::server::describe_join_error;
+
 /// Default timeout for acquiring host locks during LSP requests.
 const LOCK_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -114,17 +116,26 @@ impl ProjectHost {
         document_kind: graphql_ide::DocumentKind,
     ) -> (bool, graphql_ide::Analysis) {
         let mut guard = Arc::clone(&self.inner).lock_owned().await;
-        let path = path.clone();
+        let path_str = path.as_str().to_string();
+        let path_owned = path.clone();
         let content = content.to_string();
         match tokio::task::spawn_blocking(move || {
-            guard.update_file_and_snapshot(&path, &content, language, document_kind)
+            guard.update_file_and_snapshot(&path_owned, &content, language, document_kind)
         })
         .await
         {
             Ok(result) => result,
-            Err(e) => {
-                tracing::error!("Blocking task panicked in add_file_and_snapshot: {e}");
-                panic!("add_file_and_snapshot: blocking task panicked: {e}");
+            Err(join_err) => {
+                let payload = describe_join_error(join_err);
+                tracing::error!(
+                    path = %path_str,
+                    "add_file_and_snapshot: blocking task ended abnormally: {payload}",
+                );
+                // Re-raise so the caller's request fails loudly rather than the
+                // server silently degrading. The OwnedMutexGuard moved into the
+                // closure has already been dropped during unwinding, so the
+                // host's tokio Mutex is released.
+                panic!("add_file_and_snapshot: blocking task panicked: {payload}");
             }
         }
     }

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -17,43 +17,38 @@ use dashmap::DashMap;
 use graphql_ide::AnalysisHost;
 use lsp_types::Uri;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tower_lsp_server::ls_types as lsp_types;
-
-/// Global counter for unique lock operation IDs.
-/// Each lock acquire gets a unique ID so acquire/release pairs can be correlated in logs.
-static LOCK_ID: AtomicU64 = AtomicU64::new(1);
-
-fn next_lock_id() -> u64 {
-    LOCK_ID.fetch_add(1, Ordering::Relaxed)
-}
 
 /// Default timeout for acquiring host locks during LSP requests.
 const LOCK_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// A wrapper around `AnalysisHost` that enforces safe access patterns.
 ///
-/// This type prevents handlers from accidentally holding the lock without a timeout
-/// by only exposing safe access methods:
-/// - `try_snapshot()`: Read access with timeout (for request handlers)
-/// - `with_write()`: Write access for background tasks (no timeout, but caller is responsible)
-/// - `add_file_and_snapshot()`: Write + snapshot for `did_change` (runs on `spawn_blocking`)
+/// Exposes only:
+/// - [`try_snapshot`](Self::try_snapshot): timed read access for request
+///   handlers, returns `None` if the host is busy.
+/// - [`with_write`](Self::with_write): untimed write access for
+///   initialization and config reload paths.
+/// - [`add_file_and_snapshot`](Self::add_file_and_snapshot): the editing
+///   hot path. Runs on `spawn_blocking` because the underlying Salsa setter
+///   waits for in-flight snapshots to drop.
 ///
 /// ## Salsa Snapshot Safety
 ///
-/// Salsa setters block until all outstanding snapshots are dropped. If a setter
-/// runs on the async runtime while a `spawn_blocking` task holds a snapshot,
-/// the runtime thread is blocked and can't drive other tasks — deadlock.
+/// Salsa setters block until all outstanding snapshot clones are dropped. If
+/// a setter ran on the async runtime while a `spawn_blocking` task held a
+/// snapshot, the runtime thread would be blocked and could not drive the
+/// task that owns the snapshot — deadlock. `add_file_and_snapshot` therefore
+/// uses `lock_owned()` + `spawn_blocking` so the setter parks a pool thread
+/// instead of the runtime.
 ///
-/// `add_file_and_snapshot` (the hot path during editing) uses `lock_owned()` +
-/// `spawn_blocking` so the setter blocks a pool thread instead of the runtime.
-///
-/// `with_write` runs on the async thread and is safe only when no snapshots are
-/// outstanding (initialization, config reload). Do NOT use it on the editing
-/// hot path.
+/// In-flight snapshots can no longer take a `parking_lot` lock against the
+/// host (snapshots resolve everything through Salsa inputs), so the only
+/// remaining concern is the runtime starvation above — the lock-ordering
+/// deadlock class is gone.
 #[derive(Clone)]
 pub struct ProjectHost {
     inner: Arc<Mutex<AnalysisHost>>,
@@ -75,93 +70,42 @@ impl ProjectHost {
 
     /// Try to get a snapshot with a timeout.
     ///
-    /// This is the ONLY way request handlers should access the analysis.
-    /// Returns `None` if the lock can't be acquired within the timeout,
-    /// allowing the handler to return early instead of blocking.
+    /// The only way request handlers should access analysis. Returns `None`
+    /// if the lock can't be acquired within the timeout, allowing the handler
+    /// to return early instead of blocking the runtime thread.
     pub async fn try_snapshot(&self) -> Option<graphql_ide::Analysis> {
-        let lock_id = next_lock_id();
-        tracing::debug!(
-            lock_id,
-            "try_snapshot: waiting for ProjectHost lock (timeout=500ms)"
-        );
-        if let Ok(guard) = tokio::time::timeout(LOCK_TIMEOUT, self.inner.lock()).await {
-            tracing::debug!(lock_id, "try_snapshot: acquired ProjectHost lock");
-            let snapshot = guard.snapshot();
-            tracing::debug!(
-                lock_id,
-                "try_snapshot: releasing ProjectHost lock (snapshot created)"
-            );
-            Some(snapshot)
-        } else {
-            tracing::warn!(
-                lock_id,
-                "try_snapshot: TIMED OUT waiting for ProjectHost lock"
-            );
-            None
-        }
+        let Ok(guard) = tokio::time::timeout(LOCK_TIMEOUT, self.inner.lock()).await else {
+            tracing::warn!("try_snapshot: timed out waiting for ProjectHost lock");
+            return None;
+        };
+        Some(guard.snapshot())
     }
 
     /// Execute a write operation on the host.
     ///
-    /// This acquires the lock WITHOUT a timeout. Only use this for:
+    /// Acquires the lock without a timeout. Use only for:
     /// - Background initialization tasks
     /// - Config reload handlers
     ///
-    /// **WARNING**: This runs the closure on the async thread. Safe only when
-    /// no Salsa snapshots are outstanding (i.e., not during active editing).
-    /// For the editing hot path, use `add_file_and_snapshot` instead.
+    /// Runs the closure on the async thread. Safe whenever the work is short
+    /// and not on the editing hot path; for `did_change` use
+    /// [`add_file_and_snapshot`](Self::add_file_and_snapshot) instead.
     pub async fn with_write<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&mut AnalysisHost) -> R,
     {
-        let lock_id = next_lock_id();
-        tracing::debug!(lock_id, "with_write: waiting for ProjectHost lock");
         let mut guard = self.inner.lock().await;
-        tracing::debug!(lock_id, "with_write: acquired ProjectHost lock");
-        let result = f(&mut guard);
-        tracing::debug!(lock_id, "with_write: releasing ProjectHost lock");
-        result
-    }
-
-    /// Execute a write operation and get a snapshot in one lock acquisition.
-    ///
-    /// This is a generic helper for cases where you need to perform a write
-    /// operation and immediately get a snapshot. For file additions, prefer
-    /// `add_file_and_snapshot` which properly handles project file rebuilding.
-    ///
-    /// Doing both in one lock acquisition avoids double-locking.
-    ///
-    /// **WARNING**: Same async-thread caveat as `with_write`.
-    #[allow(dead_code)]
-    pub async fn write_and_snapshot<F, R>(&self, f: F) -> (R, graphql_ide::Analysis)
-    where
-        F: FnOnce(&mut AnalysisHost) -> R,
-    {
-        let lock_id = next_lock_id();
-        tracing::debug!(lock_id, "write_and_snapshot: waiting for ProjectHost lock");
-        let mut guard = self.inner.lock().await;
-        tracing::debug!(lock_id, "write_and_snapshot: acquired ProjectHost lock");
-        let result = f(&mut guard);
-        let snapshot = guard.snapshot();
-        tracing::debug!(
-            lock_id,
-            "write_and_snapshot: releasing ProjectHost lock (snapshot created)"
-        );
-        (result, snapshot)
+        f(&mut guard)
     }
 
     /// Add or update a file and get a snapshot in one lock acquisition.
     ///
-    /// This properly handles both new and existing files:
-    /// - For new files: rebuilds project file index before creating snapshot
-    /// - For existing files: just updates content
+    /// New files automatically rebuild the project file index before
+    /// snapshotting; existing files just bump the file's `FileContent`.
     ///
-    /// Uses `lock_owned()` + `spawn_blocking` so the Salsa setter (which may
-    /// block waiting for outstanding snapshots from previous diagnostics
-    /// computations to be dropped) blocks a pool thread instead of the async
-    /// runtime. This prevents the deadlock triggered by rapid schema edits.
-    ///
-    /// Returns `(is_new_file, Analysis)` tuple.
+    /// Runs on `spawn_blocking` so the Salsa setter — which may park waiting
+    /// for outstanding snapshots from previous diagnostics computations to be
+    /// dropped — blocks a pool thread rather than the async runtime.
     pub async fn add_file_and_snapshot(
         &self,
         path: &graphql_ide::FilePath,
@@ -169,32 +113,17 @@ impl ProjectHost {
         language: graphql_ide::Language,
         document_kind: graphql_ide::DocumentKind,
     ) -> (bool, graphql_ide::Analysis) {
-        let lock_id = next_lock_id();
-        tracing::debug!(lock_id, path = %path.as_str(), "add_file_and_snapshot: waiting for ProjectHost lock (lock_owned)");
         let mut guard = Arc::clone(&self.inner).lock_owned().await;
-        tracing::debug!(lock_id, path = %path.as_str(), "add_file_and_snapshot: acquired ProjectHost lock, spawning blocking task");
         let path = path.clone();
         let content = content.to_string();
         match tokio::task::spawn_blocking(move || {
-            tracing::debug!(
-                lock_id,
-                "add_file_and_snapshot: blocking task started (calling update_file_and_snapshot)"
-            );
-            let result = guard.update_file_and_snapshot(&path, &content, language, document_kind);
-            tracing::debug!(
-                lock_id,
-                "add_file_and_snapshot: blocking task done, releasing ProjectHost lock"
-            );
-            result
+            guard.update_file_and_snapshot(&path, &content, language, document_kind)
         })
         .await
         {
             Ok(result) => result,
             Err(e) => {
-                tracing::error!(
-                    lock_id,
-                    "Blocking task panicked in add_file_and_snapshot: {e}"
-                );
+                tracing::error!("Blocking task panicked in add_file_and_snapshot: {e}");
                 panic!("add_file_and_snapshot: blocking task panicked: {e}");
             }
         }
@@ -930,6 +859,121 @@ mod tests {
             "add_file_and_snapshot blocked the async runtime waiting for \
              a Salsa snapshot to be dropped — the Salsa setter must run \
              in spawn_blocking, not on the async thread"
+        );
+    }
+
+    /// Regression test for the lock-ordering deadlock that motivated the
+    /// `FilePathMap` refactor.
+    ///
+    /// **The bug**: snapshots used to hold a `parking_lot::RwLock` read on the
+    /// host's `FileRegistry` to resolve file paths. The `did_change` writer
+    /// took the same `RwLock` for write inside `update_file_and_snapshot`,
+    /// then called a Salsa setter that waits for outstanding snapshots to
+    /// drop. With a long-running snapshot taking repeated `registry.read()`
+    /// calls, `parking_lot`'s writer-preferring policy starved those reads,
+    /// the snapshot couldn't drop, and the setter parked forever. Two
+    /// `spawn_blocking` worker threads, each waiting on the other.
+    ///
+    /// **The fix verified here**: snapshots resolve everything via Salsa
+    /// (`FilePathMap`, `FileEntryMap`), so they hold no `parking_lot` lock
+    /// and the cycle is structurally impossible.
+    ///
+    /// The test seeds the host with a schema and 50 documents, then runs a
+    /// long-lived snapshot in `spawn_blocking` that loops over file lookups
+    /// (`diagnostics`, `file_content`, `workspace_symbols`) while a
+    /// concurrent task drives `add_file_and_snapshot` 20 times with new file
+    /// URIs (forcing the new-file path that previously held the registry
+    /// write lock across the Salsa setter). On a single-threaded runtime
+    /// with an OS-level 10s timeout, this hangs pre-refactor and finishes
+    /// quickly post-refactor.
+    #[test]
+    fn test_concurrent_snapshot_lookups_during_writer() {
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            rt.block_on(async {
+                let host = ProjectHost::new();
+
+                // Seed: schema + 50 documents.
+                let schema_path = graphql_ide::FilePath::new("file:///schema.graphql");
+                let _ = host
+                    .add_file_and_snapshot(
+                        &schema_path,
+                        "type Query { hello: String, items: [Item] } \
+                         type Item { id: ID!, name: String }",
+                        graphql_ide::Language::GraphQL,
+                        graphql_ide::DocumentKind::Schema,
+                    )
+                    .await;
+                for i in 0..50 {
+                    let doc_path = graphql_ide::FilePath::new(format!("file:///doc-{i}.graphql"));
+                    let _ = host
+                        .add_file_and_snapshot(
+                            &doc_path,
+                            "query Q { hello }",
+                            graphql_ide::Language::GraphQL,
+                            graphql_ide::DocumentKind::Executable,
+                        )
+                        .await;
+                }
+
+                // Take a fresh snapshot and hand it to a blocking worker that
+                // exercises the same lookups (`diagnostics`, `file_content`,
+                // `workspace_symbols`) the LSP would on the read path. Each
+                // call goes through the Salsa-backed file lookups; pre-refactor
+                // these would have taken `registry.read()` and parked once a
+                // writer was queued.
+                let snapshot = host.try_snapshot().await.expect("snapshot");
+                let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+                let reader = tokio::task::spawn_blocking(move || {
+                    for _ in 0..200 {
+                        for i in 0..50 {
+                            let p = graphql_ide::FilePath::new(format!("file:///doc-{i}.graphql"));
+                            let _ = snapshot.diagnostics(&p);
+                            let _ = snapshot.file_content(&p);
+                        }
+                        let _ = snapshot.workspace_symbols("Q");
+                    }
+                    // Hold the snapshot until the writer loop signals done so
+                    // we exercise the "snapshot in flight while writer runs"
+                    // condition that triggers the deadlock pre-refactor.
+                    let _ = release_rx.blocking_recv();
+                    drop(snapshot);
+                });
+
+                // Concurrently, drive 20 new-file additions. Each one forces
+                // a `rebuild_project_files` and the Salsa setter that
+                // previously parked on snapshot drop.
+                for i in 0..20 {
+                    let new_path = graphql_ide::FilePath::new(format!("file:///new-{i}.graphql"));
+                    let _ = host
+                        .add_file_and_snapshot(
+                            &new_path,
+                            "query NewQ { hello }",
+                            graphql_ide::Language::GraphQL,
+                            graphql_ide::DocumentKind::Executable,
+                        )
+                        .await;
+                }
+
+                let _ = release_tx.send(());
+                let _ = reader.await;
+            });
+
+            let _ = done_tx.send(());
+        });
+
+        let result = done_rx.recv_timeout(Duration::from_secs(10));
+        assert!(
+            result.is_ok(),
+            "Concurrent snapshot lookups deadlocked the writer — snapshots \
+             must resolve all file lookups through Salsa, never through a \
+             side-channel parking_lot lock shared with the host."
         );
     }
 }

--- a/crates/test-utils/src/database.rs
+++ b/crates/test-utils/src/database.rs
@@ -12,7 +12,7 @@
 
 use graphql_base_db::{
     DocumentFileIds, DocumentKind, FileContent, FileEntry, FileEntryMap, FileId, FileMetadata,
-    FileUri, Language, ProjectFiles, SchemaFileIds,
+    FilePathMap, FileUri, Language, ProjectFiles, SchemaFileIds,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -127,5 +127,22 @@ pub fn create_project_files<DB: salsa::Database>(
     let document_file_ids = DocumentFileIds::new(db, Arc::new(doc_ids));
     let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
 
-    ProjectFiles::new(db, schema_file_ids, document_file_ids, file_entry_map)
+    // Build a FilePathMap from the metadata URIs so test fixtures support the
+    // same Salsa-backed path lookups as production code.
+    let mut uri_to_id: HashMap<Arc<str>, FileId> = HashMap::new();
+    let mut id_to_uri: HashMap<FileId, Arc<str>> = HashMap::new();
+    for (id, _, metadata) in schema_files.iter().chain(document_files.iter()) {
+        let uri: Arc<str> = Arc::from(metadata.uri(db).as_str());
+        uri_to_id.insert(uri.clone(), *id);
+        id_to_uri.insert(*id, uri);
+    }
+    let file_path_map = FilePathMap::new(db, Arc::new(uri_to_id), Arc::new(id_to_uri));
+
+    ProjectFiles::new(
+        db,
+        schema_file_ids,
+        document_file_ids,
+        file_entry_map,
+        file_path_map,
+    )
 }


### PR DESCRIPTION
## Summary

Eliminate the architectural hazard that produced the lock-ordering deadlock class motivating recent fixes #779, #784, and #949. `Analysis` snapshots no longer share an `Arc<RwLock<FileRegistry>>` with `AnalysisHost` — every file lookup that snapshots used to do via that side-channel lock now goes through Salsa-tracked queries against a new `FilePathMap` input. With no second lock for the host writer and the snapshot reader to deadlock against, the entire deadlock class is structurally impossible.

#963 (the panic-resilience fix) suggested the user-visible symptom was actually panic-induced rather than a true cycle, so this PR is no longer load-bearing for the immediate bug. It is still valuable on its own merits:

- It removes a real lock-ordering hazard that *would* have eventually fired even if it wasn't the cause of the specific reported issue
- It eliminates an entire class of "don't call setter while holding a snapshot" footguns by construction
- Snapshots become temporally consistent (they observe the file set at their creation revision, not the live host state) — a strict correctness improvement
- The IDE crate no longer depends on `parking_lot` at all

## Changes

### Architectural

- New `FilePathMap` Salsa input in `crates/base-db/src/lib.rs` providing bidirectional URI ↔ `FileId` resolution. Stable across content edits, only bumps on file add/remove.
- New tracked queries: `file_id_for_uri`, `uri_for_file_id`, `all_file_ids`.
- New `DbFiles<'a>` adapter in `crates/ide/src/db_files.rs` — a `Copy` view over `(&dyn salsa::Database, Option<ProjectFiles>)` exposing the same `get_file_id` / `get_path` / `get_content` / `get_metadata` / `all_file_ids` surface that feature modules previously got from `&FileRegistry`.
- `Analysis` no longer has a `registry` field. `AnalysisHost::registry` is plain `FileRegistry` (no `Arc<RwLock<>>`).
- All ~30 `registry.read()` call sites in `crates/ide/src/analysis.rs` migrated to either the new `lookup_file` helper or to `DbFiles`.
- All 12 IDE feature modules: `registry: &FileRegistry` → `registry: DbFiles<'_>`. Bodies unchanged.
- `add_file`, `add_discovered_files`, `update_file_and_snapshot`, `remove_file` automatically maintain the `ProjectFiles` index — callers no longer have to remember to call `rebuild_project_files` after a mutation.
- `ProjectHost::add_file_and_snapshot` keeps `lock_owned + spawn_blocking` (the Salsa setter still parks on snapshot drop, so it still must run on a pool thread to keep the runtime responsive — that's the #949 invariant), but the manual lock-id tracing ceremony is gone.
- `parking_lot` workspace dependency dropped.

### Tests

- New regression test in `crates/lsp/src/workspace.rs`: `test_concurrent_snapshot_lookups_during_writer`. Seeds the host with a schema + 50 documents, runs a long-lived snapshot in `spawn_blocking` looping over file lookups (`diagnostics`, `file_content`, `workspace_symbols`) while a concurrent task drives 20 new-file additions (the cold path that previously held the registry write lock across the Salsa setter). On a single-threaded runtime with a 10s OS-level timeout, this hangs pre-refactor and finishes in milliseconds post-refactor.
- The existing `test_add_file_and_snapshot_does_not_block_async_runtime` from #949 keeps its meaning and continues to pass.

### Documentation

- `crates/CLAUDE.md`: new "Snapshot/Host Lock Discipline" section capturing the structural rule.
- `.claude/agents/salsa.md`: extends Pitfall 2 ("Shared `Arc<RwLock<...>>` in Database") with the real-world incident writeup so future contributors can spot the pattern early.
- `.claude/skills/debug-lsp/SKILL.md`: rewritten "Hangs / Deadlocks" guidance for the new architecture.

## Consulted SME Agents

N/A — this is the architectural fix that previous PRs (#779, #784, #949) had been working around. The Pitfall 2 entry in `salsa.md` had warned about exactly this pattern; this PR converts the warning into a fait accompli.

## Manual Testing Plan

- Build: `cargo build --release -p graphql-lsp`
- Open a large GraphQL project in VS Code with the new binary
- Hold backspace on a schema field name for several seconds
- Verify the LSP stays fully responsive — no timeouts, no `Blocking task ended abnormally` errors that take down the host (individual request panics are caught by the #963 defenses; the host continuing to serve requests is the win)
- Open and edit several files concurrently to exercise multiple snapshots in flight while the writer runs

## Diff stats

~50 files, +632 / −399 (the architectural commit). Net additions are mostly the new `FilePathMap` input + the new regression test; net deletions are the lock-id tracing ceremony and the duplicated lookup code.