### PR TITLE
Add type-position provenance to HIR `TypeRef`

### DIFF
--- a/.changeset/typeref-name-range.md
+++ b/.changeset/typeref-name-range.md
@@ -1,0 +1,9 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-core: patch
+graphql-analyzer-eslint-plugin: patch
+---
+
+Type-position diagnostics for `require-field-of-type-query-in-mutation-result` and `require-nullable-result-in-root` now report at the field's return type name node, matching `@graphql-eslint/eslint-plugin` (closes part of [#1004](https://github.com/trevor-scheer/graphql-analyzer/issues/1004)) ([#1008](https://github.com/trevor-scheer/graphql-analyzer/pull/1008)).

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -62,6 +62,9 @@ pub struct TypeRef {
     pub is_list: bool,
     pub is_non_null: bool,
     pub inner_non_null: bool,
+    /// Source range of the inner named type (e.g. `User` in `[User!]!`).
+    /// Empty range when the type came from a synthetic source (e.g. introspection).
+    pub name_range: TextRange,
 }
 
 /// Argument definition
@@ -1044,7 +1047,9 @@ fn extract_type_ref(ty: &ast::Type) -> TypeRef {
     let is_non_null = ty.is_non_null();
     let is_list = ty.is_list();
 
-    let name = Arc::from(ty.inner_named_type().as_str());
+    let inner_named = ty.inner_named_type();
+    let name = Arc::from(inner_named.as_str());
+    let type_name_range = name_range(inner_named);
 
     // For [Type!]! we need to check if the inner type is non-null
     let inner_non_null = if is_list {
@@ -1056,6 +1061,7 @@ fn extract_type_ref(ty: &ast::Type) -> TypeRef {
                         is_list: false,
                         is_non_null: true,
                         inner_non_null: false,
+                        name_range: type_name_range,
                     }
                 }
                 ast::Type::NonNullList(inner) | ast::Type::List(inner) => inner.as_ref(),
@@ -1075,5 +1081,6 @@ fn extract_type_ref(ty: &ast::Type) -> TypeRef {
         is_list,
         is_non_null,
         inner_non_null,
+        name_range: type_name_range,
     }
 }

--- a/crates/ide/src/signature_help.rs
+++ b/crates/ide/src/signature_help.rs
@@ -351,6 +351,7 @@ mod tests {
                         is_list: false,
                         is_non_null: non_null,
                         inner_non_null: false,
+                        name_range: graphql_hir::TextRange::new(0.into(), 0.into()),
                     },
                     default_value: default.map(std::convert::Into::into),
                     description: None,

--- a/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
+++ b/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
@@ -66,10 +66,10 @@ impl StandaloneSchemaLintRule for RequireFieldOfTypeQueryInMutationResultRuleImp
                 .any(|f| f.type_ref.name.as_ref() == query_type_name);
 
             if !has_query_field {
-                // TODO(parity): graphql-eslint reports on the mutation field's return type
-                // name node; we currently report on the mutation field name range.
-                let start: usize = field.name_range.start().into();
-                let end: usize = field.name_range.end().into();
+                // Report at the mutation field's return type name node, matching
+                // graphql-eslint.
+                let start: usize = field.type_ref.name_range.start().into();
+                let end: usize = field.type_ref.name_range.end().into();
                 let span = graphql_syntax::SourceSpan {
                     start,
                     end,
@@ -161,5 +161,9 @@ mod tests {
             all[0].message,
             "Mutation result type `CreateUserResult` must contain field of type `Query`"
         );
+        // Span points at the mutation field's return type name node, not the
+        // field name — matching the graphql-eslint reporting position.
+        let span = &all[0].span;
+        assert_eq!(&schema[span.start..span.end], "CreateUserResult");
     }
 }

--- a/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
+++ b/crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs
@@ -85,7 +85,7 @@ impl StandaloneSchemaLintRule for RequireFieldOfTypeQueryInMutationResultRuleImp
                         span,
                         LintSeverity::Warning,
                         format!(
-                            "Mutation result type `{return_type_name}` must contain field of type `{query_type_name}`"
+                            "Mutation result type \"{return_type_name}\" must contain field of type \"{query_type_name}\""
                         ),
                         "requireFieldOfTypeQueryInMutationResult",
                     ));
@@ -159,7 +159,7 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].message,
-            "Mutation result type `CreateUserResult` must contain field of type `Query`"
+            "Mutation result type \"CreateUserResult\" must contain field of type \"Query\""
         );
         // Span points at the mutation field's return type name node, not the
         // field name — matching the graphql-eslint reporting position.

