### PR TITLE
Extend description coverage to nested nodes

### DIFF
--- a/.changeset/description-coverage.md
+++ b/.changeset/description-coverage.md
@@ -1,0 +1,9 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-core: patch
+graphql-analyzer-eslint-plugin: patch
+---
+
+Extend `description-style` and `require-description` to cover nested AST nodes (fields, arguments, input values, enum values, directives) and — for `require-description` — operation definitions, matching `@graphql-eslint/eslint-plugin` (closes part of [#1004](https://github.com/trevor-scheer/graphql-analyzer/issues/1004)).

--- a/.changeset/description-coverage.md
+++ b/.changeset/description-coverage.md
@@ -6,4 +6,4 @@ graphql-analyzer-core: patch
 graphql-analyzer-eslint-plugin: patch
 ---
 
-Extend `description-style` and `require-description` to cover nested AST nodes (fields, arguments, input values, enum values, directives) and — for `require-description` — operation definitions, matching `@graphql-eslint/eslint-plugin` (closes part of [#1004](https://github.com/trevor-scheer/graphql-analyzer/issues/1004)).
+Extend `description-style` and `require-description` to cover nested AST nodes (fields, arguments, input values, enum values, directives) and — for `require-description` — operation definitions, matching `@graphql-eslint/eslint-plugin` (closes part of [#1004](https://github.com/trevor-scheer/graphql-analyzer/issues/1004)) ([#1011](https://github.com/trevor-scheer/graphql-analyzer/pull/1011)).

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -88,6 +88,8 @@ pub struct EnumValue {
     pub is_deprecated: bool,
     pub deprecation_reason: Option<Arc<str>>,
     pub directives: Vec<DirectiveUsage>,
+    /// The text range of the enum value's name token
+    pub name_range: TextRange,
 }
 
 /// A directive applied to a schema element
@@ -659,6 +661,7 @@ fn extract_enum_type(enum_def: &Node<ast::EnumTypeDefinition>, file_id: FileId) 
                 is_deprecated,
                 deprecation_reason,
                 directives: extract_directives(&v.directives),
+                name_range: name_range(&v.value),
             }
         })
         .collect();
@@ -859,6 +862,7 @@ fn extract_enum_type_extension(ext: &Node<ast::EnumTypeExtension>, file_id: File
                 is_deprecated,
                 deprecation_reason,
                 directives: extract_directives(&v.directives),
+                name_range: name_range(&v.value),
             }
         })
         .collect();

--- a/crates/linter/src/registry.rs
+++ b/crates/linter/src/registry.rs
@@ -36,6 +36,7 @@ static STANDALONE_DOCUMENT_RULES: LazyLock<Vec<Arc<dyn StandaloneDocumentLintRul
             Arc::new(NoDuplicateFieldsRuleImpl),
             Arc::new(OperationNameSuffixRuleImpl),
             Arc::new(RedundantFieldsRuleImpl),
+            Arc::new(RequireDescriptionRuleImpl),
             Arc::new(RequireImportFragmentRuleImpl),
             Arc::new(SelectionSetDepthRuleImpl),
             Arc::new(UnusedVariablesRuleImpl),
@@ -114,19 +115,26 @@ pub fn standalone_schema_rules() -> &'static [Arc<dyn StandaloneSchemaLintRule>]
 
 #[must_use]
 pub fn all_rule_names() -> Vec<&'static str> {
+    let mut seen = std::collections::HashSet::new();
     let mut names = Vec::new();
 
+    let mut push_unique = |name: &'static str, names: &mut Vec<&'static str>| {
+        if seen.insert(name) {
+            names.push(name);
+        }
+    };
+
     for rule in standalone_document_rules() {
-        names.push(rule.name());
+        push_unique(rule.name(), &mut names);
     }
     for rule in document_schema_rules() {
-        names.push(rule.name());
+        push_unique(rule.name(), &mut names);
     }
     for rule in project_rules() {
-        names.push(rule.name());
+        push_unique(rule.name(), &mut names);
     }
     for rule in standalone_schema_rules() {
-        names.push(rule.name());
+        push_unique(rule.name(), &mut names);
     }
 
     names.sort_unstable();
@@ -170,21 +178,33 @@ fn collect_rule_info(rule: &dyn LintRule, category: RuleCategory) -> RuleInfo {
 }
 
 /// Returns metadata for all registered lint rules, grouped by category.
+///
+/// Rules implemented for multiple sides (e.g. a rule that runs on both
+/// schemas and documents) are reported once, using the category of the
+/// first registry the rule appears in. Schema-side wins over document-side.
 #[must_use]
 pub fn all_rule_info() -> Vec<RuleInfo> {
+    let mut seen = std::collections::HashSet::new();
     let mut info = Vec::new();
 
+    let mut push_unique =
+        |rule: &dyn LintRule, category: RuleCategory, info: &mut Vec<RuleInfo>| {
+            if seen.insert(rule.name()) {
+                info.push(collect_rule_info(rule, category));
+            }
+        };
+
     for rule in standalone_schema_rules() {
-        info.push(collect_rule_info(rule.as_ref(), RuleCategory::Schema));
+        push_unique(rule.as_ref(), RuleCategory::Schema, &mut info);
     }
     for rule in standalone_document_rules() {
-        info.push(collect_rule_info(rule.as_ref(), RuleCategory::Document));
+        push_unique(rule.as_ref(), RuleCategory::Document, &mut info);
     }
     for rule in document_schema_rules() {
-        info.push(collect_rule_info(rule.as_ref(), RuleCategory::Document));
+        push_unique(rule.as_ref(), RuleCategory::Document, &mut info);
     }
     for rule in project_rules() {
-        info.push(collect_rule_info(rule.as_ref(), RuleCategory::Project));
+        push_unique(rule.as_ref(), RuleCategory::Project, &mut info);
     }
 
     info

--- a/crates/linter/src/rules/description_style.rs
+++ b/crates/linter/src/rules/description_style.rs
@@ -1,6 +1,8 @@
 use crate::diagnostics::{LintDiagnostic, LintSeverity};
 use crate::traits::{LintRule, StandaloneSchemaLintRule};
+use apollo_compiler::Node;
 use graphql_base_db::{FileId, ProjectFiles};
+use graphql_syntax::DocumentRef;
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -15,7 +17,7 @@ pub enum DescriptionStyleKind {
 }
 
 /// Options for the `description_style` rule
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(default)]
 pub struct DescriptionStyleOptions {
     /// The expected style for descriptions
@@ -78,85 +80,165 @@ impl StandaloneSchemaLintRule for DescriptionStyleRuleImpl {
                 continue;
             }
 
+            let mut diagnostics: Vec<LintDiagnostic> = Vec::new();
             for doc in parse.documents() {
-                // TODO(parity): graphql-eslint matches `.description` on every node
-                // (fields, input values, enum values, directive defs), not just
-                // top-level type definitions. We only iterate top-level defs here.
-                for definition in &doc.ast.definitions {
-                    let (desc, parent_label) = match definition {
-                        apollo_compiler::ast::Definition::ObjectTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("type \"{}\"", d.name))
-                        }
-                        apollo_compiler::ast::Definition::InterfaceTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("interface \"{}\"", d.name))
-                        }
-                        apollo_compiler::ast::Definition::UnionTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("union \"{}\"", d.name))
-                        }
-                        apollo_compiler::ast::Definition::EnumTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("enum \"{}\"", d.name))
-                        }
-                        apollo_compiler::ast::Definition::ScalarTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("scalar \"{}\"", d.name))
-                        }
-                        apollo_compiler::ast::Definition::InputObjectTypeDefinition(d) => {
-                            (d.description.as_ref(), format!("input \"{}\"", d.name))
-                        }
-                        _ => continue,
-                    };
-
-                    let Some(desc) = desc else {
-                        continue;
-                    };
-
-                    let desc_str = desc.as_str();
-                    let desc_location = desc.location();
-
-                    // Determine the actual style used by checking source text
-                    let Some(location) = desc_location else {
-                        continue;
-                    };
-                    let start = location.offset();
-                    let end = location.end_offset();
-
-                    let source = doc.source;
-                    if start >= source.len() || end > source.len() {
-                        continue;
-                    }
-
-                    let raw = &source[start..end];
-                    let is_block = raw.starts_with("\"\"\"");
-
-                    let wrong_style = match opts.style {
-                        DescriptionStyleKind::Block => !is_block,
-                        DescriptionStyleKind::Inline => is_block,
-                    };
-
-                    if wrong_style {
-                        let unexpected = match opts.style {
-                            DescriptionStyleKind::Block => "inline",
-                            DescriptionStyleKind::Inline => "block",
-                        };
-                        let suggested = match opts.style {
-                            DescriptionStyleKind::Block => "block",
-                            DescriptionStyleKind::Inline => "inline",
-                        };
-
-                        diagnostics_by_file.entry(*file_id).or_default().push(
-                            LintDiagnostic::new(
-                                doc.span(start, end.min(start + desc_str.len().min(30) + 6)),
-                                LintSeverity::Warning,
-                                format!("Unexpected {unexpected} description for {parent_label}"),
-                                "descriptionStyle",
-                            )
-                            .with_help(format!("Change to {suggested} style description")),
-                        );
-                    }
-                }
+                let mut visitor = DescriptionVisitor {
+                    diagnostics: &mut diagnostics,
+                    doc: &doc,
+                    opts,
+                };
+                visitor.walk_document();
+            }
+            if !diagnostics.is_empty() {
+                diagnostics_by_file
+                    .entry(*file_id)
+                    .or_default()
+                    .extend(diagnostics);
             }
         }
 
         diagnostics_by_file
