### PR TITLE
Fix release PR CI failures

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,11 +5,13 @@ on:
     # Run daily at 00:00 UTC
     - cron: "0 0 * * *"
   push:
+    branches: [main]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       - "deny.toml"
   pull_request:
+    branches: [main]
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/knope.toml
+++ b/knope.toml
@@ -66,6 +66,22 @@ type = "PrepareRelease"
 prerelease_label = "alpha"
 ignore_conventional_commits = true
 
+# Knope only bumps `version` fields. Re-pin intra-workspace npm deps to the
+# new core version so published packages list the exact version they were
+# tested against (and so `npm ci` on the release branch can resolve via the
+# workspace).
+[[workflows.steps]]
+type = "Command"
+command = "node scripts/sync-workspace-deps.mjs"
+
+[[workflows.steps]]
+type = "Command"
+command = "npm install --package-lock-only"
+
+[[workflows.steps]]
+type = "Command"
+command = "git add packages/ package-lock.json"
+
 [[workflows.steps]]
 type = "Command"
 command = "cargo check --workspace"

--- a/scripts/sync-workspace-deps.mjs
+++ b/scripts/sync-workspace-deps.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Syncs intra-workspace npm dependency refs to match the current workspace
+// version. Knope only updates the `version` field of `versioned_files`, not
+// dependency strings, so without this consumers of a published package would
+// pick up a stale (or non-existent) sibling version.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function setDep(pkg, section, name, version) {
+  const deps = pkg[section];
+  if (!deps || !(name in deps)) return false;
+  if (deps[name] === version) return false;
+  deps[name] = version;
+  return true;
+}
+
+const corePkgPath = "packages/core/package.json";
+const coreVersion = readJson(corePkgPath).version;
+
+const targets = [{ path: "packages/eslint-plugin/package.json", section: "dependencies" }];
+
+for (const { path, section } of targets) {
+  const pkg = readJson(path);
+  if (setDep(pkg, section, "@graphql-analyzer/core", coreVersion)) {
+    writeJson(path, pkg);
+    console.log(`Updated ${path} ${section}["@graphql-analyzer/core"] -> ${coreVersion}`);
+  }
+}


### PR DESCRIPTION
## Summary

PR #1005 is failing CI. Two independent fixes:

## Changes

- **Sync intra-workspace npm deps during release prep**: knope only bumps `version` fields, not dependency strings. The `eslint-plugin` pins `core` by exact version, so when knope bumps `core` to e.g. `0.1.1-alpha.0`, the dep ref stays at the old version. npm workspace resolution misses, the registry fallback fails (the old version was never published), and `npm ci` on the release branch fails with `ETARGET`. Added `scripts/sync-workspace-deps.mjs` and a knope step that re-pins the dep to the new core version, then regenerates `package-lock.json`. After publish, `eslint-plugin` will list an exact-version dep on the core it was tested with.
- **Stop running duplicate CI on release branches**: pushing to `release/next` while a PR to `main` is open fires both the `push` and `pull_request` triggers, doubling every check. Dropped `release/**` from CI's push branches, added `branches: [main]` to the audit workflow's `push`/`pull_request`. Release PRs will run CI once via `pull_request`.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- Confirm checks on this PR run once each (no push/pull_request duplicates).
- Locally simulate a release bump, run `node scripts/sync-workspace-deps.mjs`, then `npm ci` and `npm pack` in `packages/eslint-plugin/` — the tarball's `package.json` should list `@graphql-analyzer/core` at the bumped version.
- After merge, knope re-prepares `release/next`; verify Format / VSCode Extension / ESLint Plugin jobs pass `npm ci`.