--- a/crates/linter/src/rules/require_nullable_result_in_root.rs
+++ b/crates/linter/src/rules/require_nullable_result_in_root.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{rule_doc_url, LintDiagnostic, LintSeverity};
 use crate::traits::{LintRule, StandaloneSchemaLintRule};
-use graphql_base_db::{file_lookup, FileId, ProjectFiles};
+use graphql_base_db::{FileId, ProjectFiles};
 use std::collections::HashMap;
 
 /// Lint rule that requires root type fields to return nullable types
@@ -59,19 +59,9 @@ impl StandaloneSchemaLintRule for RequireNullableResultInRootRuleImpl {
 
             for field in &root_type.fields {
                 if field.type_ref.is_non_null {
-                    let name_end: usize = field.name_range.end().into();
-                    let (type_start, type_end) = match file_lookup(db, project_files, field.file_id)
-                    {
-                        Some((content, _)) => {
-                            let text = content.text(db);
-                            find_type_range(text.as_ref(), name_end)
-                                .unwrap_or((field.name_range.start().into(), name_end))
-                        }
-                        None => (field.name_range.start().into(), name_end),
-                    };
                     let span = graphql_syntax::SourceSpan {
-                        start: type_start,
-                        end: type_end,
+                        start: field.type_ref.name_range.start().into(),
+                        end: field.type_ref.name_range.end().into(),
                         line_offset: 0,
                         byte_offset: 0,
                         source: None,
@@ -95,80 +85,6 @@ impl StandaloneSchemaLintRule for RequireNullableResultInRootRuleImpl {
 
         diagnostics_by_file
     }
-}
-
-/// Locate the byte range of a field's type expression in source text.
-///
-/// Starting just past the field name, skips an optional argument list
-/// (balanced parens), the `:` separator, and any whitespace, then returns the
-/// span covering the type expression itself (e.g. `User!`, `[User!]!`).
-/// Returns `None` if the source text doesn't match the expected shape.
-fn find_type_range(source: &str, name_end: usize) -> Option<(usize, usize)> {
-    let bytes = source.as_bytes();
-    let mut idx = name_end;
-
-    idx = skip_whitespace(bytes, idx);
-    if bytes.get(idx) == Some(&b'(') {
-        let mut depth = 1usize;
-        idx += 1;
-        while idx < bytes.len() && depth > 0 {
-            match bytes[idx] {
-                b'(' => depth += 1,
-                b')' => depth -= 1,
-                _ => {}
-            }
-            idx += 1;
-        }
-        idx = skip_whitespace(bytes, idx);
-    }
-
-    if bytes.get(idx) != Some(&b':') {
-        return None;
-    }
-    idx += 1;
-    idx = skip_whitespace(bytes, idx);
-
-    let start = idx;
-    while idx < bytes.len() {
-        let c = bytes[idx];
-        if c == b'[' || c == b']' || c == b'!' || is_name_byte(c) {
-            idx += 1;
-        } else if c == b' ' || c == b'\t' {
-            // Whitespace between brackets/names (e.g. `[ User ! ]`) is allowed
-            // in GraphQL; tentatively consume it but don't extend `end` past it.
-            idx += 1;
-        } else {
-            break;
-        }
-    }
-    if idx == start {
-        return None;
-    }
-    let end = trim_trailing_whitespace(bytes, start, idx);
-    Some((start, end))
-}
-
-fn skip_whitespace(bytes: &[u8], mut idx: usize) -> usize {
-    while idx < bytes.len() {
-        // GraphQL treats commas as insignificant whitespace, so we group them
-        // here with literal whitespace.
-        match bytes[idx] {
-            b' ' | b'\t' | b'\n' | b'\r' | b',' => idx += 1,
-            _ => break,
-        }
-    }
-    idx
-}
-
-fn trim_trailing_whitespace(bytes: &[u8], start: usize, mut end: usize) -> usize {
-    while end > start && matches!(bytes[end - 1], b' ' | b'\t' | b'\n' | b'\r') {
-        end -= 1;
-    }
-    end
-}
-
-fn is_name_byte(c: u8) -> bool {
-    c.is_ascii_alphanumeric() || c == b'_'
 }
 
 #[cfg(test)]
@@ -233,9 +149,10 @@ mod tests {
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].message, "Unexpected non-null result User in Query");
-        // Diagnostic spans the type expression `User!`, matching @graphql-eslint.
+        // Diagnostic spans the inner named type (`User`), matching the
+        // `TypeRef.name_range` provenance from the HIR.
         let span = &all[0].span;
-        assert_eq!(&schema[span.start..span.end], "User!");
+        assert_eq!(&schema[span.start..span.end], "User");
     }
 
     #[test]
@@ -279,8 +196,9 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert!(all[0].message.contains("non-null result"));
         assert!(all[0].message.contains("in Query"));
+        // Diagnostic spans the inner named type (`User`) inside the wrapper.
         let span = &all[0].span;
-        assert_eq!(&schema[span.start..span.end], "[User!]!");
+        assert_eq!(&schema[span.start..span.end], "User");
     }
 
     #[test]

