### PR TITLE
Fix release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,8 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep]
+    needs:
+      [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep]
     steps:
       - name: Check all jobs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,11 +229,26 @@ jobs:
       - name: TypeScript type check
         run: npm run typecheck
 
+  release-prep:
+    name: Release Prep Simulation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Simulate knope's release-prep
+        run: node scripts/check-release-prep.mjs
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format]
+    needs: [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep]
     steps:
       - name: Check all jobs
         run: |

--- a/scripts/check-release-prep.mjs
+++ b/scripts/check-release-prep.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Simulates knope's release-prep transformations and verifies the result still
+// works. Run on every PR so we catch drift between what's tested on main and
+// what knope would produce on release — without this, those transformations
+// (version bumps + dep-ref rewrites + lockfile regen) are first exercised in
+// the auto-generated release PR, making any breakage block the release.
+//
+// Steps:
+//   1. Bump every npm workspace package's `version` to a synthetic value
+//      (mimics what knope writes to its `versioned_files`).
+//   2. Run `sync-workspace-deps.mjs` to re-pin intra-workspace dep refs.
+//   3. Regenerate `package-lock.json` via `npm install --package-lock-only`.
+//   4. Run `npm ci` against the regenerated lockfile to confirm it resolves.
+//
+// CI runs this in a throwaway checkout, so we don't bother restoring state.
+// For local runs, use a clean working tree (the script will refuse otherwise).
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SYNTHETIC_VERSION = "999.0.0-ci-release-prep";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function expandWorkspaceGlob(pattern) {
+  if (!pattern.includes("*")) return [pattern];
+  if (!pattern.endsWith("/*")) throw new Error(`Unsupported glob: ${pattern}`);
+  const parent = pattern.slice(0, -2);
+  const parentAbs = join(REPO_ROOT, parent);
+  return readdirSync(parentAbs)
+    .filter((name) => statSync(join(parentAbs, name)).isDirectory())
+    .map((name) => `${parent}/${name}`);
+}
+
+// Mirrors the discovery logic in sync-workspace-deps.mjs so we bump exactly
+// the same set of files the sync script considers.
+function collectWorkspacePackages() {
+  const root = readJson(join(REPO_ROOT, "package.json"));
+  const dirs = (root.workspaces ?? []).flatMap(expandWorkspaceGlob);
+  const queue = [...dirs];
+  const seen = new Set();
+  const packages = [];
+
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+
+    const pkgPath = join(REPO_ROOT, dir, "package.json");
+    let pkg;
+    try {
+      pkg = readJson(pkgPath);
+    } catch {
+      continue;
+    }
+    if (!pkg.name) continue;
+    packages.push({ dir, path: pkgPath, pkg });
+
+    const abs = join(REPO_ROOT, dir);
+    let entries;
+    try {
+      entries = readdirSync(abs, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      queue.push(join(dir, entry.name));
+      const sub = join(abs, entry.name);
+      let subEntries;
+      try {
+        subEntries = readdirSync(sub, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const subEntry of subEntries) {
+        if (!subEntry.isDirectory() || subEntry.name === "node_modules" || subEntry.name.startsWith(".")) continue;
+        queue.push(join(dir, entry.name, subEntry.name));
+      }
+    }
+  }
+
+  return packages;
+}
+
+function ensureCleanTree() {
+  if (process.env.CI) return; // throwaway checkout
+  const out = execFileSync("git", ["status", "--porcelain"], { cwd: REPO_ROOT, encoding: "utf8" });
+  if (out.trim().length > 0) {
+    console.error("Refusing to run: working tree has uncommitted changes.");
+    console.error("This script mutates package.json and package-lock.json. Stash or commit first.");
+    process.exit(2);
+  }
+}
+
+function run(cmd, args) {
+  console.log(`\n$ ${cmd} ${args.join(" ")}`);
+  execFileSync(cmd, args, { cwd: REPO_ROOT, stdio: "inherit" });
+}
+
+ensureCleanTree();
+
+const packages = collectWorkspacePackages();
+
+// Only bump packages that are publishable (i.e. not `private: true` test
+// fixtures). Knope's versioned_files only ever cover publishable packages.
+const bumped = packages.filter((p) => !p.pkg.private);
+console.log(`Bumping ${bumped.length} packages to ${SYNTHETIC_VERSION}:`);
+for (const p of bumped) {
+  console.log(`  ${p.dir} (${p.pkg.name})`);
+  p.pkg.version = SYNTHETIC_VERSION;
+  writeJson(p.path, p.pkg);
+}
+
+run("node", ["scripts/sync-workspace-deps.mjs"]);
+run("npm", ["install", "--package-lock-only"]);
+run("npm", ["ci"]);
+
+console.log("\nRelease-prep simulation passed.");

--- a/scripts/check-release-prep.mjs
+++ b/scripts/check-release-prep.mjs
@@ -73,7 +73,8 @@ function collectWorkspacePackages() {
       continue;
     }
     for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith("."))
