### PR TITLE
fix(hooks): remove colons from PreToolUse hook if-patterns

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,17 +75,17 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit:*)",
+            "if": "Bash(git commit*)",
             "command": "cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test"
           },
           {
             "type": "command",
-            "if": "Bash(git push:*)",
+            "if": "Bash(git push*)",
             "command": "cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo test"
           },
           {
             "type": "command",
-            "if": "Bash(git:*)",
+            "if": "Bash(git*)",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-no-verify.sh"
           }
         ]


### PR DESCRIPTION
## Summary

The `if` field in Claude Code hooks uses glob syntax (`Bash(git*)`), not permission rule syntax (`Bash(git:*)`). The colon-delimited patterns were causing "PreToolUse:Bash hook error" on every git command.

## Changes

- Remove colons from all three `if` patterns in the `PreToolUse:Bash` hook section of `.claude/settings.json`
  - `Bash(git commit:*)` → `Bash(git commit*)`
  - `Bash(git push:*)` → `Bash(git push*)`
  - `Bash(git:*)` → `Bash(git*)`

## Consulted SME Agents

N/A

## Manual Testing Plan

- Run any git command (e.g. `git status`, `git log`) via Claude Code and confirm no "PreToolUse:Bash hook error" appears

## Related Issues