### PR TITLE
feat(ide): show inlay type hints on non-leaf fields

### DIFF
--- a/.changeset/object-type-inlays.md
+++ b/.changeset/object-type-inlays.md
@@ -3,4 +3,4 @@ graphql-analyzer-lsp: minor
 graphql-analyzer-vscode: minor
 ---
 
-Show inlay type hints on non-leaf (object type) fields in queries
+Show inlay type hints on non-leaf (object type) fields in queries ([#970](https://github.com/trevor-scheer/graphql-analyzer/pull/970))

--- a/.changeset/object-type-inlays.md
+++ b/.changeset/object-type-inlays.md
@@ -1,0 +1,6 @@
+---
+graphql-analyzer-lsp: minor
+graphql-analyzer-vscode: minor
+---
+
+Show inlay type hints on non-leaf (object type) fields in queries

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -1,7 +1,7 @@
 //! Inlay hints feature implementation.
 //!
 //! This module provides IDE inlay hints functionality:
-//! - Field return types (displayed after scalar field selections)
+//! - Field return types (displayed after field selections)
 //!
 //! Note: Variable definition types are NOT shown as hints since they already
 //! have explicit type annotations in the GraphQL syntax.
@@ -17,9 +17,10 @@ use crate::DbFiles;
 
 /// Get inlay hints for a file.
 ///
-/// Returns inlay hints showing return types after scalar field selections.
-/// Hints are only shown for leaf fields (fields without nested selection sets)
-/// since the return type is not visible in the query syntax.
+/// Returns inlay hints showing return types for all field selections.
+/// For leaf fields, the hint appears after the field name/alias.
+/// For non-leaf fields, the hint appears after arguments (if any) and
+/// before the opening brace of the selection set.
 ///
 /// If `range` is provided, only returns hints within that range for efficiency.
 pub fn inlay_hints(
@@ -182,25 +183,33 @@ fn collect_selection_set_hints(
                         .iter()
                         .find(|f| f.name.as_ref() == field_name)
                     {
-                        // If there's no selection set, show the type hint
-                        // (for scalar fields, showing the type is most useful)
-                        if field.selection_set().is_none() {
-                            let end_offset: usize = end_node.into();
-                            let position = offset_to_position(line_index, end_offset);
-                            let adjusted = adjust_position_for_line_offset(position, line_offset);
+                        let nested = field.selection_set();
 
-                            if should_include_position(adjusted, range) {
-                                let type_str = format_type_ref(&field_def.type_ref);
-                                hints.push(InlayHint::new(
-                                    adjusted,
-                                    format!(": {type_str}"),
-                                    InlayHintKind::Type,
-                                ));
-                            }
+                        // For non-leaf fields, position hint after arguments
+                        // (before the opening brace) when present
+                        let hint_end_node = if nested.is_some() {
+                            field
+                                .arguments()
+                                .map_or(end_node, |args| args.syntax().text_range().end())
+                        } else {
+                            end_node
+                        };
+
+                        let end_offset: usize = hint_end_node.into();
+                        let position = offset_to_position(line_index, end_offset);
+                        let adjusted = adjust_position_for_line_offset(position, line_offset);
+
+                        if should_include_position(adjusted, range) {
+                            let type_str = format_type_ref(&field_def.type_ref);
+                            hints.push(InlayHint::new(
+                                adjusted,
+                                format!(": {type_str}"),
+                                InlayHintKind::Type,
+                            ));
                         }
 
                         // Recurse into nested selection sets
-                        if let Some(nested) = field.selection_set() {
+                        if let Some(nested) = nested {
                             let field_type_name = field_def.type_ref.name.as_ref();
                             collect_selection_set_hints(
                                 &nested,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -5651,13 +5651,17 @@ type Post {
         let snapshot = host.snapshot();
         let hints = snapshot.inlay_hints(&doc_path, None);
 
-        // Should have hints for both __typename and name
+        // Should have hints for user (object type), __typename, and name
         assert_eq!(
             hints.len(),
-            2,
-            "Expected 2 inlay hints (for __typename and name), got {}",
+            3,
+            "Expected 3 inlay hints (user, __typename, name), got {}",
             hints.len()
         );
+
+        // Check user shows User type hint
+        let user_hint = hints.iter().find(|h| h.label == ": User");
+        assert!(user_hint.is_some(), "Expected user hint with 'User' type");
 
         // Check __typename shows String! hint
         let typename_hint = hints.iter().find(|h| h.label == ": String!");
@@ -5665,6 +5669,67 @@ type Post {
             typename_hint.is_some(),
             "Expected __typename hint with 'String!' type"
         );
+    }
+
+    #[test]
+    fn test_inlay_hints_object_type_fields() {
+        let mut host = AnalysisHost::new();
+
+        let schema_path = FilePath::new("file:///schema.graphql");
+        host.add_file(
+            &schema_path,
+            r#"type Query { user(id: ID!): User }
+type User {
+  name: String!
+  posts: [Post!]!
+}
+type Post {
+  title: String!
+}"#,
+            Language::GraphQL,
+            DocumentKind::Schema,
+        );
+
+        let doc_path = FilePath::new("file:///query.graphql");
+        host.add_file(
+            &doc_path,
+            // Non-leaf fields with and without arguments
+            r#"query {
+  user(id: "1") {
+    name
+    posts {
+      title
+    }
+  }
+}"#,
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+
+        host.rebuild_project_files();
+
+        let snapshot = host.snapshot();
+        let hints = snapshot.inlay_hints(&doc_path, None);
+
+        let hint_labels: Vec<&str> = hints.iter().map(|h| h.label.as_str()).collect();
+
+        // Non-leaf fields should get type hints too
+        assert!(
+            hint_labels.contains(&": User"),
+            "Expected User type hint for user field, got: {hint_labels:?}"
+        );
+        assert!(
+            hint_labels.contains(&": [Post]!"),
+            "Expected [Post]! type hint for posts field, got: {hint_labels:?}"
+        );
+
+        // user(id: "1") hint should appear after the arguments
+        let user_hint = hints.iter().find(|h| h.label == ": User").unwrap();
+        let name_hint = hints.iter().find(|h| h.label == ": String!").unwrap();
+        // user hint should be on line 1, after the closing paren of args
+        assert_eq!(user_hint.position.line, 1);
+        // name hint should be on a later line
+        assert!(name_hint.position.line > user_hint.position.line);
     }
 
     // =============================================================================


### PR DESCRIPTION
## Summary

Extends inlay hints to show return types for non-leaf (object type) fields in queries, not just scalar/leaf fields. For fields with arguments, the hint appears after the closing `)` and before the opening `{`.

## Changes

- Show type hints on all field selections, not just leaf fields
- Position hints after arguments when present on non-leaf fields
- Add `test_inlay_hints_object_type_fields` test covering non-leaf fields with and without arguments
- Update `test_inlay_hints_typename` to account for new `user` field hint

## Consulted SME Agents

- N/A

## Manual Testing Plan

- Open a `.graphql` file with nested queries in VS Code
- Verify non-leaf fields like `user { ... }` show their return type (e.g., `: User`) as an inlay hint
- Verify fields with arguments like `user(id: "1") { ... }` show the hint after the closing paren, before the `{`
- Verify leaf fields still show hints as before

## Related Issues