+        continue;
       queue.push(join(dir, entry.name));
       const sub = join(abs, entry.name);
       let subEntries;
@@ -83,7 +84,12 @@ function collectWorkspacePackages() {
         continue;
       }
       for (const subEntry of subEntries) {
-        if (!subEntry.isDirectory() || subEntry.name === "node_modules" || subEntry.name.startsWith(".")) continue;
+        if (
+          !subEntry.isDirectory() ||
+          subEntry.name === "node_modules" ||
+          subEntry.name.startsWith(".")
+        )
+          continue;
         queue.push(join(dir, entry.name, subEntry.name));
       }
     }

--- a/scripts/sync-workspace-deps.mjs
+++ b/scripts/sync-workspace-deps.mjs
@@ -22,7 +22,12 @@ import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const DEP_SECTIONS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+const DEP_SECTIONS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -84,7 +89,8 @@ function collectWorkspacePackages() {
       continue;
     }
     for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith("."))
+        continue;
       queue.push(join(dir, entry.name));
       // Two levels deep also (covers nested napi platform stubs).
       const sub = join(abs, entry.name);
@@ -95,7 +101,12 @@ function collectWorkspacePackages() {
         continue;
       }
       for (const subEntry of subEntries) {
-        if (!subEntry.isDirectory() || subEntry.name === "node_modules" || subEntry.name.startsWith(".")) continue;
+        if (
+          !subEntry.isDirectory() ||
+          subEntry.name === "node_modules" ||
+          subEntry.name.startsWith(".")
+        )
+          continue;
         queue.push(join(dir, entry.name, subEntry.name));
       }
     }

--- a/scripts/sync-workspace-deps.mjs
+++ b/scripts/sync-workspace-deps.mjs
@@ -1,10 +1,28 @@
 #!/usr/bin/env node
 // Syncs intra-workspace npm dependency refs to match the current workspace
-// version. Knope only updates the `version` field of `versioned_files`, not
-// dependency strings, so without this consumers of a published package would
-// pick up a stale (or non-existent) sibling version.
+// version of each referenced package. Knope only updates the `version` field
+// of `versioned_files`, not dependency strings, so without this consumers of a
+// published package would pick up a stale (or non-existent) sibling version.
+//
+// Auto-discovers workspace packages by reading the root `package.json#workspaces`
+// (with glob support) so adding a new package doesn't require updating this
+// script.
+//
+// Usage:
+//   node scripts/sync-workspace-deps.mjs           # rewrite files in place
+//   node scripts/sync-workspace-deps.mjs --check   # exit non-zero on drift
+//
+// `--check` is the CI mode — it asserts the committed state is already in
+// sync (every intra-workspace dep ref equals the referenced package's current
+// version). After knope bumps versions, the release-prep workflow runs the
+// in-place mode to fix up dep refs before regenerating the lock file.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEP_SECTIONS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -14,23 +32,125 @@ function writeJson(path, data) {
   writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
 }
 