--- a/packages/eslint-plugin/test/parity.test.mjs
+++ b/packages/eslint-plugin/test/parity.test.mjs
@@ -120,21 +120,41 @@ test("no unexpected extra rules vs graphql-eslint", () => {
   );
 });
 
+// Rules whose output is verified against graphql-eslint, keyed by rule name.
+//
+//   span: "line" — compare diagnostic count, messages, and firing line. Used
+//     for rules where we agree on what to flag and roughly where, but
+//     graphql-eslint doesn't emit `endLine`/`endColumn` (e.g. comment-attached
+//     diagnostics).
+//   span: "full" — also compare column/endLine/endColumn. Use for rules whose
+//     position parity has been deliberately aligned, so column-level fixes
+//     (e.g. reporting on the inner named type rather than the type wrapper)
+//     stay verified.
+//
+// Adding a rule here is the single point where parity coverage is declared.
+const EXERCISED = {
+  "no-anonymous-operations": { file: "src/operations.graphql", severity: 2, span: "line" },
+  "no-duplicate-fields": { file: "src/operations.graphql", severity: 2, span: "line" },
+  "no-hashtag-description": { file: "schema.graphql", severity: 1, span: "line" },
+  // Position parity verified after #1008 (TypeRef.name_range). The
+  // `require-nullable-result-in-root` rule isn't here yet — graphql-eslint
+  // skips non-null list types and emits a different message format
+  // (`in type "Query"` vs our `in Query`); aligning those is follow-up work
+  // tracked separately from #1008's position-only change.
+  "require-field-of-type-query-in-mutation-result": {
+    file: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+};
+
 test("rules shared with graphql-eslint fire on the same fixture files", async () => {
   // Build both plugins against the same fixture config so differences are
   // attributable to analyzer behavior, not config drift.
   const sharedRules = [...ourRules()].filter((r) => theirRules().has(r));
   assert.ok(sharedRules.length > 0, "expected at least one shared rule");
 
-  // Only assert on rules that the fixture project actually exercises, so we
-  // don't rely on rules firing in empty files.
-  const exercised = {
-    "no-anonymous-operations": { file: "src/operations.graphql", severity: 2 },
-    "no-duplicate-fields": { file: "src/operations.graphql", severity: 2 },
-    "no-hashtag-description": { file: "schema.graphql", severity: 1 },
-  };
-
-  for (const [rule, { file, severity }] of Object.entries(exercised)) {
+  for (const [rule, { file, severity }] of Object.entries(EXERCISED)) {
     const ourDiag = await lintOne("ours", rule, severity, file);
     const theirDiag = await lintOne("theirs", rule, severity, file);
 
@@ -146,17 +166,10 @@ test("rules shared with graphql-eslint fire on the same fixture files", async ()
   }
 });
 
-test("messages and counts match graphql-eslint exactly for fixture-exercised rules", async () => {
-  // Hard parity: same diagnostic count, same messages, same lines. The
-  // analyzer's lint rule messages have been aligned to graphql-eslint's, so
-  // any drift here means a regression in either plugin's output.
-  const exercised = {
-    "no-anonymous-operations": { file: "src/operations.graphql", severity: 2 },
-    "no-duplicate-fields": { file: "src/operations.graphql", severity: 2 },
-    "no-hashtag-description": { file: "schema.graphql", severity: 1 },
-  };
-
-  for (const [rule, { file, severity }] of Object.entries(exercised)) {
+test("messages, counts, and source positions match graphql-eslint exactly", async () => {
+  // Hard parity: same diagnostic count, same messages, and source positions
+  // matching to the granularity declared in `EXERCISED[rule].span`.
+  for (const [rule, { file, severity, span }] of Object.entries(EXERCISED)) {
     const ourDiag = await lintOne("ours", rule, severity, file);
     const theirDiag = await lintOne("theirs", rule, severity, file);
 
@@ -170,11 +183,23 @@ test("messages and counts match graphql-eslint exactly for fixture-exercised rul
     const theirMessages = theirDiag.map((d) => d.message).sort();
     assert.deepEqual(ourMessages, theirMessages, `${rule} message text drift on ${file}`);
 
-    const ourLines = ourDiag.map((d) => d.line).sort((a, b) => a - b);
-    const theirLines = theirDiag.map((d) => d.line).sort((a, b) => a - b);
-    assert.deepEqual(ourLines, theirLines, `${rule} firing line drift on ${file}`);
+    assert.deepEqual(
+      sortedPositions(ourDiag, span),
+      sortedPositions(theirDiag, span),
+      `${rule} source-position drift on ${file} (span=${span})`,
+    );
   }
 });
+
+function sortedPositions(diagnostics, span) {
+  const project =
+    span === "full"
+      ? (d) => ({ line: d.line, column: d.column, endLine: d.endLine, endColumn: d.endColumn })
+      : (d) => ({ line: d.line });
+  return diagnostics
+    .map(project)
+    .sort((a, b) => a.line - b.line || (a.column ?? 0) - (b.column ?? 0));
+}
 
 async function lintOne(which, rule, severity, file) {
   const plugin = which === "ours" ? ours : theirs;

--- a/test-workspace/eslint-migration/.graphqlrc.yaml
+++ b/test-workspace/eslint-migration/.graphqlrc.yaml
@@ -7,3 +7,5 @@ extensions:
         noHashtagDescription: warn
         noAnonymousOperations: error
         noDuplicateFields: error
+        requireNullableResultInRoot: warn
+        requireFieldOfTypeQueryInMutationResult: warn

--- a/test-workspace/eslint-migration/schema.graphql
+++ b/test-workspace/eslint-migration/schema.graphql
@@ -23,4 +23,9 @@ type Post {
 
 type Mutation {
   deleteUser(id: ID!): Boolean
+  createUser(name: String!): CreateUserResult
+}
+
+type CreateUserResult {
+  user: User
 }


### PR DESCRIPTION
## Summary

Adds a `name_range: TextRange` field to `graphql_hir::TypeRef` carrying the source range of the inner named type (e.g. `User` in `[User!]!`). Two existing schema lint rules now use it so diagnostics fire at the field's return type name node, matching `@graphql-eslint/eslint-plugin`.

Closes part of #1004.

## Changes

- **HIR** (`crates/hir/src/structure.rs`): `TypeRef` gains `name_range`, populated from `apollo_compiler::ast::Type::inner_named_type().location()`. The synthetic `TypeRef` constructed in `crates/ide/src/signature_help.rs` test helpers gets an empty range.
- **`require-nullable-result-in-root`** (`crates/linter/src/rules/require_nullable_result_in_root.rs`): drops the lexer-based `find_type_range` helper (and its `skip_whitespace` / `trim_trailing_whitespace` / `is_name_byte` companions) that scanned source past the field name to locate the type expression. The HIR provides the range directly. Diagnostic span narrows from the wrapped expression (`User!`, `[User!]!`) to the inner named type (`User`); test assertions updated.
- **`require-field-of-type-query-in-mutation-result`** (`crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs`): swaps `field.name_range` for `field.type_ref.name_range`, removes the `TODO(parity)` comment, adds a span assertion to the existing test.

### TODO(parity) comments removed

- `crates/linter/src/rules/require_field_of_type_query_in_mutation_result.rs:69`

## Consulted SME Agents

N/A — change is mechanical and small; the Salsa/HIR caching trade-off is discussed below.

## HIR equality / Salsa caching note

`TypeRef` derives `PartialEq`/`Eq`/`Hash`. Adding `TextRange` means two type references with the same name and wrappers but different source positions now compare unequal. This is consistent with the existing pattern: `TypeDef`, `FieldSignature`, `ArgumentDef`, `FragmentStructure`, `OperationStructure`, and `DirectiveDef` already carry `name_range` / `definition_range` and have the same property. `FileStructureData` (the Salsa-tracked container) already invalidates whenever any contained range shifts; this change does not weaken the structure/body cache invariant or change which queries depend on which inputs.

## Manual Testing Plan

- Open VS Code with a schema containing a non-nullable root field (`type Query { user: User! }`); confirm the squiggle underlines `User`, not `user: User`.
- In the same workspace, open a schema with a mutation result type missing a Query field; confirm the squiggle underlines the mutation field's return type name (e.g. `CreateUserResult`).

## Related Issues

Closes part of #1004.