### PR TITLE
Fix `cargo-deny` advisories: bump `thin-vec` and `rustls-webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,9 +3297,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3931,9 +3931,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
## Summary

Fixes the `cargo deny` failures showing up on every recent PR.

## Changes

- `thin-vec` `0.2.14` → `0.2.16` — [RUSTSEC-2026-0103](https://rustsec.org/advisories/RUSTSEC-2026-0103) (Use-After-Free / Double Free in `IntoIter::drop` when element drop panics; pulled in via `salsa`)
- `rustls-webpki` `0.103.12` → `0.103.13` — [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (reachable panic when parsing certificate revocation lists; pulled in via `reqwest` → `graphql-introspect`)

Both are transitive dependencies; the fix is a targeted `cargo update -p thin-vec -p rustls-webpki` (no `Cargo.toml` changes).

## Consulted SME Agents

None — straightforward dependency bump.

## Manual Testing Plan

- `cargo deny --all-features check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo check --workspace --all-features` passes