-function setDep(pkg, section, name, version) {
-  const deps = pkg[section];
-  if (!deps || !(name in deps)) return false;
-  if (deps[name] === version) return false;
-  deps[name] = version;
-  return true;
+function expandWorkspaceGlob(pattern) {
+  // Supports the two forms used in this repo: literal paths ("editors/vscode")
+  // and one-level globs ("packages/*"). Avoid pulling in a glob library for
+  // such a tiny surface.
+  if (!pattern.includes("*")) return [pattern];
+  if (!pattern.endsWith("/*")) {
+    throw new Error(`Unsupported workspace glob: ${pattern}`);
+  }
+  const parent = pattern.slice(0, -2);
+  const parentAbs = join(REPO_ROOT, parent);
+  return readdirSync(parentAbs)
+    .filter((name) => statSync(join(parentAbs, name)).isDirectory())
+    .map((name) => `${parent}/${name}`);
 }
 
-const corePkgPath = "packages/core/package.json";
-const coreVersion = readJson(corePkgPath).version;
+function collectWorkspacePackages() {
+  const root = readJson(join(REPO_ROOT, "package.json"));
+  const dirs = (root.workspaces ?? []).flatMap(expandWorkspaceGlob);
 
-const targets = [{ path: "packages/eslint-plugin/package.json", section: "dependencies" }];
+  // Workspace packages can themselves contain nested package.json files (e.g.
+  // packages/core/npm/<platform>/package.json). Knope versions these, so we
+  // need to discover them too.
+  const queue = [...dirs];
+  const seen = new Set();
+  const packages = [];
 
-for (const { path, section } of targets) {
-  const pkg = readJson(path);
-  if (setDep(pkg, section, "@graphql-analyzer/core", coreVersion)) {
-    writeJson(path, pkg);
-    console.log(`Updated ${path} ${section}["@graphql-analyzer/core"] -> ${coreVersion}`);
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+
+    const pkgPath = join(REPO_ROOT, dir, "package.json");
+    let pkg;
+    try {
+      pkg = readJson(pkgPath);
+    } catch {
+      continue;
+    }
+    if (!pkg.name) continue;
+
+    packages.push({ dir, path: pkgPath, pkg });
+
+    // Walk one level of subdirectories looking for further package.json files
+    // (covers `packages/core/npm/<platform>`). Skip node_modules.
+    const abs = join(REPO_ROOT, dir);
+    let entries;
+    try {
+      entries = readdirSync(abs, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      queue.push(join(dir, entry.name));
+      // Two levels deep also (covers nested napi platform stubs).
+      const sub = join(abs, entry.name);
+      let subEntries;
+      try {
+        subEntries = readdirSync(sub, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const subEntry of subEntries) {
+        if (!subEntry.isDirectory() || subEntry.name === "node_modules" || subEntry.name.startsWith(".")) continue;
+        queue.push(join(dir, entry.name, subEntry.name));
+      }
+    }
   }
+
+  return packages;
+}
+
+// Only rewrite exact-version pins. Wildcards (`*`), ranges (`^1.0.0`, `~1.0.0`,
+// `>=1.0.0`), and protocol refs (`workspace:*`, `file:`, `link:`) are
+// intentional in test fixtures and dev-only deps — leave them alone.
+const EXACT_VERSION_RE = /^\d+\.\d+\.\d+(?:-[\w.+-]+)?$/;
+
+function syncPackages(packages, { write }) {
+  const versionByName = new Map(packages.map((p) => [p.pkg.name, p.pkg.version]));
+  const changes = [];
+
+  for (const { path, pkg } of packages) {
+    let mutated = false;
+    for (const section of DEP_SECTIONS) {
+      const deps = pkg[section];
+      if (!deps) continue;
+      for (const [name, current] of Object.entries(deps)) {
+        const target = versionByName.get(name);
+        if (target === undefined) continue; // not an intra-workspace dep
+        if (!EXACT_VERSION_RE.test(current)) continue; // wildcards/ranges intentional
+        if (current === target) continue;
+        deps[name] = target;
+        mutated = true;
+        changes.push({ path, section, name, from: current, to: target });
+      }
+    }
+    if (mutated && write) writeJson(path, pkg);
+  }
+
+  return changes;
+}
+
+const checkMode = process.argv.includes("--check");
+const packages = collectWorkspacePackages();
+const changes = syncPackages(packages, { write: !checkMode });
+
+if (changes.length === 0) {
+  if (!checkMode) console.log("Workspace dep refs already in sync.");
+  process.exit(0);
+}
+
+for (const c of changes) {
+  console.log(`${c.path} ${c.section}["${c.name}"]: ${c.from} -> ${c.to}`);
+}
+
+if (checkMode) {
+  console.error(
+    "\nError: intra-workspace dep refs are out of sync. " +
+      "Run `node scripts/sync-workspace-deps.mjs` and commit the changes.",
+  );
+  process.exit(1);
 }


### PR DESCRIPTION
## Summary

PR #1005 (release PR) is failing `Format` / `VSCode Extension` / `ESLint Plugin` checks again. Two independent fixes — one for the immediate breakage, one to stop this class of bug from reaching the release PR in the first place.

## Changes

- **`scripts/sync-workspace-deps.mjs` — auto-discover & sync `optionalDependencies`**: PR #1007 covered `eslint-plugin -> core`, but `packages/core/package.json#optionalDependencies` (the 5 platform stub pins) were still left at the old version after knope bumped everything. `npm install --package-lock-only` produced a lockfile that `npm ci` then rejected with `Missing: @graphql-analyzer/core-darwin-arm64@ from lock file`. Rewrote the script to walk the workspace and re-pin every exact-version intra-workspace dep ref in any section — so adding a new workspace package or dep section doesn't require touching this script. Wildcards (`*`, `^x`, `~x`) are intentionally left alone (test fixtures). Adds `--check` mode for CI use.

- **`scripts/check-release-prep.mjs` + new `Release Prep Simulation` CI job**: structurally, knope's release-prep transformations (version bumps + dep-ref rewrites + lockfile regen) only run when generating the release PR — they're never exercised on regular PRs. That's why two consecutive bugs of the same shape both reached the release PR before being noticed. The new script bumps every publishable workspace package to a synthetic version, runs the sync script, regenerates the lockfile, and runs `npm ci`. The new CI job runs it on every PR.

## How this happened (and why CI on `main` never caught it)

The release PR is **not** the same code as `main` — it's `main` after knope's transformations. Those transformations:

1. Bump `version` fields in `versioned_files` (only `version`, not dep refs).
2. Run `scripts/sync-workspace-deps.mjs` to re-pin intra-workspace dep refs.
3. Run `npm install --package-lock-only` to regenerate the lockfile.

On `main`, all packages share `0.1.0` and everything is self-consistent — the sync script is a no-op, no drift exists. The transformed state is first realized when knope creates the release PR, which is also the first time CI sees it. Any gap in the sync script (like missing `optionalDependencies`) only blows up there.

The simulation job closes that gap by exercising the same transformations on every PR, against a synthetic version.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- This PR's own `Release Prep Simulation` job exercises the new path.
- After merge, knope re-prepares `release/next` (the `eslint-plugin-initial-release.md` changeset is still on `main`, so prepare-release will run). Verify `Format` / `VSCode Extension` / `ESLint Plugin` jobs on the regenerated release PR pass `npm ci`.
- Locally simulate a release bump:
  ```bash
  CI=1 node scripts/check-release-prep.mjs
  ```
  Should print `Release-prep simulation passed.` (mutates the working tree — run on a throwaway checkout).