### PR TITLE
chore(deps): replace serde_yml with serde-saphyr

### DIFF
--- a/.husky/README.md
+++ b/.husky/README.md
@@ -14,6 +14,7 @@ This directory contains the git hook configuration.
 The hooks are automatically installed when you build the project with `cargo build`.
 
 To manually reinstall hooks after modifying them, run:
+
 ```bash
 cargo test -p husky-hooks
 ```
@@ -21,13 +22,17 @@ cargo test -p husky-hooks
 ## Hooks
 
 ### pre-commit
+
 Runs on staged files before each commit:
+
 - **Rust formatting**: `cargo fmt --check` (for `.rs` files)
 - **Rust linting**: `cargo clippy` (for `.rs`/`.toml` files)
 - **TS/JS linting**: `npm run lint` (for `.ts`/`.tsx`/`.js`/`.jsx` files)
 - **Multi-format checking**: `npm run fmt:check` (for `.graphql`/`.ts`/`.js`/`.md`/`.yaml`/`.json` files)
 
 ### pre-push
+
 Runs on all changed files (vs remote) before each push:
+
 - All the same checks as pre-commit
 - **Tests**: `cargo test` (for `.rs`/`.toml` files)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +171,12 @@ dependencies = [
  "unicode-width",
  "yansi",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "ast_node"
@@ -488,7 +505,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -860,6 +877,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1201,8 +1236,8 @@ dependencies = [
  "glob",
  "jsonschema",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yml",
  "strsim",
  "tempfile",
  "thiserror 2.0.18",
@@ -1296,8 +1331,8 @@ dependencies = [
  "graphql-syntax",
  "insta",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yml",
  "tracing",
 ]
 
@@ -1863,7 +1898,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2064,16 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2203,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify"
@@ -2762,7 +2793,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3124,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3150,7 +3181,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3233,6 +3264,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saphyr-parser-bw"
+version = "0.0.611"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3332,6 +3374,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fbdfe7a27a1b1633dfc0c4c8e65940b8d819c5ddb9cca48ebc3223b00c8b14"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,21 +3471,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -3768,7 +3815,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4551,7 +4598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ authors = ["Trevor Scheer <trevor.scheer@gmail.com>"]
 # Common dependencies
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yml = "0.0.12"
+serde-saphyr = "0.0.23"
 thiserror = "2.0"
 anyhow = "1.0"
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["config", "parser-implementations"]
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
+serde-saphyr = { workspace = true }
 toml = "1.0"
 thiserror = { workspace = true }
 glob = { workspace = true }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -812,7 +812,7 @@ extensions:
   graphql-analyzer:
     client: apollo
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.client(), Some(ClientConfig::Apollo));
     }
 
@@ -824,7 +824,7 @@ extensions:
   graphql-analyzer:
     client: relay
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.client(), Some(ClientConfig::Relay));
     }
 
@@ -836,7 +836,7 @@ extensions:
   graphql-analyzer:
     client: none
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.client(), Some(ClientConfig::None));
     }
 
@@ -845,7 +845,7 @@ extensions:
         let yaml = r"
 schema: schema.graphql
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.client(), None);
     }
 
@@ -861,7 +861,7 @@ extensions:
   otherExtension:
     someKey: "someValue"
 "#;
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
         assert!(config.extensions.is_some());
         let extensions = config.extensions.unwrap();
         assert!(extensions.contains_key("extractConfig"));
@@ -1112,7 +1112,7 @@ schema:
   retry: 3
 documents: "**/*.graphql"
 "#;
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         assert!(config.schema.has_remote_schema());
@@ -1137,7 +1137,7 @@ documents: "**/*.graphql"
 schema:
   url: https://api.example.com/graphql
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         let introspection = config.schema.introspection_config().unwrap();
@@ -1176,7 +1176,7 @@ schema:
       X-API-Key: my-key
 documents: "**/*.graphql"
 "#;
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         assert!(config.schema.has_remote_schema());
@@ -1199,7 +1199,7 @@ documents: "**/*.graphql"
 schema:
   https://api.example.com/graphql: {}
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         let introspection = config.schema.introspection_config().unwrap();
@@ -1217,7 +1217,7 @@ schema:
     timeout: 60
     retry: 3
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         let introspection = config.schema.introspection_config().unwrap();
         assert_eq!(introspection.url, "https://api.example.com/graphql");