+    }
+}
+
+/// Walks a document and emits a diagnostic for every `.description` whose
+/// style (block vs inline) doesn't match the configured style. Mirrors
+/// `@graphql-eslint/eslint-plugin`'s `description-style`, which selects
+/// `.description[type=StringValue]` on every AST node — so we visit
+/// `FieldDefinition`, `InputValueDefinition` (input fields + arguments),
+/// `EnumValueDefinition`, and `DirectiveDefinition` in addition to the
+/// top-level type definitions.
+struct DescriptionVisitor<'a> {
+    diagnostics: &'a mut Vec<LintDiagnostic>,
+    doc: &'a DocumentRef<'a>,
+    opts: DescriptionStyleOptions,
+}
+
+impl DescriptionVisitor<'_> {
+    fn walk_document(&mut self) {
+        for definition in &self.doc.ast.definitions {
+            match definition {
+                apollo_compiler::ast::Definition::ObjectTypeDefinition(d) => {
+                    let parent = format!("type \"{}\"", d.name);
+                    self.check(d.description.as_ref(), &parent);
+                    for field in &d.fields {
+                        self.walk_field(field, &parent);
+                    }
+                }
+                apollo_compiler::ast::Definition::InterfaceTypeDefinition(d) => {
+                    let parent = format!("interface \"{}\"", d.name);
+                    self.check(d.description.as_ref(), &parent);
+                    for field in &d.fields {
+                        self.walk_field(field, &parent);
+                    }
+                }
+                apollo_compiler::ast::Definition::UnionTypeDefinition(d) => {
+                    self.check(d.description.as_ref(), &format!("union \"{}\"", d.name));
+                }
+                apollo_compiler::ast::Definition::EnumTypeDefinition(d) => {
+                    let parent = format!("enum \"{}\"", d.name);
+                    self.check(d.description.as_ref(), &parent);
+                    for value in &d.values {
+                        self.check(
+                            value.description.as_ref(),
+                            &format!("enum value \"{}\" in {parent}", value.value),
+                        );
+                    }
+                }
+                apollo_compiler::ast::Definition::ScalarTypeDefinition(d) => {
+                    self.check(d.description.as_ref(), &format!("scalar \"{}\"", d.name));
+                }
+                apollo_compiler::ast::Definition::InputObjectTypeDefinition(d) => {
+                    let parent = format!("input \"{}\"", d.name);
+                    self.check(d.description.as_ref(), &parent);
+                    for field in &d.fields {
+                        self.check(
+                            field.description.as_ref(),
+                            &format!("input value \"{}\" in {parent}", field.name),
+                        );
+                    }
+                }
+                apollo_compiler::ast::Definition::DirectiveDefinition(d) => {
+                    let parent = format!("directive \"{}\"", d.name);
+                    self.check(d.description.as_ref(), &parent);
+                    for arg in &d.arguments {
+                        self.check(
+                            arg.description.as_ref(),
+                            &format!("input value \"{}\" in {parent}", arg.name),
+                        );
+                    }
+                }
+                // Type extensions don't carry descriptions in the spec.
+                _ => {}
+            }
+        }
+    }
+
+    fn walk_field(
+        &mut self,
+        field: &Node<apollo_compiler::ast::FieldDefinition>,
+        parent_label: &str,
+    ) {
+        let field_label = format!("field \"{}\" in {parent_label}", field.name);
+        self.check(field.description.as_ref(), &field_label);
+        for arg in &field.arguments {
+            self.check(
+                arg.description.as_ref(),
+                &format!("input value \"{}\" in {field_label}", arg.name),
+            );
+        }
+    }
+
+    fn check(&mut self, description: Option<&Node<str>>, parent_label: &str) {
+        let Some(desc) = description else {
+            return;
+        };
+        let Some(location) = desc.location() else {
+            return;
+        };
+
+        let start = location.offset();
+        let end = location.end_offset();
+        let source = self.doc.source;
+        if start >= source.len() || end > source.len() {
+            return;
+        }
+
+        let raw = &source[start..end];
+        let is_block = raw.starts_with("\"\"\"");
+
+        let wrong_style = match self.opts.style {
+            DescriptionStyleKind::Block => !is_block,
+            DescriptionStyleKind::Inline => is_block,
+        };
+
+        if !wrong_style {
+            return;
+        }
+
+        let unexpected = match self.opts.style {
+            DescriptionStyleKind::Block => "inline",
+            DescriptionStyleKind::Inline => "block",
+        };
+        let suggested = match self.opts.style {
+            DescriptionStyleKind::Block => "block",
+            DescriptionStyleKind::Inline => "inline",
+        };
+
+        // Cap the highlighted span so multi-line block descriptions don't
+        // produce noisy underlines; matches the original behavior.
+        let desc_str = desc.as_str();
+        let span_end = end.min(start + desc_str.len().min(30) + 6);
+
+        self.diagnostics.push(
+            LintDiagnostic::new(
+                self.doc.span(start, span_end),
+                LintSeverity::Warning,
+                format!("Unexpected {unexpected} description for {parent_label}"),
+                "descriptionStyle",
+            )
+            .with_help(format!("Change to {suggested} style description")),
+        );
     }
 }
 
