### PR TITLE
feat(ide): directive IDE features (go-to-def, hover, references, symbols)

### DIFF
--- a/.changeset/directive-ide-features.md
+++ b/.changeset/directive-ide-features.md
@@ -1,5 +1,6 @@
 ---
 graphql-analyzer-lsp: minor
+graphql-analyzer-vscode: minor
 ---
 
 Add directive IDE features: go-to-definition, hover, find references, and document/workspace symbols ([#969](https://github.com/trevor-scheer/graphql-analyzer/pull/969))

--- a/.changeset/directive-ide-features.md
+++ b/.changeset/directive-ide-features.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-lsp: minor
+---
+
+Add directive IDE features: go-to-definition, hover, find references, and document/workspace symbols ([#969](https://github.com/trevor-scheer/graphql-analyzer/pull/969))

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -245,8 +245,13 @@ pub fn goto_definition(
             None
         }
         Symbol::DirectiveName { name } => {
-            let directives = graphql_hir::schema_directives(db, project_files);
-            let directive = directives.get(name.as_str())?;
+            // Try source schema first for navigation, fallback to resolved
+            let source_directives = graphql_hir::source_schema_directives(db, project_files);
+            let directive = source_directives
+                .get(name.as_str())
+                .or_else(|| {
+                    graphql_hir::schema_directives(db, project_files).get(name.as_str())
+                })?;
 
             let file_path = registry.get_path(directive.file_id)?;
             let content = registry.get_content(directive.file_id)?;
@@ -261,8 +266,13 @@ pub fn goto_definition(
             directive_name,
             argument_name,
         } => {
-            let directives = graphql_hir::schema_directives(db, project_files);
-            let directive = directives.get(directive_name.as_str())?;
+            let source_directives = graphql_hir::source_schema_directives(db, project_files);
+            let directive = source_directives
+                .get(directive_name.as_str())
+                .or_else(|| {
+                    graphql_hir::schema_directives(db, project_files)
+                        .get(directive_name.as_str())
+                })?;
             let arg = directive
                 .arguments
                 .iter()

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -244,6 +244,38 @@ pub fn goto_definition(
             }
             None
         }
-        Symbol::DirectiveName { .. } | Symbol::DirectiveArgumentName { .. } => None,
+        Symbol::DirectiveName { name } => {
+            let directives = graphql_hir::schema_directives(db, project_files);
+            let directive = directives.get(name.as_str())?;
+
+            let file_path = registry.get_path(directive.file_id)?;
+            let content = registry.get_content(directive.file_id)?;
+            let line_index = graphql_syntax::line_index(db, content);
+            let start: usize = directive.name_range.start().into();
+            let end: usize = directive.name_range.end().into();
+            let range = offset_range_to_range(&line_index, start, end);
+
+            Some(vec![Location::new(file_path, range)])
+        }
+        Symbol::DirectiveArgumentName {
+            directive_name,
+            argument_name,
+        } => {
+            let directives = graphql_hir::schema_directives(db, project_files);
+            let directive = directives.get(directive_name.as_str())?;
+            let arg = directive
+                .arguments
+                .iter()
+                .find(|a| a.name.as_ref() == argument_name)?;
+
+            let file_path = registry.get_path(arg.file_id)?;
+            let content = registry.get_content(arg.file_id)?;
+            let line_index = graphql_syntax::line_index(db, content);
+            let start: usize = arg.name_range.start().into();
+            let end: usize = arg.name_range.end().into();
+            let range = offset_range_to_range(&line_index, start, end);
+
+            Some(vec![Location::new(file_path, range)])
+        }
     }
 }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -244,5 +244,6 @@ pub fn goto_definition(
             }
             None
         }
+        Symbol::DirectiveName { .. } | Symbol::DirectiveArgumentName { .. } => None,
     }
 }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -249,9 +249,7 @@ pub fn goto_definition(
             let source_directives = graphql_hir::source_schema_directives(db, project_files);
             let directive = source_directives
                 .get(name.as_str())
-                .or_else(|| {
-                    graphql_hir::schema_directives(db, project_files).get(name.as_str())
-                })?;
+                .or_else(|| graphql_hir::schema_directives(db, project_files).get(name.as_str()))?;
 
             let file_path = registry.get_path(directive.file_id)?;
             let content = registry.get_content(directive.file_id)?;
@@ -267,12 +265,9 @@ pub fn goto_definition(
             argument_name,
         } => {
             let source_directives = graphql_hir::source_schema_directives(db, project_files);
-            let directive = source_directives
-                .get(directive_name.as_str())
-                .or_else(|| {
-                    graphql_hir::schema_directives(db, project_files)
-                        .get(directive_name.as_str())
-                })?;
+            let directive = source_directives.get(directive_name.as_str()).or_else(|| {
+                graphql_hir::schema_directives(db, project_files).get(directive_name.as_str())
+            })?;
             let arg = directive
                 .arguments
                 .iter()

--- a/crates/ide/src/helpers.rs
+++ b/crates/ide/src/helpers.rs
@@ -232,6 +232,272 @@ pub fn find_field_usages_in_parse(
     results
 }
 
+/// Find all directive usages in a parsed file by scanning all definitions
+pub fn find_directive_usages_in_parse(
+    parse: &graphql_syntax::Parse,
+    directive_name: &str,
+) -> Vec<Range> {
+    let mut results = Vec::new();
+
+    for doc in parse.documents() {
+        let line_index = graphql_syntax::LineIndex::new(doc.source);
+        let ranges = find_directive_usages_in_tree(doc.tree, directive_name);
+        for (start, end) in ranges {
+            let range = offset_range_to_range(&line_index, start, end);
+            results.push(adjust_range_for_line_offset(range, doc.line_offset));
+        }
+    }
+
+    results
+}
+
+/// Find a directive definition's name range in a parsed file
+pub fn find_directive_definition_in_parse(
+    parse: &graphql_syntax::Parse,
+    directive_name: &str,
+) -> Option<Range> {
+    use apollo_parser::cst::{CstNode, Definition};
+
+    for doc in parse.documents() {
+        for definition in doc.tree.document().definitions() {
+            if let Definition::DirectiveDefinition(dir_def) = definition {
+                if let Some(name) = dir_def.name() {
+                    if name.text() == directive_name {
+                        let range = name.syntax().text_range();
+                        let start: usize = range.start().into();
+                        let end: usize = range.end().into();
+                        let line_index = graphql_syntax::LineIndex::new(doc.source);
+                        let pos_range = offset_range_to_range(&line_index, start, end);
+                        return Some(adjust_range_for_line_offset(pos_range, doc.line_offset));
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Find all usages of a directive by name in a single syntax tree.
+/// Returns `(start_offset, end_offset)` pairs for each directive name occurrence.
+fn find_directive_usages_in_tree(
+    tree: &apollo_parser::SyntaxTree,
+    target_directive: &str,
+) -> Vec<(usize, usize)> {
+    use apollo_parser::cst::{CstNode, Definition, Selection};
+
+    fn collect_from_directives(
+        directives: &apollo_parser::cst::Directives,
+        target: &str,
+        results: &mut Vec<(usize, usize)>,
+    ) {
+        for directive in directives.directives() {
+            if let Some(name) = directive.name() {
+                if name.text() == target {
+                    let range = name.syntax().text_range();
+                    results.push((range.start().into(), range.end().into()));
+                }
+            }
+        }
+    }
+
+    fn collect_from_selection_set(
+        selection_set: &apollo_parser::cst::SelectionSet,
+        target: &str,
+        results: &mut Vec<(usize, usize)>,
+    ) {
+        for selection in selection_set.selections() {
+            match selection {
+                Selection::Field(field) => {
+                    if let Some(directives) = field.directives() {
+                        collect_from_directives(&directives, target, results);
+                    }
+                    if let Some(nested) = field.selection_set() {
+                        collect_from_selection_set(&nested, target, results);
+                    }
+                }
+                Selection::InlineFragment(inline_frag) => {
+                    if let Some(directives) = inline_frag.directives() {
+                        collect_from_directives(&directives, target, results);
+                    }
+                    if let Some(nested) = inline_frag.selection_set() {
+                        collect_from_selection_set(&nested, target, results);
+                    }
+                }
+                Selection::FragmentSpread(frag_spread) => {
+                    if let Some(directives) = frag_spread.directives() {
+                        collect_from_directives(&directives, target, results);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_from_fields_definition(
+        fields: &apollo_parser::cst::FieldsDefinition,
+        target: &str,
+        results: &mut Vec<(usize, usize)>,
+    ) {
+        for field in fields.field_definitions() {
+            if let Some(directives) = field.directives() {
+                collect_from_directives(&directives, target, results);
+            }
+            if let Some(args) = field.arguments_definition() {
+                for arg in args.input_value_definitions() {
+                    if let Some(directives) = arg.directives() {
+                        collect_from_directives(&directives, target, results);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_from_input_fields_definition(
+        fields: &apollo_parser::cst::InputFieldsDefinition,
+        target: &str,
+        results: &mut Vec<(usize, usize)>,
+    ) {
+        for field in fields.input_value_definitions() {
+            if let Some(directives) = field.directives() {
+                collect_from_directives(&directives, target, results);
+            }
+        }
+    }
+
+    fn collect_from_enum_values_definition(
+        values: &apollo_parser::cst::EnumValuesDefinition,
+        target: &str,
+        results: &mut Vec<(usize, usize)>,
+    ) {
+        for value in values.enum_value_definitions() {
+            if let Some(directives) = value.directives() {
+                collect_from_directives(&directives, target, results);
+            }
+        }
+    }
+
+    let mut results = Vec::new();
+    let doc = tree.document();
+
+    for definition in doc.definitions() {
+        match &definition {
+            Definition::OperationDefinition(op) => {
+                if let Some(directives) = op.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(selection_set) = op.selection_set() {
+                    collect_from_selection_set(&selection_set, target_directive, &mut results);
+                }
+            }
+            Definition::FragmentDefinition(frag) => {
+                if let Some(directives) = frag.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(selection_set) = frag.selection_set() {
+                    collect_from_selection_set(&selection_set, target_directive, &mut results);
+                }
+            }
+            Definition::ObjectTypeDefinition(obj) => {
+                if let Some(directives) = obj.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = obj.fields_definition() {
+                    collect_from_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::InterfaceTypeDefinition(iface) => {
+                if let Some(directives) = iface.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = iface.fields_definition() {
+                    collect_from_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::UnionTypeDefinition(union_def) => {
+                if let Some(directives) = union_def.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            Definition::EnumTypeDefinition(enum_def) => {
+                if let Some(directives) = enum_def.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(values) = enum_def.enum_values_definition() {
+                    collect_from_enum_values_definition(&values, target_directive, &mut results);
+                }
+            }
+            Definition::ScalarTypeDefinition(scalar) => {
+                if let Some(directives) = scalar.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            Definition::InputObjectTypeDefinition(input) => {
+                if let Some(directives) = input.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = input.input_fields_definition() {
+                    collect_from_input_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::SchemaDefinition(schema) => {
+                if let Some(directives) = schema.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            Definition::ObjectTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = ext.fields_definition() {
+                    collect_from_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::InterfaceTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = ext.fields_definition() {
+                    collect_from_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::UnionTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            Definition::EnumTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(values) = ext.enum_values_definition() {
+                    collect_from_enum_values_definition(&values, target_directive, &mut results);
+                }
+            }
+            Definition::ScalarTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            Definition::InputObjectTypeExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+                if let Some(fields) = ext.input_fields_definition() {
+                    collect_from_input_fields_definition(&fields, target_directive, &mut results);
+                }
+            }
+            Definition::SchemaExtension(ext) => {
+                if let Some(directives) = ext.directives() {
+                    collect_from_directives(&directives, target_directive, &mut results);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    results
+}
+
 /// Check if `current_type` matches `target_type` directly or implements it as an interface
 fn type_matches_or_implements(
     current_type: &str,

--- a/crates/ide/src/helpers.rs
+++ b/crates/ide/src/helpers.rs
@@ -491,7 +491,7 @@ fn find_directive_usages_in_tree(
                     collect_from_directives(&directives, target_directive, &mut results);
                 }
             }
-            _ => {}
+            Definition::DirectiveDefinition(_) => {}
         }
     }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -168,6 +168,95 @@ pub fn hover(
 
             Some(HoverResult::new(hover_text))
         }
+        Symbol::DirectiveName { name } => {
+            let directives = graphql_hir::schema_directives(db, project_files);
+            let directive = directives.get(name.as_str())?;
+
+            let mut hover_text = format!("**Directive:** `@{name}`\n\n");
+
+            let locations: Vec<&str> = directive
+                .locations
+                .iter()
+                .map(|l| format_directive_location(l))
+                .collect();
+            write!(hover_text, "**Locations:** {}\n\n", locations.join(" | ")).ok();
+
+            if directive.repeatable {
+                write!(hover_text, "**Repeatable:** yes\n\n").ok();
+            }
+
+            if !directive.arguments.is_empty() {
+                write!(hover_text, "**Arguments:**\n\n").ok();
+                for arg in &directive.arguments {
+                    let type_str = format_type_ref(&arg.type_ref);
+                    if let Some(default) = &arg.default_value {
+                        write!(hover_text, "- `{}: {} = {}`\n", arg.name, type_str, default)
+                            .ok();
+                    } else {
+                        write!(hover_text, "- `{}: {}`\n", arg.name, type_str).ok();
+                    }
+                }
+                write!(hover_text, "\n").ok();
+            }
+
+            if let Some(desc) = &directive.description {
+                write!(hover_text, "---\n\n{desc}\n\n").ok();
+            }
+
+            Some(HoverResult::new(hover_text))
+        }
+        Symbol::DirectiveArgumentName {
+            directive_name,
+            argument_name,
+        } => {
+            let directives = graphql_hir::schema_directives(db, project_files);
+            let directive = directives.get(directive_name.as_str())?;
+            let arg = directive
+                .arguments
+                .iter()
+                .find(|a| a.name.as_ref() == argument_name)?;
+
+            let type_str = format_type_ref(&arg.type_ref);
+            let mut hover_text = format!("**Argument:** `{argument_name}: {type_str}`\n\n");
+            write!(hover_text, "**Directive:** `@{directive_name}`\n\n").ok();
+
+            if let Some(default) = &arg.default_value {
+                write!(hover_text, "**Default:** `{default}`\n\n").ok();
+            }
+
+            if let Some(desc) = &arg.description {
+                write!(hover_text, "---\n\n{desc}\n\n").ok();
+            }
+
+            Some(HoverResult::new(hover_text))
+        }
         _ => Some(HoverResult::new(format!("Symbol: {symbol:?}"))),
+    }
+}
+
+pub(crate) fn format_directive_location(
+    location: &graphql_hir::DirectiveLocationKind,
+) -> &'static str {
+    use graphql_hir::DirectiveLocationKind;
+    match location {
+        DirectiveLocationKind::Query => "QUERY",
+        DirectiveLocationKind::Mutation => "MUTATION",
+        DirectiveLocationKind::Subscription => "SUBSCRIPTION",
+        DirectiveLocationKind::Field => "FIELD",
+        DirectiveLocationKind::FragmentDefinition => "FRAGMENT_DEFINITION",
+        DirectiveLocationKind::FragmentSpread => "FRAGMENT_SPREAD",
+        DirectiveLocationKind::InlineFragment => "INLINE_FRAGMENT",
+        DirectiveLocationKind::VariableDefinition => "VARIABLE_DEFINITION",
+        DirectiveLocationKind::Schema => "SCHEMA",
+        DirectiveLocationKind::Scalar => "SCALAR",
+        DirectiveLocationKind::Object => "OBJECT",
+        DirectiveLocationKind::FieldDefinition => "FIELD_DEFINITION",
+        DirectiveLocationKind::ArgumentDefinition => "ARGUMENT_DEFINITION",
+        DirectiveLocationKind::Interface => "INTERFACE",
+        DirectiveLocationKind::Union => "UNION",
+        DirectiveLocationKind::Enum => "ENUM",
+        DirectiveLocationKind::EnumValue => "ENUM_VALUE",
+        DirectiveLocationKind::InputObject => "INPUT_OBJECT",
+        DirectiveLocationKind::InputFieldDefinition => "INPUT_FIELD_DEFINITION",
     }
 }

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -169,8 +169,11 @@ pub fn hover(
             Some(HoverResult::new(hover_text))
         }
         Symbol::DirectiveName { name } => {
-            let directives = graphql_hir::schema_directives(db, project_files);
-            let directive = directives.get(name.as_str())?;
+            let source_directives = graphql_hir::source_schema_directives(db, project_files);
+            let resolved_directives = graphql_hir::schema_directives(db, project_files);
+            let directive = source_directives
+                .get(name.as_str())
+                .or_else(|| resolved_directives.get(name.as_str()))?;
 
             let mut hover_text = format!("**Directive:** `@{name}`\n\n");
 
@@ -209,8 +212,11 @@ pub fn hover(
             directive_name,
             argument_name,
         } => {
-            let directives = graphql_hir::schema_directives(db, project_files);
-            let directive = directives.get(directive_name.as_str())?;
+            let source_directives = graphql_hir::source_schema_directives(db, project_files);
+            let resolved_directives = graphql_hir::schema_directives(db, project_files);
+            let directive = source_directives
+                .get(directive_name.as_str())
+                .or_else(|| resolved_directives.get(directive_name.as_str()))?;
             let arg = directive
                 .arguments
                 .iter()

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -177,7 +177,8 @@ pub fn hover(
             let locations: Vec<&str> = directive
                 .locations
                 .iter()
-                .map(|l| format_directive_location(l))
+                .copied()
+                .map(format_directive_location)
                 .collect();
             write!(hover_text, "**Locations:** {}\n\n", locations.join(" | ")).ok();
 
@@ -190,13 +191,12 @@ pub fn hover(
                 for arg in &directive.arguments {
                     let type_str = format_type_ref(&arg.type_ref);
                     if let Some(default) = &arg.default_value {
-                        write!(hover_text, "- `{}: {} = {}`\n", arg.name, type_str, default)
-                            .ok();
+                        writeln!(hover_text, "- `{}: {} = {}`", arg.name, type_str, default).ok();
                     } else {
-                        write!(hover_text, "- `{}: {}`\n", arg.name, type_str).ok();
+                        writeln!(hover_text, "- `{}: {}`", arg.name, type_str).ok();
                     }
                 }
-                write!(hover_text, "\n").ok();
+                writeln!(hover_text).ok();
             }
 
             if let Some(desc) = &directive.description {
@@ -235,7 +235,7 @@ pub fn hover(
 }
 
 pub(crate) fn format_directive_location(
-    location: &graphql_hir::DirectiveLocationKind,
+    location: graphql_hir::DirectiveLocationKind,
 ) -> &'static str {
     use graphql_hir::DirectiveLocationKind;
     match location {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -1264,6 +1264,76 @@ type User implements Node & Timestamped { id: ID!, createdAt: String! }"#;
     }
 
     #[test]
+    fn test_goto_definition_directive_name() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String @cacheControl(maxAge: 30)\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Cursor on "cacheControl" in the field usage (line 3, after the @)
+        let result = snapshot.goto_definition(&schema_path, Position::new(3, 18));
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn test_goto_definition_directive_argument_name() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String @cacheControl(maxAge: 30)\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Cursor on "maxAge" in usage (line 3)
+        let result = snapshot.goto_definition(&schema_path, Position::new(3, 31));
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn test_goto_definition_directive_on_operation() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @myDirective on QUERY\n\ntype Query { hello: String }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        let doc_path = FilePath::new("file:///query.graphql");
+        host.add_file(
+            &doc_path,
+            "query MyQuery @myDirective {\n  hello\n}",
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let result = snapshot.goto_definition(&doc_path, Position::new(0, 17));
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].file.as_str(), "file:///schema.graphql");
+        assert_eq!(locations[0].range.start.line, 0);
+    }
+
+    #[test]
     fn test_find_references_fragment() {
         let mut host = AnalysisHost::new();
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -6818,4 +6818,118 @@ directive @skip(if: Boolean!) on FIELD"#,
         assert!(hover.contents.contains("maxAge"));
         assert!(hover.contents.contains("Int"));
     }
+
+    #[test]
+    fn test_document_symbols_includes_directives() {
+        let mut host = AnalysisHost::new();
+        let path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &path,
+            "directive @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let symbols = snapshot.document_symbols(&path);
+        let directive_sym = symbols.iter().find(|s| s.name == "@cacheControl");
+        assert!(
+            directive_sym.is_some(),
+            "Should include directive definition in document symbols"
+        );
+        assert_eq!(directive_sym.unwrap().kind, SymbolKind::Directive);
+    }
+
+    #[test]
+    fn test_workspace_symbols_includes_directives() {
+        let mut host = AnalysisHost::new();
+        let path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &path,
+            "directive @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let symbols = snapshot.workspace_symbols("cache");
+        let directive_sym = symbols.iter().find(|s| s.name == "@cacheControl");
+        assert!(
+            directive_sym.is_some(),
+            "Should include directive definition in workspace symbols"
+        );
+        assert_eq!(directive_sym.unwrap().kind, SymbolKind::Directive);
+    }
+
+    #[test]
+    fn test_find_references_directive() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @deprecated(reason: String) on FIELD_DEFINITION\n\ntype Query {\n  oldField: String @deprecated(reason: \"use newField\")\n  newField: String\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Without declaration - just usages
+        // Position on @deprecated usage: line 3, inside "deprecated"
+        let result = snapshot.find_references(&schema_path, Position::new(3, 21), false);
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].range.start.line, 3);
+    }
+
+    #[test]
+    fn test_find_references_directive_with_declaration() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        // "directive @tag(name: String!) on FIELD_DEFINITION\n\ntype Query {\n  a: String @tag(name: \"public\")\n  b: Int @tag(name: \"internal\")\n}"
+        host.add_file(
+            &schema_path,
+            "directive @tag(name: String!) on FIELD_DEFINITION\n\ntype Query {\n  a: String @tag(name: \"public\")\n  b: Int @tag(name: \"internal\")\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Position on @tag usage: line 3 "  a: String @tag(...)" -> "@tag" starts at col 12, "tag" at col 13
+        let result = snapshot.find_references(&schema_path, Position::new(3, 13), true);
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 3); // declaration + 2 usages
+    }
+
+    #[test]
+    fn test_find_references_directive_across_files() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @myDir on QUERY\n\ntype Query { hello: String }",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        let doc_path = FilePath::new("file:///query.graphql");
+        host.add_file(
+            &doc_path,
+            "query Foo @myDir {\n  hello\n}",
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Position on @myDir usage in query file: "query Foo @myDir" -> "myDir" starts at col 11
+        let result = snapshot.find_references(&doc_path, Position::new(0, 11), true);
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 2); // declaration + usage in query file
+    }
 }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -6907,6 +6907,68 @@ directive @skip(if: Boolean!) on FIELD"#,
     }
 
     #[test]
+    fn test_find_references_directive_from_definition() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @tag(name: String!) on FIELD_DEFINITION\n\ntype Query {\n  a: String @tag(name: \"public\")\n  b: Int @tag(name: \"internal\")\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Cursor on "tag" in the directive DEFINITION (line 0, col 11 = 't' in 'tag')
+        let result = snapshot.find_references(&schema_path, Position::new(0, 11), true);
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 3); // declaration + 2 usages
+    }
+
+    #[test]
+    fn test_goto_definition_from_directive_definition() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "directive @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String @cacheControl(maxAge: 30)\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Cursor on "cacheControl" in the directive definition (line 0)
+        let result = snapshot.goto_definition(&schema_path, Position::new(0, 12));
+        assert!(result.is_some());
+        let locations = result.unwrap();
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn test_hover_on_directive_definition() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "\"Cache control\"\ndirective @cacheControl(maxAge: Int) on FIELD_DEFINITION\n\ntype Query {\n  hello: String\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        // Cursor on "cacheControl" in the directive definition (line 1)
+        let result = snapshot.hover(&schema_path, Position::new(1, 12));
+        assert!(result.is_some());
+        let hover = result.unwrap();
+        assert!(hover.contents.contains("@cacheControl"));
+        assert!(hover.contents.contains("FIELD_DEFINITION"));
+    }
+
+    #[test]
     fn test_find_references_directive_across_files() {
         let mut host = AnalysisHost::new();
         let schema_path = FilePath::new("file:///schema.graphql");

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -6777,4 +6777,45 @@ directive @skip(if: Boolean!) on FIELD"#,
         );
         assert_eq!(query_refs.len(), 1, "Should have 1 usage in query file");
     }
+
+    #[test]
+    fn test_hover_on_directive_usage() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "\"Cache control directive\"\ndirective @cacheControl(maxAge: Int) repeatable on FIELD_DEFINITION\n\ntype Query {\n  hello: String @cacheControl(maxAge: 30)\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let result = snapshot.hover(&schema_path, Position::new(4, 18));
+        assert!(result.is_some());
+        let hover = result.unwrap();
+        assert!(hover.contents.contains("@cacheControl"));
+        assert!(hover.contents.contains("FIELD_DEFINITION"));
+        assert!(hover.contents.contains("Repeatable"));
+    }
+
+    #[test]
+    fn test_hover_on_directive_argument() {
+        let mut host = AnalysisHost::new();
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            "\"Cache control\"\ndirective @cacheControl(\"Max age in seconds\" maxAge: Int = 60) on FIELD_DEFINITION\n\ntype Query {\n  hello: String @cacheControl(maxAge: 30)\n}",
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let result = snapshot.hover(&schema_path, Position::new(4, 31));
+        assert!(result.is_some());
+        let hover = result.unwrap();
+        assert!(hover.contents.contains("maxAge"));
+        assert!(hover.contents.contains("Int"));
+    }
 }

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -335,10 +335,15 @@ fn find_directive_references(
         return locations;
     };
 
-    let directives = graphql_hir::schema_directives(db, project_files);
+    // Prefer source schema for declaration location
+    let source_directives = graphql_hir::source_schema_directives(db, project_files);
+    let resolved_directives = graphql_hir::schema_directives(db, project_files);
 
     if include_declaration {
-        if let Some(directive) = directives.get(directive_name) {
+        if let Some(directive) = source_directives
+            .get(directive_name)
+            .or_else(|| resolved_directives.get(directive_name))
+        {
             if let Some(file_path) = registry.get_path(directive.file_id) {
                 if let (Some(content), Some(metadata)) = (
                     registry.get_content(directive.file_id),

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -8,9 +8,10 @@
 use std::sync::Arc;
 
 use crate::helpers::{
-    find_block_for_position, find_field_usages_in_parse, find_fragment_definition_in_parse,
-    find_fragment_spreads_in_parse, find_type_definition_in_parse, find_type_references_in_parse,
-    offset_range_to_range, position_to_offset,
+    find_block_for_position, find_directive_definition_in_parse, find_directive_usages_in_parse,
+    find_field_usages_in_parse, find_fragment_definition_in_parse, find_fragment_spreads_in_parse,
+    find_type_definition_in_parse, find_type_references_in_parse, offset_range_to_range,
+    position_to_offset,
 };
 use crate::symbol::{find_schema_field_parent_type, find_symbol_at_offset, Symbol};
 use crate::types::{FilePath, Location, Position};
@@ -76,6 +77,13 @@ pub fn find_references(
                 include_declaration,
             ))
         }
+        Symbol::DirectiveName { name } => Some(find_directive_references(
+            db,
+            registry,
+            project_files,
+            &name,
+            include_declaration,
+        )),
         _ => None,
     }
 }
@@ -307,6 +315,76 @@ pub fn find_field_references(
         let field_ranges = find_field_usages_in_parse(&parse, type_name, field_name, schema_types);
 
         for range in field_ranges {
+            locations.push(Location::new(file_path.clone(), range));
+        }
+    }
+
+    locations
+}
+
+/// Find all references to a directive.
+fn find_directive_references(
+    db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
+    registry: DbFiles<'_>,
+    project_files: Option<graphql_base_db::ProjectFiles>,
+    directive_name: &str,
+    include_declaration: bool,
+) -> Vec<Location> {
+    let mut locations = Vec::new();
+    let Some(project_files) = project_files else {
+        return locations;
+    };
+
+    let directives = graphql_hir::schema_directives(db, project_files);
+
+    if include_declaration {
+        if let Some(directive) = directives.get(directive_name) {
+            if let Some(file_path) = registry.get_path(directive.file_id) {
+                if let (Some(content), Some(metadata)) = (
+                    registry.get_content(directive.file_id),
+                    registry.get_metadata(directive.file_id),
+                ) {
+                    let def_parse = graphql_syntax::parse(db, content, metadata);
+                    if let Some(range) =
+                        find_directive_definition_in_parse(&def_parse, directive_name)
+                    {
+                        locations.push(Location::new(file_path, range));
+                    }
+                }
+            }
+        }
+    }
+
+    // Scan schema files for usages
+    let schema_ids = project_files.schema_file_ids(db).ids(db);
+    for file_id in schema_ids.iter() {
+        let Some((content, metadata)) = graphql_base_db::file_lookup(db, project_files, *file_id)
+        else {
+            continue;
+        };
+        let Some(file_path) = registry.get_path(*file_id) else {
+            continue;
+        };
+
+        let parse = graphql_syntax::parse(db, content, metadata);
+        for range in find_directive_usages_in_parse(&parse, directive_name) {
+            locations.push(Location::new(file_path.clone(), range));
+        }
+    }
+
+    // Scan document files for usages
+    let doc_ids = project_files.document_file_ids(db).ids(db);
+    for file_id in doc_ids.iter() {
+        let Some((content, metadata)) = graphql_base_db::file_lookup(db, project_files, *file_id)
+        else {
+            continue;
+        };
+        let Some(file_path) = registry.get_path(*file_id) else {
+            continue;
+        };
+
+        let parse = graphql_syntax::parse(db, content, metadata);
+        for range in find_directive_usages_in_parse(&parse, directive_name) {
             locations.push(Location::new(file_path.clone(), range));
         }
     }

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -45,7 +45,11 @@ pub fn prepare_rename(
             Some(range)
         }
         // Schema symbols cannot be renamed through document operations
-        Symbol::TypeName { .. } | Symbol::FieldName { .. } | Symbol::ArgumentName { .. } => None,
+        Symbol::TypeName { .. }
+        | Symbol::FieldName { .. }
+        | Symbol::ArgumentName { .. }
+        | Symbol::DirectiveName { .. }
+        | Symbol::DirectiveArgumentName { .. } => None,
     }
 }
 
@@ -77,7 +81,11 @@ pub fn rename(
         }
         Symbol::OperationName { name } => rename_operation(db, registry, file, &name, new_name),
         Symbol::VariableReference { name } => rename_variable(db, registry, file, &name, new_name),
-        Symbol::TypeName { .. } | Symbol::FieldName { .. } | Symbol::ArgumentName { .. } => None,
+        Symbol::TypeName { .. }
+        | Symbol::FieldName { .. }
+        | Symbol::ArgumentName { .. }
+        | Symbol::DirectiveName { .. }
+        | Symbol::DirectiveArgumentName { .. } => None,
     }
 }
 

--- a/crates/ide/src/symbol.rs
+++ b/crates/ide/src/symbol.rs
@@ -189,6 +189,13 @@ pub enum Symbol {
     VariableReference { name: String },
     /// An argument name in a field or directive
     ArgumentName { name: String },
+    /// A directive name (@directiveName)
+    DirectiveName { name: String },
+    /// An argument name within a directive's argument list
+    DirectiveArgumentName {
+        directive_name: String,
+        argument_name: String,
+    },
 }
 
 /// Find the symbol at a specific byte offset in the document
@@ -491,53 +498,95 @@ fn check_definition(definition: &cst::Definition, byte_offset: usize) -> Option<
         cst::Definition::FragmentDefinition(frag) => check_fragment_definition(frag, byte_offset),
         cst::Definition::ObjectTypeDefinition(obj) => {
             check_type_definition_name(obj.name(), byte_offset)
+                .or_else(|| {
+                    obj.directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
                 .or_else(|| check_implements_interfaces(obj.implements_interfaces(), byte_offset))
                 .or_else(|| check_fields_definition(obj.fields_definition(), byte_offset))
         }
         cst::Definition::InterfaceTypeDefinition(iface) => {
             check_type_definition_name(iface.name(), byte_offset)
-                .or_else(|| check_implements_interfaces(iface.implements_interfaces(), byte_offset))
+                .or_else(|| {
+                    iface
+                        .directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
+                .or_else(|| {
+                    check_implements_interfaces(iface.implements_interfaces(), byte_offset)
+                })
                 .or_else(|| check_fields_definition(iface.fields_definition(), byte_offset))
         }
         cst::Definition::ObjectTypeExtension(ext) => {
             check_type_definition_name(ext.name(), byte_offset)
+                .or_else(|| {
+                    ext.directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
                 .or_else(|| check_implements_interfaces(ext.implements_interfaces(), byte_offset))
                 .or_else(|| check_fields_definition(ext.fields_definition(), byte_offset))
         }
         cst::Definition::InterfaceTypeExtension(ext) => {
             check_type_definition_name(ext.name(), byte_offset)
+                .or_else(|| {
+                    ext.directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
                 .or_else(|| check_implements_interfaces(ext.implements_interfaces(), byte_offset))
                 .or_else(|| check_fields_definition(ext.fields_definition(), byte_offset))
         }
-        cst::Definition::UnionTypeDefinition(union) => {
-            check_type_definition_name(union.name(), byte_offset).or_else(|| {
-                if let Some(members) = union.union_member_types() {
-                    for member in members.named_types() {
-                        if let Some(name) = member.name() {
-                            if is_within_range(&name, byte_offset) {
-                                return Some(Symbol::TypeName {
-                                    name: name.text().to_string(),
-                                });
+        cst::Definition::UnionTypeDefinition(union_def) => {
+            check_type_definition_name(union_def.name(), byte_offset)
+                .or_else(|| {
+                    union_def
+                        .directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
+                .or_else(|| {
+                    if let Some(members) = union_def.union_member_types() {
+                        for member in members.named_types() {
+                            if let Some(name) = member.name() {
+                                if is_within_range(&name, byte_offset) {
+                                    return Some(Symbol::TypeName {
+                                        name: name.text().to_string(),
+                                    });
+                                }
                             }
                         }
                     }
-                }
-                None
-            })
+                    None
+                })
         }
         cst::Definition::EnumTypeDefinition(enum_def) => {
-            check_type_definition_name(enum_def.name(), byte_offset)
+            check_type_definition_name(enum_def.name(), byte_offset).or_else(|| {
+                enum_def
+                    .directives()
+                    .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+            })
         }
         cst::Definition::ScalarTypeDefinition(scalar) => {
-            check_type_definition_name(scalar.name(), byte_offset)
+            check_type_definition_name(scalar.name(), byte_offset).or_else(|| {
+                scalar
+                    .directives()
+                    .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+            })
         }
         cst::Definition::ScalarTypeExtension(ext) => {
-            check_type_definition_name(ext.name(), byte_offset)
+            check_type_definition_name(ext.name(), byte_offset).or_else(|| {
+                ext.directives()
+                    .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+            })
         }
         cst::Definition::InputObjectTypeDefinition(input) => {
-            check_type_definition_name(input.name(), byte_offset).or_else(|| {
-                check_input_fields_definition(input.input_fields_definition(), byte_offset)
-            })
+            check_type_definition_name(input.name(), byte_offset)
+                .or_else(|| {
+                    input
+                        .directives()
+                        .and_then(|d| check_directives_for_symbol(&d, byte_offset))
+                })
+                .or_else(|| {
+                    check_input_fields_definition(input.input_fields_definition(), byte_offset)
+                })
         }
         _ => None,
     }
@@ -568,6 +617,16 @@ fn check_fields_definition(
                         return Some(symbol);
                     }
                 }
+                if let Some(directives) = arg.directives() {
+                    if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+                        return Some(symbol);
+                    }
+                }
+            }
+        }
+        if let Some(directives) = field.directives() {
+            if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+                return Some(symbol);
             }
         }
     }
@@ -582,6 +641,11 @@ fn check_input_fields_definition(
     for field in fields.input_value_definitions() {
         if let Some(ty) = field.ty() {
             if let Some(symbol) = check_type_reference(&ty, byte_offset) {
+                return Some(symbol);
+            }
+        }
+        if let Some(directives) = field.directives() {
+            if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
                 return Some(symbol);
             }
         }
@@ -662,6 +726,12 @@ fn check_operation(op: &cst::OperationDefinition, byte_offset: usize) -> Option<
         }
     }
 
+    if let Some(directives) = op.directives() {
+        if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+            return Some(symbol);
+        }
+    }
+
     if let Some(selection_set) = op.selection_set() {
         if let Some(symbol) = check_selection_set(&selection_set, byte_offset) {
             return Some(symbol);
@@ -691,6 +761,12 @@ fn check_fragment_definition(frag: &cst::FragmentDefinition, byte_offset: usize)
                     });
                 }
             }
+        }
+    }
+
+    if let Some(directives) = frag.directives() {
+        if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+            return Some(symbol);
         }
     }
 
@@ -753,6 +829,45 @@ fn check_value(value: &cst::Value, byte_offset: usize) -> Option<Symbol> {
     None
 }
 
+fn check_directives_for_symbol(
+    directives: &cst::Directives,
+    byte_offset: usize,
+) -> Option<Symbol> {
+    for directive in directives.directives() {
+        if let Some(name) = directive.name() {
+            if is_within_range(&name, byte_offset) {
+                return Some(Symbol::DirectiveName {
+                    name: name.text().to_string(),
+                });
+            }
+        }
+        if let Some(arguments) = directive.arguments() {
+            let args_range = arguments.syntax().text_range();
+            let args_start: usize = args_range.start().into();
+            let args_end: usize = args_range.end().into();
+            if byte_offset >= args_start && byte_offset <= args_end {
+                let directive_name = directive.name()?.text().to_string();
+                for arg in arguments.arguments() {
+                    if let Some(arg_name) = arg.name() {
+                        if is_within_range(&arg_name, byte_offset) {
+                            return Some(Symbol::DirectiveArgumentName {
+                                directive_name,
+                                argument_name: arg_name.text().to_string(),
+                            });
+                        }
+                    }
+                    if let Some(value) = arg.value() {
+                        if let Some(symbol) = check_value(&value, byte_offset) {
+                            return Some(symbol);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 fn check_selection_set(selection_set: &cst::SelectionSet, byte_offset: usize) -> Option<Symbol> {
     for selection in selection_set.selections() {
         match selection {
@@ -771,6 +886,12 @@ fn check_selection_set(selection_set: &cst::SelectionSet, byte_offset: usize) ->
                     }
                 }
 
+                if let Some(directives) = field.directives() {
+                    if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+                        return Some(symbol);
+                    }
+                }
+
                 if let Some(nested) = field.selection_set() {
                     if let Some(symbol) = check_selection_set(&nested, byte_offset) {
                         return Some(symbol);
@@ -785,6 +906,12 @@ fn check_selection_set(selection_set: &cst::SelectionSet, byte_offset: usize) ->
                         });
                     }
                 }
+
+                if let Some(directives) = spread.directives() {
+                    if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+                        return Some(symbol);
+                    }
+                }
             }
             cst::Selection::InlineFragment(inline_frag) => {
                 if let Some(type_cond) = inline_frag.type_condition() {
@@ -796,6 +923,12 @@ fn check_selection_set(selection_set: &cst::SelectionSet, byte_offset: usize) ->
                                 });
                             }
                         }
+                    }
+                }
+
+                if let Some(directives) = inline_frag.directives() {
+                    if let Some(symbol) = check_directives_for_symbol(&directives, byte_offset) {
+                        return Some(symbol);
                     }
                 }
 

--- a/crates/ide/src/symbol.rs
+++ b/crates/ide/src/symbol.rs
@@ -512,9 +512,7 @@ fn check_definition(definition: &cst::Definition, byte_offset: usize) -> Option<
                         .directives()
                         .and_then(|d| check_directives_for_symbol(&d, byte_offset))
                 })
-                .or_else(|| {
-                    check_implements_interfaces(iface.implements_interfaces(), byte_offset)
-                })
+                .or_else(|| check_implements_interfaces(iface.implements_interfaces(), byte_offset))
                 .or_else(|| check_fields_definition(iface.fields_definition(), byte_offset))
         }
         cst::Definition::ObjectTypeExtension(ext) => {
@@ -829,10 +827,7 @@ fn check_value(value: &cst::Value, byte_offset: usize) -> Option<Symbol> {
     None
 }
 
-fn check_directives_for_symbol(
-    directives: &cst::Directives,
-    byte_offset: usize,
-) -> Option<Symbol> {
+fn check_directives_for_symbol(directives: &cst::Directives, byte_offset: usize) -> Option<Symbol> {
     for directive in directives.directives() {
         if let Some(name) = directive.name() {
             if is_within_range(&name, byte_offset) {

--- a/crates/ide/src/symbol.rs
+++ b/crates/ide/src/symbol.rs
@@ -1709,6 +1709,22 @@ pub fn extract_all_definitions(
                     ));
                 }
             }
+            cst::Definition::DirectiveDefinition(dir) => {
+                if let Some(name) = dir.name() {
+                    let name_range = name.syntax().text_range();
+                    let def_range = dir.syntax().text_range();
+                    results.push((
+                        format!("@{}", name.text()),
+                        "directive",
+                        SymbolRanges {
+                            name_start: name_range.start().into(),
+                            name_end: name_range.end().into(),
+                            def_start: def_range.start().into(),
+                            def_end: def_range.end().into(),
+                        },
+                    ));
+                }
+            }
             _ => {}
         }
     }

--- a/crates/ide/src/symbol.rs
+++ b/crates/ide/src/symbol.rs
@@ -586,6 +586,35 @@ fn check_definition(definition: &cst::Definition, byte_offset: usize) -> Option<
                     check_input_fields_definition(input.input_fields_definition(), byte_offset)
                 })
         }
+        cst::Definition::DirectiveDefinition(dir) => {
+            if let Some(name) = dir.name() {
+                if is_within_range(&name, byte_offset) {
+                    return Some(Symbol::DirectiveName {
+                        name: name.text().to_string(),
+                    });
+                }
+            }
+            if let Some(args) = dir.arguments_definition() {
+                for arg in args.input_value_definitions() {
+                    if let Some(arg_name) = arg.name() {
+                        if is_within_range(&arg_name, byte_offset) {
+                            let directive_name =
+                                dir.name().map(|n| n.text().to_string()).unwrap_or_default();
+                            return Some(Symbol::DirectiveArgumentName {
+                                directive_name,
+                                argument_name: arg_name.text().to_string(),
+                            });
+                        }
+                    }
+                    if let Some(ty) = arg.ty() {
+                        if let Some(symbol) = check_type_reference(&ty, byte_offset) {
+                            return Some(symbol);
+                        }
+                    }
+                }
+            }
+            None
+        }
         _ => None,
     }
 }

--- a/crates/ide/src/symbols.rs
+++ b/crates/ide/src/symbols.rs
@@ -163,7 +163,7 @@ pub fn workspace_symbols(
         }
     }
 
-    let directives = graphql_hir::schema_directives(db, project_files);
+    let directives = graphql_hir::source_schema_directives(db, project_files);
     for (dir_name, directive) in directives {
         let search_name = format!("@{dir_name}");
         if search_name.to_lowercase().contains(&query_lower)

--- a/crates/ide/src/symbols.rs
+++ b/crates/ide/src/symbols.rs
@@ -101,6 +101,9 @@ pub fn document_symbols(
                     }
                     sym
                 }
+                "directive" => {
+                    DocumentSymbol::new(name, SymbolKind::Directive, range, selection_range)
+                }
                 _ => continue,
             };
 
@@ -156,6 +159,22 @@ pub fn workspace_symbols(
                     WorkspaceSymbol::new(name.to_string(), SymbolKind::Fragment, location)
                         .with_container(format!("on {}", fragment.type_condition)),
                 );
+            }
+        }
+    }
+
+    let directives = graphql_hir::schema_directives(db, project_files);
+    for (dir_name, directive) in directives.iter() {
+        let search_name = format!("@{dir_name}");
+        if search_name.to_lowercase().contains(&query_lower)
+            || dir_name.to_lowercase().contains(&query_lower)
+        {
+            if let Some(location) = get_directive_location(db, registry, directive) {
+                symbols.push(WorkspaceSymbol::new(
+                    search_name,
+                    SymbolKind::Directive,
+                    location,
+                ));
             }
         }
     }
@@ -395,6 +414,37 @@ fn get_operation_location(
             let doc_line_index = graphql_syntax::LineIndex::new(doc.source);
             let range = adjust_range_for_line_offset(
                 offset_range_to_range(&doc_line_index, ranges.name_start, ranges.name_end),
+                doc.line_offset,
+            );
+            return Some(Location::new(file_path, range));
+        }
+    }
+
+    None
+}
+
+/// Get location for a directive definition.
+fn get_directive_location(
+    db: &dyn graphql_analysis::GraphQLAnalysisDatabase,
+    registry: DbFiles<'_>,
+    directive: &graphql_hir::DirectiveDef,
+) -> Option<Location> {
+    let file_path = registry.get_path(directive.file_id)?;
+    let content = registry.get_content(directive.file_id)?;
+    let metadata = registry.get_metadata(directive.file_id)?;
+
+    let parse = graphql_syntax::parse(db, content, metadata);
+
+    // Find the directive definition in the CST to get proper line offset context
+    for doc in parse.documents() {
+        let doc_line_index = graphql_syntax::LineIndex::new(doc.source);
+        let start: usize = directive.name_range.start().into();
+        let end: usize = directive.name_range.end().into();
+
+        // Check if this range falls within this document's source
+        if start <= doc.source.len() {
+            let range = adjust_range_for_line_offset(
+                offset_range_to_range(&doc_line_index, start, end),
                 doc.line_offset,
             );
             return Some(Location::new(file_path, range));

--- a/crates/ide/src/symbols.rs
+++ b/crates/ide/src/symbols.rs
@@ -164,7 +164,7 @@ pub fn workspace_symbols(
     }
 
     let directives = graphql_hir::schema_directives(db, project_files);
-    for (dir_name, directive) in directives.iter() {
+    for (dir_name, directive) in directives {
         let search_name = format!("@{dir_name}");
         if search_name.to_lowercase().contains(&query_lower)
             || dir_name.to_lowercase().contains(&query_lower)

--- a/crates/ide/src/types.rs
+++ b/crates/ide/src/types.rs
@@ -326,6 +326,8 @@ pub enum SymbolKind {
     Union,
     /// Enum type
     Enum,
+    /// Directive definition
+    Directive,
 }
 
 /// A document symbol (hierarchical structure for outline view)

--- a/crates/lsp/src/conversions.rs
+++ b/crates/lsp/src/conversions.rs
@@ -125,6 +125,7 @@ pub const fn convert_ide_symbol_kind(kind: graphql_ide::SymbolKind) -> lsp_types
         graphql_ide::SymbolKind::Union | graphql_ide::SymbolKind::Enum => {
             lsp_types::SymbolKind::ENUM
         }
+        graphql_ide::SymbolKind::Directive => lsp_types::SymbolKind::EVENT,
     }
 }
 
@@ -499,6 +500,10 @@ mod tests {
         assert_eq!(
             convert_ide_symbol_kind(graphql_ide::SymbolKind::Interface),
             lsp_types::SymbolKind::INTERFACE
+        );
+        assert_eq!(
+            convert_ide_symbol_kind(graphql_ide::SymbolKind::Directive),
+            lsp_types::SymbolKind::EVENT
         );
     }
 

--- a/crates/mcp/src/types.rs
+++ b/crates/mcp/src/types.rs
@@ -410,6 +410,7 @@ fn symbol_kind_str(kind: graphql_ide::SymbolKind) -> &'static str {
         graphql_ide::SymbolKind::Interface => "interface",
         graphql_ide::SymbolKind::Union => "union",
         graphql_ide::SymbolKind::Enum => "enum",
+        graphql_ide::SymbolKind::Directive => "directive",
     }
 }
 


### PR DESCRIPTION
## Summary

- Add go-to-definition for directive names (`@directive` -> definition) and directive arguments (`argName` -> argument definition within the directive)
- Add hover for directives (shows description, valid locations, arguments, repeatable status) and directive arguments (shows type, default value, description)
- Add find-references for directives across all schema and document files
- Add directive definitions to document symbols (file outline) and workspace symbols (Cmd+T search)

The foundation is two new `Symbol` enum variants (`DirectiveName`, `DirectiveArgumentName`) with CST detection wired into all definition types, selection sets, fields, and fragments.

## Test plan

- [x] 12 new integration tests covering all features (254 total IDE tests pass)
- [x] All 27 LSP tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean