### PR TITLE
fix(hooks): add pre-push safety gates

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Pre-push checks: ensure lint, formatting, and tests pass before pushing.
+# Installed by cargo-husky.
+#
+
+set -e
+
+# Get the range of commits being pushed
+remote="$1"
+url="$2"
+
+while read local_ref local_sha remote_ref remote_sha; do
+    # Skip deletes
+    if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+        continue
+    fi
+
+    # For new branches, compare against main
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        remote_sha=$(git merge-base HEAD main 2>/dev/null || echo "")
+        if [ -z "$remote_sha" ]; then
+            # Can't determine base, run all checks
+            remote_sha="HEAD~1"
+        fi
+    fi
+
+    # Get list of changed files in the push
+    changed_files=$(git diff --name-only "$remote_sha" "$local_sha" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+
+    # Check Rust formatting if any Rust files changed
+    if echo "$changed_files" | grep -qE '\.rs$'; then
+        echo '+cargo fmt --check'
+        cargo fmt --check
+    fi
+
+    # Run clippy if any Rust or TOML files changed
+    if echo "$changed_files" | grep -qE '\.(rs|toml)$'; then
+        echo '+cargo clippy --workspace --all-targets --all-features -- -D warnings'
+        cargo clippy --workspace --all-targets --all-features -- -D warnings
+    fi
+
+    # Lint TS/JS files if any changed
+    if echo "$changed_files" | grep -qE '\.(ts|tsx|js|jsx)$'; then
+        echo '+npm run lint'
+        npm run lint
+    fi
+
+    # Check formatting with oxfmt for supported file types
+    if echo "$changed_files" | grep -qE '\.(graphql|ts|tsx|js|md|yaml|yml|toml|json)$'; then
+        echo '+npm run fmt:check'
+        npm run fmt:check
+    fi
+
+    # Run tests if any source files changed
+    if echo "$changed_files" | grep -qE '\.(rs|toml)$'; then
+        echo '+cargo test'
+        cargo test
+    fi
+done

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# PreToolUse hook: block --no-verify flag in git commands.
+# Git hooks enforce lint/fmt/test checks and must not be bypassed.
+#
+
+command=$(echo "$CLAUDE_TOOL_INPUT" | jq -r '.command // empty')
+
+if echo "$command" | grep -q -- '--no-verify\|-n '; then
+    # Only block -n for git commit (not other commands where -n means something else)
+    if echo "$command" | grep -q -- '--no-verify'; then
+        echo "BLOCKED: --no-verify is not allowed. Git hooks must not be bypassed." >&2
+        exit 2
+    fi
+    if echo "$command" | grep -qE 'git commit.*-n\b'; then
+        echo "BLOCKED: git commit -n (--no-verify) is not allowed. Git hooks must not be bypassed." >&2
+        exit 2
+    fi
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,11 +71,22 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit:*)",
             "command": "cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push:*)",
+            "command": "cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git:*)",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-no-verify.sh"
           }
         ]
       }

--- a/.husky/README.md
+++ b/.husky/README.md
@@ -1,21 +1,33 @@
-# Pre-commit Hooks
+# Git Hooks
 
-This directory contains the git pre-commit hook configuration.
+This directory contains the git hook configuration.
 
 ## How it works
 
 - `Cargo.toml` configures [cargo-husky](https://github.com/rhysd/cargo-husky) to automatically install git hooks during build
-- cargo-husky runs `cargo clippy` and `cargo fmt --check` on Rust code
-- `pre-commit.sh` contains additional custom checks (e.g., linting VSCode extension TypeScript files)
+- Hooks are stored in `.cargo-husky/hooks/` and copied to `.git/hooks/` by cargo-husky
+- **pre-commit**: Checks formatting and linting for staged files
+- **pre-push**: Runs the full check suite (fmt, clippy, lint, tests) for changed files before pushing
 
 ## Setup
 
 The hooks are automatically installed when you build the project with `cargo build`.
 
-To manually update the git hook after modifying `pre-commit.sh`, rebuild the project or manually edit `.git/hooks/pre-commit` to source the custom script.
+To manually reinstall hooks after modifying them, run:
+```bash
+cargo test -p husky-hooks
+```
 
-## Custom checks
+## Hooks
 
-- **VSCode extension formatting**: Runs `prettier --check` when staging changes to `editors/vscode/`
-- **VSCode extension linting**: Runs `oxlint` when staging changes to `editors/vscode/`
-- **GraphQL formatting**: Runs `oxfmt --check` when staging changes to `.graphql` files
+### pre-commit
+Runs on staged files before each commit:
+- **Rust formatting**: `cargo fmt --check` (for `.rs` files)
+- **Rust linting**: `cargo clippy` (for `.rs`/`.toml` files)
+- **TS/JS linting**: `npm run lint` (for `.ts`/`.tsx`/`.js`/`.jsx` files)
+- **Multi-format checking**: `npm run fmt:check` (for `.graphql`/`.ts`/`.js`/`.md`/`.yaml`/`.json` files)
+
+### pre-push
+Runs on all changed files (vs remote) before each push:
+- All the same checks as pre-commit
+- **Tests**: `cargo test` (for `.rs`/`.toml` files)


### PR DESCRIPTION
## Summary

When running Claude Code with `--dangerously-skip-permissions` in worktrees, branches were being pushed that fail lint, fmt, and tests. Three gaps allowed this:

1. **Broken PreToolUse commit hook** — used incorrect matcher syntax (`Bash(git commit:*)` in the `matcher` field instead of the `if` field), and prefix matching can't catch chained commands like `git add -A && git commit -m "msg"`
2. **No pre-push gate** — nothing stopped a push even if checks would fail
3. **No --no-verify blocker** — Claude could bypass git hooks entirely

## Changes

- **`.cargo-husky/hooks/pre-push`** — New git-level pre-push hook that runs the full check suite (fmt, clippy, lint, tests) on all changed files before any push. This is the hard gate — works regardless of how commits were created.
- **`.claude/settings.json`** — Fixed `PreToolUse` hooks to use the correct `matcher`/`if` field structure per Claude Code docs. Added `if: "Bash(git push:*)"` hook for push commands. Added `block-no-verify.sh` hook.
- **`.claude/hooks/block-no-verify.sh`** — Inspects `$CLAUDE_TOOL_INPUT` and blocks any git command containing `--no-verify`.
- **`.husky/README.md`** — Updated to document both pre-commit and pre-push hooks.

## Test plan

- [ ] Run `cargo test -p husky-hooks` to verify pre-push hook gets installed to `.git/hooks/`
- [ ] Verify pre-push hook blocks a push with intentional fmt errors
- [ ] Verify `block-no-verify.sh` blocks `git commit --no-verify`
- [ ] Verify normal `git diff`, `git status`, etc. are not affected by the hooks
- [ ] Run Claude Code in a worktree with `--dangerously-skip-permissions` and verify checks run before push