@@ -235,5 +317,155 @@ type User {
             all[0].message,
             "Unexpected inline description for type \"User\""
         );
+    }
+
+    #[test]
+    fn test_inline_field_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""A user"""
+type User {
+    "The user id"
+    id: ID!
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].message,
+            "Unexpected inline description for field \"id\" in type \"User\""
+        );
+    }
+
+    #[test]
+    fn test_inline_argument_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""A query"""
+type Query {
+    """Lookup a user"""
+    user(
+        "The user id"
+        id: ID!
+    ): String
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].message,
+            "Unexpected inline description for input value \"id\" in field \"user\" in type \"Query\""
+        );
+    }
+
+    #[test]
+    fn test_inline_input_field_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""Filter input"""
+input UserFilter {
+    "Match users by id"
+    id: ID
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].message,
+            "Unexpected inline description for input value \"id\" in input \"UserFilter\""
+        );
+    }
+
+    #[test]
+    fn test_inline_enum_value_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""Color"""
+enum Color {
+    "The color red"
+    RED
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].message,
+            "Unexpected inline description for enum value \"RED\" in enum \"Color\""
+        );
+    }
+
+    #[test]
+    fn test_inline_directive_definition_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"Mark a field as cached"
+directive @cached(
+    "How long to cache"
+    seconds: Int
+) on FIELD_DEFINITION
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let messages: Vec<&str> = diagnostics
+            .values()
+            .flatten()
+            .map(|d| d.message.as_str())
+            .collect();
+        assert_eq!(messages.len(), 2);
+        assert!(messages.contains(&"Unexpected inline description for directive \"cached\""));
+        assert!(messages.contains(
+            &"Unexpected inline description for input value \"seconds\" in directive \"cached\""
+        ));
+    }
+
+    #[test]
+    fn test_block_style_on_nested_nodes_does_not_warn() {
+        let db = RootDatabase::default();
+        let rule = DescriptionStyleRuleImpl;
+        let schema = r#"
+"""A user"""
+type User {
+    """Field id"""
+    id(
+        """Argument something"""
+        something: String
+    ): ID!
+}
+
+"""Color"""
+enum Color {
+    """Red"""
+    RED
+}
+
+"""Filter"""
+input UserFilter {
+    """Filter by id"""
+    id: ID
+}
+
+"""Cache directive"""
+directive @cached(
+    """seconds"""
+    seconds: Int
+) on FIELD_DEFINITION
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        assert!(all.is_empty(), "expected no diagnostics, got: {all:?}");
     }
 }

