### PR TITLE
Adopt cargo-nextest and fix CI for non-code PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -101,7 +101,7 @@ Skills enforce important workflows. Skipping them leads to incomplete work.
 
 **Before opening a PR:**
 
-1. Run checks: `cargo fmt && cargo clippy && cargo test`
+1. Run checks: `cargo fmt && cargo clippy && cargo nextest run --workspace`
 2. **Create a changeset** for user-facing changes:
    ```bash
    knope document-change

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.default]
+# Fail fast — stop on first test failure
+fail-fast = true
+# Show which tests are slow (>1s)
+slow-timeout = { period = "1s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,24 +23,6 @@ on:
       - ".github/workflows/**"
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - "rustfmt.toml"
-      - "editors/vscode/**/*.ts"
-      - "editors/vscode/package.json"
-      - "editors/vscode/package-lock.json"
-      - "editors/vscode/tsconfig.json"
-      - "test-workspace/**/*.ts"
-      - "test-workspace/**/*.tsx"
-      - "test-workspace/**/*.js"
-      - "**/*.graphql"
-      - "package.json"
-      - "package-lock.json"
-      - "CHANGELOG.md"
-      - ".github/workflows/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -75,6 +57,9 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run --workspace --all-features
+
+      - name: Run doctests
+        run: cargo test --workspace --doc
 
   lint:
     name: Lint
@@ -135,8 +120,8 @@ jobs:
 
   dogfood:
     name: Dogfood GraphQL Check
-    runs-on: ubuntu-latest
     needs: [build]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -214,7 +199,7 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, lint, build, check, vscode-extension, format]
+    needs: [test, lint, build, check, dogfood, vscode-extension, format]
     steps:
       - name: Check all jobs
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,16 +37,28 @@ cargo install --git https://github.com/trevor-scheer/graphql-analyzer graphql-cl
 
 ## Testing
 
+This project uses [cargo-nextest](https://nexte.st/) for running tests. It runs
+test binaries in parallel and provides better output than `cargo test`.
+
 ```bash
+# Install nextest
+cargo install cargo-nextest
+
 # Run all tests
-cargo test --workspace
+cargo nextest run --workspace
 
 # Run tests for a specific crate
-cargo test --package graphql-linter
+cargo nextest run --package graphql-linter
 
-# Run with output
-cargo test -- --nocapture
+# Run a specific test by name
+cargo nextest run --workspace test_name
+
+# Run with output (stdout visible)
+cargo nextest run --workspace --no-capture
 ```
+
+> **Note:** nextest doesn't support doctests. Run `cargo test --workspace --doc`
+> separately if needed.
 
 ## Linting and Formatting
 


### PR DESCRIPTION
## Summary

- Adopt [cargo-nextest](https://nexte.st/) as the recommended test runner for local development, matching what CI already uses
- Fix CI getting stuck on PRs that only touch non-code files by removing path filters from the `pull_request` trigger
- Add a doctest CI step since nextest can't run doctests

## Changes

- Updated `DEVELOPMENT.md` to document nextest as the test runner with install/usage instructions
- Added `.config/nextest.toml` with default profile settings (fail-fast, slow test detection)
- Updated `.claude/CLAUDE.md` pre-PR check command to use `cargo nextest run`
- Removed path filters from the `pull_request` CI trigger (kept on `push`) so `ci-success` always reports
- Added `cargo test --workspace --doc` step to CI workflow

## Consulted SME Agents

N/A

## Manual Testing Plan

- Run `cargo nextest run --workspace` locally and confirm all tests pass
- Confirm CI runs on this PR and `ci-success` reports

## Related Issues