@@ -1233,7 +1233,7 @@ schema:
       headers:
         Authorization: "Bearer token"
 "#;
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         let introspection = config.schema.introspection_config().unwrap();
@@ -1250,7 +1250,7 @@ schema:
 schema:
   - https://api.example.com/graphql: {}
 ";
-        let config: ProjectConfig = serde_yml::from_str(yaml).unwrap();
+        let config: ProjectConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert!(config.schema.is_introspection());
         let introspection = config.schema.introspection_config().unwrap();
@@ -1281,11 +1281,11 @@ mod schema_sync_tests {
     /// Validate a YAML config string against both serde and JSON schema
     fn validate_config(yaml: &str) -> (bool, bool, String) {
         // Try serde deserialization
-        let serde_result = serde_yml::from_str::<GraphQLConfig>(yaml);
+        let serde_result = serde_saphyr::from_str::<GraphQLConfig>(yaml);
         let serde_valid = serde_result.is_ok();
 
         // Convert to JSON for schema validation
-        let json_value: Result<serde_json::Value, _> = serde_yml::from_str(yaml);
+        let json_value: Result<serde_json::Value, _> = serde_saphyr::from_str(yaml);
         let schema_valid = if let Ok(value) = json_value {
             let schema = load_schema();
             let compiled = jsonschema::draft7::new(&schema).expect("Failed to compile JSON schema");

--- a/crates/config/src/error.rs
+++ b/crates/config/src/error.rs
@@ -11,7 +11,7 @@ pub enum ConfigError {
     Io(#[from] io::Error),
 
     #[error("YAML parse error: {0}")]
-    YamlParse(#[from] serde_yml::Error),
+    YamlParse(#[from] serde_saphyr::Error),
 
     #[error("JSON parse error: {0}")]
     JsonParse(#[from] serde_json::Error),

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -143,7 +143,7 @@ pub fn load_config_from_str(contents: &str, path: &Path) -> Result<GraphQLConfig
 
 /// Parse YAML configuration
 fn parse_yaml(contents: &str, path: &Path) -> Result<GraphQLConfig> {
-    serde_yml::from_str(contents).map_err(|e| ConfigError::Invalid {
+    serde_saphyr::from_str(contents).map_err(|e| ConfigError::Invalid {
         path: path.to_path_buf(),
         message: format!("YAML parse error: {e}"),
     })

--- a/crates/linter/Cargo.toml
+++ b/crates/linter/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { workspace = true }
 tracing = "0.1"
 
 [dev-dependencies]
-serde_yml = { workspace = true }
+serde-saphyr = { workspace = true }
 insta = { workspace = true }
 graphql-ide-db = { path = "../ide-db" }
 

--- a/crates/linter/src/config.rs
+++ b/crates/linter/src/config.rs
@@ -1,14 +1,54 @@
-use serde::{Deserialize, Serialize};
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
 /// Severity level for a lint rule
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Custom deserializer handles YAML 1.1 boolean coercion where bare `off`
+/// is parsed as boolean `false` by spec-compliant YAML parsers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum LintSeverity {
     Off,
     Warn,
     Error,
+}
+
+impl<'de> Deserialize<'de> for LintSeverity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SeverityVisitor;
+
+        impl Visitor<'_> for SeverityVisitor {
+            type Value = LintSeverity;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a severity: 'off', 'warn', or 'error'")
+            }
+
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                if v {
+                    Err(E::custom("boolean `true` is not a valid severity"))
+                } else {
+                    Ok(LintSeverity::Off)
+                }
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "off" => Ok(LintSeverity::Off),
+                    "warn" => Ok(LintSeverity::Warn),
+                    "error" => Ok(LintSeverity::Error),
+                    _ => Err(E::custom(format!("unknown severity: {v}"))),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(SeverityVisitor)
+    }
 }
 
 impl std::fmt::Display for LintSeverity {
@@ -73,10 +113,8 @@ impl LintRuleConfig {
 impl<'de> Deserialize<'de> for LintRuleConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        use serde::de::{self, MapAccess, SeqAccess, Visitor};
-
         struct LintRuleConfigVisitor;
 
         impl<'de> Visitor<'de> for LintRuleConfigVisitor {
@@ -88,6 +126,21 @@ impl<'de> Deserialize<'de> for LintRuleConfig {
                      an array [severity, options], \
                      or an object { severity, options }",
                 )
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                // YAML 1.1 treats `off`/`no`/`false` as boolean false and
+                // `on`/`yes`/`true` as boolean true. Map false → Off severity.
+                if value {
+                    Err(E::custom(
+                        "boolean `true` is not a valid severity; use 'off', 'warn', or 'error'",
+                    ))
+                } else {
+                    Ok(LintRuleConfig::Severity(LintSeverity::Off))
+                }
             }
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
@@ -375,7 +428,7 @@ mod tests {
     #[test]
     fn test_simple_preset() {
         let yaml = r"recommended";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert!(matches!(
             config,
             LintConfig::Preset(ExtendsConfig::Single(ref s)) if s == "recommended"
@@ -394,7 +447,7 @@ mod tests {
     #[test]
     fn test_preset_list() {
         let yaml = r"[recommended]";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert!(matches!(
             config,
             LintConfig::Preset(ExtendsConfig::Multiple(_))
@@ -411,7 +464,7 @@ rules:
   uniqueNames: error
   noDeprecated: warn
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(
             config.get_severity("uniqueNames"),
             Some(LintSeverity::Error)
@@ -430,7 +483,7 @@ extends: recommended
 rules:
   noDeprecated: off
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         // uniqueNames and requireIdField are not in recommended (opinionated rules)
         assert!(!config.is_enabled("uniqueNames"));
         assert!(!config.is_enabled("noDeprecated"));
@@ -444,7 +497,7 @@ extends: [recommended]
 rules:
   unusedFields: warn
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         // uniqueNames is not in recommended (opinionated)
         assert!(!config.is_enabled("uniqueNames"));
         assert!(config.is_enabled("unusedFields"));
@@ -458,7 +511,7 @@ rules:
   uniqueNames: warn
   requireIdField: off
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(config.get_severity("uniqueNames"), Some(LintSeverity::Warn));
         assert_eq!(
             config.get_severity("requireIdField"),
@@ -488,7 +541,7 @@ rules:
 rules:
   notARule: error
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         let result = config.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("notARule"));
@@ -518,7 +571,7 @@ rules:
 rules:
   requireIdField: [warn, { fields: ["id", "nodeId"] }]
 "#;
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(
             config.get_severity("requireIdField"),
             Some(LintSeverity::Warn)
@@ -537,7 +590,7 @@ rules:
 rules:
   requireIdField: [error]
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(
             config.get_severity("requireIdField"),
             Some(LintSeverity::Error)
@@ -554,7 +607,7 @@ rules:
     options:
       fields: ["id", "uuid"]
 "#;
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(
             config.get_severity("requireIdField"),
             Some(LintSeverity::Warn)
@@ -573,7 +626,7 @@ rules:
 rules:
   requireIdField: warn
 ";
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
         assert!(config.get_options("requireIdField").is_none());
     }
 
@@ -592,7 +645,7 @@ rules:
   uniqueNames:
     severity: error
 "#;
-        let config: LintConfig = serde_yml::from_str(yaml).unwrap();
+        let config: LintConfig = serde_saphyr::from_str(yaml).unwrap();
 
         // Simple severity
         assert_eq!(


### PR DESCRIPTION
## Summary

- Replace `serde_yml` with `serde-saphyr` to resolve RUSTSEC-2025-0068 (unsound/unmaintained advisory) that is failing `cargo deny` on #975
- Add `visit_bool` handling to `LintSeverity` and `LintRuleConfig` deserializers to handle YAML 1.1 boolean coercion (bare `off` is parsed as `false` by spec-compliant parsers)

## Test plan

- [x] All existing tests pass (`cargo test` - 230+ linter tests, 95 config tests)
- [x] `cargo deny check` passes cleanly
- [x] No new clippy warnings introduced