--- a/crates/linter/src/rules/require_description.rs
+++ b/crates/linter/src/rules/require_description.rs
@@ -1,13 +1,21 @@
 use crate::diagnostics::{LintDiagnostic, LintSeverity};
-use crate::traits::{LintRule, StandaloneSchemaLintRule};
-use graphql_base_db::{FileId, ProjectFiles};
-use graphql_hir::TypeDefKind;
+use crate::traits::{LintRule, StandaloneDocumentLintRule, StandaloneSchemaLintRule};
+use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
+use graphql_hir::{TextRange, TypeDefKind};
 use std::collections::HashMap;
 
-/// Lint rule that requires descriptions on type definitions
+/// Lint rule that requires descriptions on schema definitions and operations.
 ///
-/// Descriptions serve as documentation for schema consumers. This rule
-/// ensures that all type definitions include a description.
+/// Descriptions serve as documentation for schema consumers and operation
+/// readers. Mirrors `@graphql-eslint/eslint-plugin`'s `require-description`,
+/// which fires on every AST node that can carry a `.description`:
+/// type/interface/union/enum/scalar/input definitions, field definitions,
+/// input value definitions (input fields and arguments), enum value
+/// definitions, directive definitions, and operation definitions.
+///
+/// `OperationDefinition` description support uses the GraphQL `#` comment
+/// immediately above the operation (operations don't have a syntactic
+/// `description` slot in the spec).
 pub struct RequireDescriptionRuleImpl;
 
 impl LintRule for RequireDescriptionRuleImpl {
@@ -16,7 +24,7 @@ impl LintRule for RequireDescriptionRuleImpl {
     }
 
     fn description(&self) -> &'static str {
-        "Requires descriptions on type definitions"
+        "Requires descriptions on type definitions, fields, arguments, enum values, directives, and operations"
     }
 
     fn default_severity(&self) -> LintSeverity {
@@ -34,6 +42,23 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
         let schema_types = graphql_hir::schema_types(db, project_files);
 
+        // Source schema file ids — used to filter out builtins and resolved-schema
+        // entries that the user didn't write themselves and can't add descriptions to.
+        let source_file_ids: std::collections::HashSet<FileId> = project_files
+            .schema_file_ids(db)
+            .ids(db)
+            .iter()
+            .copied()
+            .filter(|fid| {
+                graphql_base_db::file_lookup(db, project_files, *fid).is_some_and(|(_, meta)| {
+                    let uri = meta.uri(db);
+                    let s = uri.as_str();
+                    !s.ends_with("schema_builtins.graphql")
+                        && !s.ends_with("client_builtins.graphql")
+                })
+            })
+            .collect();
+
         for type_def in schema_types.values() {
             // Skip built-in scalars
             if type_def.kind == TypeDefKind::Scalar
@@ -42,6 +67,11 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                     "String" | "Int" | "Float" | "Boolean" | "ID"
                 )
             {
+                continue;
+            }
+
+            // Only flag entities defined in source files (skip resolved schema/builtins)
+            if !source_file_ids.contains(&type_def.file_id) {
                 continue;
             }
 
@@ -55,35 +85,104 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                     _ => "type",
                 };
 
-                let start: usize = type_def.name_range.start().into();
-                let end: usize = type_def.name_range.end().into();
+                push_missing_description(
+                    &mut diagnostics_by_file,
+                    type_def.file_id,
+                    type_def.name_range,
+                    &format!("{kind_name} \"{}\"", type_def.name),
+                );
+            }
 
