### PR TITLE
ci: publish VS Code extension to Open VSX

### DIFF
--- a/.changeset/open-vsx-publishing.md
+++ b/.changeset/open-vsx-publishing.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-vscode: patch
+---
+
+Publish to Open VSX Registry ([#979](https://github.com/trevor-scheer/graphql-analyzer/pull/979))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,33 @@ jobs:
             npx vsce publish --packagePath "$vsix"
           done
 
+  # Publish VS Code extension to Open VSX Registry
+  publish-openvsx:
+    needs: [check-release, build-vscode, release]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+
+      - name: Download all VSIX artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: vscode-extension-*
+          path: vsix-artifacts
+          merge-multiple: true
+
+      - name: Publish to Open VSX Registry
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_ACCESS_TOKEN }}
+        run: |
+          for vsix in vsix-artifacts/*.vsix; do
+            echo "Publishing $vsix"
+            npx ovsx publish "$vsix" --pat "$OVSX_PAT"
+          done
+
   # Update the Homebrew tap formula with the new CLI version
   update-homebrew-formula:
     needs: [check-release, release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Publish to Open VSX Registry
         env:
-          OVSX_PAT: ${{ secrets.OPENVSX_ACCESS_TOKEN }}
+          OVSX_PAT: ${{ secrets.OPENVSX_PUBLISH_PAT }}
         run: |
           for vsix in vsix-artifacts/*.vsix; do
             echo "Publishing $vsix"


### PR DESCRIPTION
## Summary
- Adds a `publish-openvsx` job to the release workflow that publishes all platform-specific VSIX artifacts to the [Open VSX Registry](https://open-vsx.org/)
- Runs as a separate job (parallel to `publish-vscode`) so a failure in one registry doesn't block the other
- Uses the same VSIX artifacts already built by `build-vscode`

## Setup required
Add the `OPENVSX_ACCESS_TOKEN` repository secret with an Open VSX personal access token.