-                // Create a SourceSpan from the schema file
-                let span = graphql_syntax::SourceSpan {
-                    start,
-                    end,
-                    line_offset: 0,
-                    byte_offset: 0,
-                    source: None,
+            let parent_label = match type_def.kind {
+                TypeDefKind::Interface => format!("interface \"{}\"", type_def.name),
+                TypeDefKind::InputObject => format!("input \"{}\"", type_def.name),
+                TypeDefKind::Enum => format!("enum \"{}\"", type_def.name),
+                _ => format!("type \"{}\"", type_def.name),
+            };
+
+            // Field definitions (object/interface) and input value definitions (input).
+            for field in &type_def.fields {
+                let field_kind = if type_def.kind == TypeDefKind::InputObject {
+                    "input value"
+                } else {
+                    "field"
                 };
+                let field_label = format!("{field_kind} \"{}\" in {parent_label}", field.name);
 
-                diagnostics_by_file
-                    .entry(type_def.file_id)
-                    .or_default()
-                    .push(
-                        LintDiagnostic::new(
-                            span,
-                            LintSeverity::Warning,
-                            format!(
-                                "Description is required for {kind_name} \"{}\"",
-                                type_def.name
-                            ),
-                            "requireDescription",
-                        )
-                        .with_help(
-                            "Add a description string above the definition to document its purpose",
-                        ),
+                if !source_file_ids.contains(&field.file_id) {
+                    continue;
+                }
+
+                if field.description.is_none() {
+                    push_missing_description(
+                        &mut diagnostics_by_file,
+                        field.file_id,
+                        field.name_range,
+                        &field_label,
                     );
+                }
+
+                // Arguments only apply to object/interface fields, not input values.
+                if type_def.kind != TypeDefKind::InputObject {
+                    for arg in &field.arguments {
+                        if !source_file_ids.contains(&arg.file_id) {
+                            continue;
+                        }
+                        if arg.description.is_none() {
+                            push_missing_description(
+                                &mut diagnostics_by_file,
+                                arg.file_id,
+                                arg.name_range,
+                                &format!("input value \"{}\" in {field_label}", arg.name),
+                            );
+                        }
+                    }
+                }
+            }
+
+            // Enum value definitions
+            for value in &type_def.enum_values {
+                if value.description.is_none() {
+                    push_missing_description(
+                        &mut diagnostics_by_file,
+                        type_def.file_id,
+                        value.name_range,
+                        &format!("enum value \"{}\" in {parent_label}", value.name),
+                    );
+                }
+            }
+        }
+
+        // Directive definitions (and their arguments).
+        let directives = graphql_hir::schema_directives(db, project_files);
+        for dir_def in directives.values() {
+            if !source_file_ids.contains(&dir_def.file_id) {
+                continue;
+            }
+
+            let dir_label = format!("directive \"{}\"", dir_def.name);
+
+            if dir_def.description.is_none() {
+                push_missing_description(
+                    &mut diagnostics_by_file,
+                    dir_def.file_id,
+                    dir_def.name_range,
+                    &dir_label,
+                );
+            }
+
+            for arg in &dir_def.arguments {
+                if !source_file_ids.contains(&arg.file_id) {
+                    continue;
+                }
+                if arg.description.is_none() {
+                    push_missing_description(
+                        &mut diagnostics_by_file,
+                        arg.file_id,
+                        arg.name_range,
+                        &format!("input value \"{}\" in {dir_label}", arg.name),
+                    );
+                }
             }
         }
 
@@ -91,10 +190,160 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
     }
 }
 
+impl StandaloneDocumentLintRule for RequireDescriptionRuleImpl {
+    fn check(
+        &self,
+        db: &dyn graphql_hir::GraphQLHirDatabase,
+        _file_id: FileId,
+        content: FileContent,
+        metadata: FileMetadata,
+        _project_files: ProjectFiles,
+        _options: Option<&serde_json::Value>,
+    ) -> Vec<LintDiagnostic> {
+        let mut diagnostics = Vec::new();
+        let parse = graphql_syntax::parse(db, content, metadata);
+        if parse.has_errors() {
+            return diagnostics;
+        }
+
+        // graphql-eslint treats the `#` comment immediately above an operation
+        // (no blank line between) as that operation's description.
+        for doc in parse.documents() {
+            let source = doc.source;
+            for definition in &doc.ast.definitions {
+                let apollo_compiler::ast::Definition::OperationDefinition(op) = definition else {
+                    continue;
+                };
+                let Some(loc) = op.location() else { continue };
+                let op_start = loc.offset();
+                let op_end = loc.end_offset();
+                if op_start >= source.len() || op_end > source.len() {
+                    continue;
+                }
+
+                if has_immediate_comment(source, op_start) {
+                    continue;
+                }
+
+                // Find the operation keyword (`query`/`mutation`/`subscription`)
+                // or for shorthand queries, the opening `{` brace. Mirrors
+                // `getLocation(node.loc.start, node.operation)` in graphql-eslint.
+                let op_keyword = match op.operation_type {
+                    apollo_compiler::ast::OperationType::Query => "query",
+                    apollo_compiler::ast::OperationType::Mutation => "mutation",
+                    apollo_compiler::ast::OperationType::Subscription => "subscription",
+                };
+                let raw = &source[op_start..op_end];
+                let (rel_start, rel_end) =
+                    if let Some(pos) = raw.find(op_keyword).filter(|p| *p < 8) {
+                        (pos, pos + op_keyword.len())
+                    } else if let Some(pos) = raw.find('{') {
+                        (pos, pos + 1)
+                    } else {
+                        (0, raw.len().min(1))
+                    };
+                let span_start = op_start + rel_start;
+                let span_end = op_start + rel_end;
+
+                let label = match (op.name.as_ref(), op.operation_type) {
+                    (Some(name), apollo_compiler::ast::OperationType::Query) => {
+                        format!("query \"{name}\"")
+                    }
+                    (Some(name), apollo_compiler::ast::OperationType::Mutation) => {
+                        format!("mutation \"{name}\"")
+                    }
+                    (Some(name), apollo_compiler::ast::OperationType::Subscription) => {
+                        format!("subscription \"{name}\"")
+                    }
+                    (None, _) => op_keyword.to_string(),
+                };
+
+                diagnostics.push(
+                    LintDiagnostic::new(
+                        doc.span(span_start, span_end),
+                        LintSeverity::Warning,
+                        format!("Description is required for {label}"),
+                        "requireDescription",
+                    )
+                    .with_help(
+                        "Add a `# comment` line directly above the operation to document its purpose",
+                    ),
+                );
+            }
+        }
+
+        diagnostics
+    }
+}
+
+fn push_missing_description(
+    diagnostics_by_file: &mut HashMap<FileId, Vec<LintDiagnostic>>,
+    file_id: FileId,
+    name_range: TextRange,
+    label: &str,
+) {
+    let span = graphql_syntax::SourceSpan {
+        start: name_range.start().into(),
+        end: name_range.end().into(),
+        line_offset: 0,
+        byte_offset: 0,
+        source: None,
+    };
+
+    diagnostics_by_file.entry(file_id).or_default().push(
+        LintDiagnostic::new(
+            span,
+            LintSeverity::Warning,
+            format!("Description is required for {label}"),
+            "requireDescription",
+        )
+        .with_help("Add a description string above the definition to document its purpose"),
+    );
+}
+
+/// Returns true when the byte at `op_start` is preceded by a `#` comment
+/// whose final newline is on the line directly before the operation
+/// (matches graphql-eslint's `linesBefore === 1` check).
+fn has_immediate_comment(source: &str, op_start: usize) -> bool {
+    let before = &source[..op_start];
+
+    // Walk back over whitespace on the operation's start line.
+    let mut idx = before.len();
+    while idx > 0 {
+        let b = before.as_bytes()[idx - 1];
+        if b == b'\n' {
+            break;
+        }
+        if !b.is_ascii_whitespace() {
+            // Non-whitespace before the operation on its own line — anything
+            // else here means this isn't a leading-comment scenario.
+            return false;
+        }
+        idx -= 1;
+    }
+
+    // `idx` now points at the newline at the end of the previous line, or 0.
+    // Skip back past blank lines — graphql-eslint requires the comment to be
+    // on the line *immediately* preceding the operation.
+    if idx == 0 {
+        return false;
+    }
+    // Step over the newline at idx-1, then look at the previous line.
+    let prev_line_end = idx - 1; // position of '\n'
+    let prev_line_start = before[..prev_line_end].rfind('\n').map_or(0, |nl| nl + 1);
+    let prev_line = &before[prev_line_start..prev_line_end];
+    let trimmed = prev_line.trim_start();
+    if !trimmed.starts_with('#') {
+        return false;
+    }
+    // Skip ESLint directive comments — `# eslint-disable …` etc.
+    let body = trimmed.trim_start_matches('#').trim();
+    !body.starts_with("eslint")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::StandaloneSchemaLintRule;
     use graphql_base_db::{
         DocumentFileIds, DocumentKind, FileContent, FileEntry, FileEntryMap, FileId, FileMetadata,
         FileUri, Language, ProjectFiles, SchemaFileIds,
@@ -133,6 +382,49 @@ mod tests {
         )
     }
 
+    fn create_document_project(
+        db: &RootDatabase,
+        source: &str,
+    ) -> (FileId, FileContent, FileMetadata, ProjectFiles) {
+        let file_id = FileId::new(0);
+        let content = FileContent::new(db, Arc::from(source));
+        let metadata = FileMetadata::new(
+            db,
+            file_id,
+            FileUri::new("file:///query.graphql"),
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        let entry = FileEntry::new(db, content, metadata);
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(file_id, entry);
+
+        let schema_file_ids = SchemaFileIds::new(db, Arc::new(vec![]));
+        let document_file_ids = DocumentFileIds::new(db, Arc::new(vec![file_id]));
+        let file_entry_map = FileEntryMap::new(db, Arc::new(entries));
+        let project_files = ProjectFiles::new(
+            db,
+            schema_file_ids,
+            document_file_ids,
+            graphql_base_db::ResolvedSchemaFileIds::new(db, std::sync::Arc::new(vec![])),
+            file_entry_map,
+            graphql_base_db::FilePathMap::new(
+                db,
+                Arc::new(std::collections::HashMap::new()),
+                Arc::new(std::collections::HashMap::new()),
+            ),
+        );
+        (file_id, content, metadata, project_files)
+    }
+
+    fn messages(diagnostics: &HashMap<FileId, Vec<LintDiagnostic>>) -> Vec<&str> {
+        diagnostics
+            .values()
+            .flatten()
+            .map(|d| d.message.as_str())
+            .collect()
+    }
+
     #[test]
     fn test_type_with_description() {
         let db = RootDatabase::default();
@@ -141,15 +433,16 @@ mod tests {
         let schema = r#"
 "A user in the system"
 type User {
+    "An id"
     id: ID!
+    "A name"
     name: String!
 }
 "#;
 
         let project_files = create_schema_project(&db, schema);
-        let diagnostics = rule.check(&db, project_files, None);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
 
-        // Should not warn about User (has description) or built-in types
         let user_warnings: Vec<_> = diagnostics
             .values()
             .flatten()
@@ -171,13 +464,273 @@ type User {
 ";
 
         let project_files = create_schema_project(&db, schema);
-        let diagnostics = rule.check(&db, project_files, None);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
 
         let user_warnings: Vec<_> = diagnostics
             .values()
             .flatten()
-            .filter(|d| d.message.contains("\"User\""))
+            .filter(|d| d.message == "Description is required for type \"User\"")
             .collect();
         assert_eq!(user_warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_field_without_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r#"
+"A user"
+type User {
+    id: ID!
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(
+            msgs.contains(&"Description is required for field \"id\" in type \"User\""),
+            "missing field diagnostic, got: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn test_argument_without_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r#"
+"A query"
+type Query {
+    "Lookup a user"
+    user(id: ID!): String
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(
+            msgs.contains(
+                &"Description is required for input value \"id\" in field \"user\" in type \"Query\""
+            ),
+            "missing arg diagnostic, got: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn test_input_field_without_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r#"
+"Filter input"
+input UserFilter {
+    id: ID
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(
+            msgs.contains(
+                &"Description is required for input value \"id\" in input \"UserFilter\""
+            ),
+            "missing input field diagnostic, got: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn test_enum_value_without_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r#"
+"A color"
+enum Color {
+    RED
+}
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(
+            msgs.contains(&"Description is required for enum value \"RED\" in enum \"Color\""),
+            "missing enum value diagnostic, got: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn test_directive_without_description_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r"
+directive @cached(seconds: Int) on FIELD_DEFINITION
+";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(
+            msgs.contains(&"Description is required for directive \"cached\""),
+            "missing directive diagnostic, got: {msgs:?}"
+        );
+        assert!(
+            msgs.contains(
+                &"Description is required for input value \"seconds\" in directive \"cached\""
+            ),
+            "missing directive arg diagnostic, got: {msgs:?}"
+        );
+    }
+
+    #[test]
+    fn test_fully_documented_schema_clean() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let schema = r#"
+"A user"
+type User {
+    "The id"
+    id: ID!
+}
+
+"Filter input"
+input UserFilter {
+    "Filter by id"
+    id: ID
+}
+
+"Color"
+enum Color {
+    "Red"
+    RED
+}
+
+"Cache directive"
+directive @cached(
+    "How long to cache"
+    seconds: Int
+) on FIELD_DEFINITION
+"#;
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = StandaloneSchemaLintRule::check(&rule, &db, project_files, None);
+        let msgs = messages(&diagnostics);
+        assert!(msgs.is_empty(), "expected no diagnostics, got: {msgs:?}");
+    }
+
+    #[test]
+    fn test_operation_without_comment_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let source = "query GetUser { user { id } }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "Description is required for query \"GetUser\""
+        );
+    }
+
+    #[test]
+    fn test_operation_with_leading_comment_clean() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let source = "# Fetches the current user\nquery GetUser { user { id } }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_operation_with_blank_line_after_comment_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        // Blank line between comment and operation — graphql-eslint requires
+        // `linesBefore === 1`, so this is NOT a description.
+        let source = "# Fetches the current user\n\nquery GetUser { user { id } }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn test_anonymous_operation_uses_keyword_label() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let source = "mutation { updateUser(id: \"1\") { id } }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "Description is required for mutation"
+        );
+    }
+
+    #[test]
+    fn test_eslint_disable_comment_does_not_satisfy() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let source = "# eslint-disable-next-line\nquery GetUser { user { id } }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn test_fragment_definitions_not_flagged() {
+        let db = RootDatabase::default();
+        let rule = RequireDescriptionRuleImpl;
+        let source = "fragment UserFields on User { id }\n";
+        let (file_id, content, metadata, project_files) = create_document_project(&db, source);
+        let diagnostics = StandaloneDocumentLintRule::check(
+            &rule,
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            None,
+        );
+        assert!(diagnostics.is_empty());
     }
 }

--- a/test-workspace/lint-examples/schema/descriptionStyle.graphql
+++ b/test-workspace/lint-examples/schema/descriptionStyle.graphql
@@ -10,10 +10,7 @@ type Category {
   """
   id: ID!
   "The category label"
-  label(
-    "Format hint for the label"
-    format: String
-  ): String!
+  label("Format hint for the label" format: String): String!
 }
 
 "Available color options"
@@ -24,14 +21,13 @@ enum Color {
   BLUE
 }
 
-"""Filter input for users"""
+"""
+Filter input for users
+"""
 input UserFilter {
   "Match users by id"
   id: ID
 }
 
 "Mark a field as cached"
-directive @cached(
-  "How long to cache, in seconds"
-  seconds: Int
-) on FIELD_DEFINITION
+directive @cached("How long to cache, in seconds" seconds: Int) on FIELD_DEFINITION

--- a/test-workspace/lint-examples/schema/descriptionStyle.graphql
+++ b/test-workspace/lint-examples/schema/descriptionStyle.graphql
@@ -1,5 +1,7 @@
 # Demonstrates: descriptionStyle
-# Default expects block descriptions ("""..."""). These use inline style ("...").
+# Default expects block descriptions ("""..."""). Inline descriptions on
+# any node — types, fields, arguments, input values, enum values, and
+# directives — are flagged.
 
 "A category for organizing items"
 type Category {
@@ -8,12 +10,28 @@ type Category {
   """
   id: ID!
   "The category label"
-  label: String!
+  label(
+    "Format hint for the label"
+    format: String
+  ): String!
 }
 
 "Available color options"
 enum Color {
+  "Red"
   RED
   GREEN
   BLUE
 }
+
+"""Filter input for users"""
+input UserFilter {
+  "Match users by id"
+  id: ID
+}
+
+"Mark a field as cached"
+directive @cached(
+  "How long to cache, in seconds"
+  seconds: Int
+) on FIELD_DEFINITION

--- a/test-workspace/lint-examples/schema/requireDescription.graphql
+++ b/test-workspace/lint-examples/schema/requireDescription.graphql
@@ -1,9 +1,11 @@
 # Demonstrates: requireDescription
-# These types are missing descriptions, which the rule will flag.
+# Every type, field, argument, input value, enum value, and directive
+# definition needs a description. Operations also need a `#` comment
+# directly above them (see src/requireDescription.graphql).
 
 type UndocumentedType {
   id: ID!
-  value: String!
+  value(format: String): String!
 }
 
 enum UndocumentedEnum {
@@ -14,3 +16,9 @@ enum UndocumentedEnum {
 interface UndocumentedInterface {
   id: ID!
 }
+
+input UndocumentedInput {
+  id: ID
+}
+
+directive @undocumented(seconds: Int) on FIELD_DEFINITION

--- a/test-workspace/lint-examples/src/requireDescription.graphql
+++ b/test-workspace/lint-examples/src/requireDescription.graphql
@@ -1,0 +1,15 @@
+# Demonstrates: requireDescription (operation side)
+# Operations need a `#` comment line directly above them (no blank line
+# between the comment and the operation keyword). Otherwise the rule fires.
+
+query UndocumentedQuery {
+  undocumented {
+    id
+  }
+}
+
+mutation {
+  undocumentedMutation {
+    id
+  }
+}


### PR DESCRIPTION
## Summary

Closes part of #1004 (Description coverage gaps).

`@graphql-eslint/eslint-plugin` matches `.description` on every AST node that can carry one — `FieldDefinition`, `InputValueDefinition` (input fields + arguments + directive args), `EnumValueDefinition`, `DirectiveDefinition`, and (for `require-description`) `OperationDefinition`. Today we only iterate top-level type definitions. This PR closes that gap.

## Changes

- `description-style`: walk the AST and check `.description` on field definitions, input value definitions, enum value definitions, and directive definitions in addition to top-level type definitions. Diagnostic messages mirror graphql-eslint's `getNodeName` shape (e.g. `Unexpected inline description for field "id" in type "User"`).
- `require-description`: same coverage extension plus operation definitions. Schema-side coverage uses `graphql_hir::schema_types` and `graphql_hir::schema_directives`. Operation-side coverage walks the parsed document and looks for a `#` comment immediately above the operation (no blank line between, non-`eslint`), matching graphql-eslint's `linesBefore === 1` rule.
- `RequireDescriptionRuleImpl` now implements both `StandaloneSchemaLintRule` and `StandaloneDocumentLintRule`. Updated `registry.rs` to dedupe rule names in `all_rule_names`/`all_rule_info`.
- HIR: added `name_range: TextRange` to `EnumValue` so enum-value diagnostics can point at the value's name token.
- Removed the `// TODO(parity)` comment in `description_style.rs`.
- Updated `test-workspace/lint-examples/schema/{descriptionStyle,requireDescription}.graphql` to demonstrate the extended coverage; added `test-workspace/lint-examples/src/requireDescription.graphql` for the operation-side demo.

## Consulted SME Agents

N/A

## Manual Testing Plan

- Open `test-workspace/lint-examples/schema/descriptionStyle.graphql` and `requireDescription.graphql` in VS Code with the extension and confirm diagnostics fire on every nested node (fields, args, input values, enum values, directives).
- Open `test-workspace/lint-examples/src/requireDescription.graphql` and confirm both operations are flagged for missing leading `#` comment, then prepend `# A description` (no blank line) to one of them and confirm the diagnostic clears.

## Related Issues

Closes part of #1004