### PR TITLE
Align `require-nullable-result-in-root` with graphql-eslint

### DIFF
--- a/.changeset/require-nullable-result-parity.md
+++ b/.changeset/require-nullable-result-parity.md
@@ -1,0 +1,9 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-core: patch
+graphql-analyzer-eslint-plugin: patch
+---
+
+`require-nullable-result-in-root` now matches `@graphql-eslint/eslint-plugin` exactly: non-null list types like `[User!]!` are no longer flagged (only non-null *named* returns are), and the diagnostic message is `Unexpected non-null result <type> in type "<root>"` to match graphql-eslint's wording.

--- a/crates/linter/src/rules/require_nullable_result_in_root.rs
+++ b/crates/linter/src/rules/require_nullable_result_in_root.rs
@@ -58,7 +58,11 @@ impl StandaloneSchemaLintRule for RequireNullableResultInRootRuleImpl {
             };
 
             for field in &root_type.fields {
-                if field.type_ref.is_non_null {
+                // Match graphql-eslint: only flag non-null *named* returns
+                // (e.g. `User!`). A non-null list (`[User!]!`) is acceptable —
+                // an empty list is a valid empty-but-non-null payload, so the
+                // null-bubbling concern doesn't apply at the list level.
+                if field.type_ref.is_non_null && !field.type_ref.is_list {
                     let span = graphql_syntax::SourceSpan {
                         start: field.type_ref.name_range.start().into(),
                         end: field.type_ref.name_range.end().into(),
@@ -72,7 +76,7 @@ impl StandaloneSchemaLintRule for RequireNullableResultInRootRuleImpl {
                             span,
                             LintSeverity::Warning,
                             format!(
-                                "Unexpected non-null result {} in {}",
+                                "Unexpected non-null result {} in type \"{}\"",
                                 field.type_ref.name, type_name
                             ),
                             "requireNullableResultInRoot",
@@ -148,7 +152,10 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, None);
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert_eq!(all[0].message, "Unexpected non-null result User in Query");
+        assert_eq!(
+            all[0].message,
+            "Unexpected non-null result User in type \"Query\""
+        );
         // Diagnostic spans the inner named type (`User`), matching the
         // `TypeRef.name_range` provenance from the HIR.
         let span = &all[0].span;
@@ -166,7 +173,7 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].message,
-            "Unexpected non-null result User in Mutation"
+            "Unexpected non-null result User in type \"Mutation\""
         );
     }
 
@@ -181,24 +188,22 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].message,
-            "Unexpected non-null result Message in Subscription"
+            "Unexpected non-null result Message in type \"Subscription\""
         );
     }
 
     #[test]
-    fn test_non_null_list_fails() {
+    fn test_non_null_list_passes() {
+        // Non-null list types (`[User!]!`) are acceptable — graphql-eslint
+        // skips them too, since an empty list is a valid empty-but-non-null
+        // payload that doesn't trigger field-level null-bubbling.
         let db = RootDatabase::default();
         let rule = RequireNullableResultInRootRuleImpl;
         let schema = "type Query { users: [User!]! } type User { id: ID! }";
         let project_files = create_schema_project(&db, schema);
         let diagnostics = rule.check(&db, project_files, None);
         let all: Vec<_> = diagnostics.values().flatten().collect();
-        assert_eq!(all.len(), 1);
-        assert!(all[0].message.contains("non-null result"));
-        assert!(all[0].message.contains("in Query"));
-        // Diagnostic spans the inner named type (`User`) inside the wrapper.
-        let span = &all[0].span;
-        assert_eq!(&schema[span.start..span.end], "User");
+        assert!(all.is_empty());
     }
 
     #[test]
@@ -250,7 +255,7 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(
             all[0].message,
-            "Unexpected non-null result User in RootQuery"
+            "Unexpected non-null result User in type \"RootQuery\""
         );
     }
 
@@ -276,6 +281,9 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, None);
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert_eq!(all[0].message, "Unexpected non-null result Post in Query");
+        assert_eq!(
+            all[0].message,
+            "Unexpected non-null result Post in type \"Query\""
+        );
     }
 }

--- a/docs/src/content/docs/rules/requireNullableResultInRoot.mdx
+++ b/docs/src/content/docs/rules/requireNullableResultInRoot.mdx
@@ -13,25 +13,26 @@ description: Require root type fields to return nullable types for error resilie
 
 ## What it checks
 
-Requires fields on root types (Query, Mutation, Subscription) to return nullable types. When a root field returns a non-null type and an error occurs at runtime, GraphQL's null-bubbling behavior propagates the null up to the nearest nullable parent — potentially nulling out the entire `data` response. Making root fields nullable isolates errors to the individual field that failed, keeping the rest of the response intact.
+Requires fields on root types (Query, Mutation, Subscription) to return nullable types. When a root field returns a non-null named type and an error occurs at runtime, GraphQL's null-bubbling behavior propagates the null up to the nearest nullable parent — potentially nulling out the entire `data` response. Making root fields nullable isolates errors to the individual field that failed, keeping the rest of the response intact.
+
+Non-null **list** types like `[User!]!` are intentionally allowed: an empty list is a valid non-null payload, so the null-bubbling concern doesn't apply at the list level. This matches `@graphql-eslint/eslint-plugin`.
 
 The rule also works with custom root type names defined via a `schema` definition.
 
 ## Examples
 
 ```graphql
-# ❌ Bad — root fields return non-null types
+# ❌ Bad — root field returns a non-null named type
 type Query {
   user(id: ID!): User!
-  users: [User!]!
 }
 ```
 
 ```graphql
-# ✅ Good — root fields return nullable types
+# ✅ Good — root fields are nullable, or non-null lists
 type Query {
   user(id: ID!): User
-  users: [User!]
+  users: [User!]!
 }
 ```
 

--- a/packages/eslint-plugin/test/parity.test.mjs
+++ b/packages/eslint-plugin/test/parity.test.mjs
@@ -132,12 +132,15 @@ const EXERCISED = {
   "no-anonymous-operations": { file: "src/operations.graphql", severity: 2, span: "line" },
   "no-duplicate-fields": { file: "src/operations.graphql", severity: 2, span: "line" },
   "no-hashtag-description": { file: "schema.graphql", severity: 1, span: "full" },
-  // Position parity verified after #1008 (TypeRef.name_range). The
-  // `require-nullable-result-in-root` rule isn't here yet — graphql-eslint
-  // skips non-null list types and emits a different message format
-  // (`in type "Query"` vs our `in Query`); aligning those is follow-up work
-  // tracked separately from #1008's position-only change.
+  // Position parity verified after #1008 (TypeRef.name_range).
   "require-field-of-type-query-in-mutation-result": {
+    file: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+  // Firing condition aligned (skip non-null lists) and message format
+  // aligned (`in type "Query"`) to match graphql-eslint exactly.
+  "require-nullable-result-in-root": {
     file: "schema.graphql",
     severity: 1,
     span: "full",

--- a/test-workspace/eslint-migration/schema.graphql
+++ b/test-workspace/eslint-migration/schema.graphql
@@ -1,6 +1,11 @@
 type Query {
   user(id: ID!): User
   users: [User!]!
+  # Non-null named scalar — exercises `require-nullable-result-in-root`.
+  # Built-in scalar (vs custom type) avoids an upstream graphql-eslint bug
+  # where the diagnostic message drops the inner type name when the wrapper
+  # is `NonNullType` of a custom `NamedType`.
+  version: String!
 }
 
 type User {

--- a/test-workspace/lint-examples/schema/requireNullableResultInRoot.graphql
+++ b/test-workspace/lint-examples/schema/requireNullableResultInRoot.graphql
@@ -1,15 +1,15 @@
 # Demonstrates: requireNullableResultInRoot
 # Root type fields should return nullable types for error resilience.
-# Non-null root fields cause null-bubbling to propagate errors to the
-# entire response.
+# Non-null named root fields cause null-bubbling to propagate errors to
+# the entire response.
+#
+# Non-null *list* fields like `[Post!]!` are intentionally not flagged —
+# an empty list is a valid non-null payload, so the null-bubbling concern
+# doesn't apply at the list level.
 
 extend type Query {
   """
-  Non-null return type - violates the rule
+  Non-null named return type - violates the rule
   """
   currentUser: User!
-  """
-  Non-null list return type - also violates the rule
-  """
-  allPosts: [Post!]!
 }


### PR DESCRIPTION
## Summary

Closes two parity drifts that #1008's new parity test surfaced.

## Changes

- **Firing condition** (`crates/linter/src/rules/require_nullable_result_in_root.rs`): the rule now skips non-null list types (`[User!]!`), matching `@graphql-eslint/eslint-plugin`. An empty list is a valid non-null payload — null-bubbling concerns don't apply at the list level.
- **Message format**: changed from `Unexpected non-null result <type> in <root>` to `Unexpected non-null result <type> in type "<root>"` to match graphql-eslint exactly.
- **Parity test** (`packages/eslint-plugin/test/parity.test.mjs`): adds `require-nullable-result-in-root` to `EXERCISED` with `span: "full"`. The fixture (`test-workspace/eslint-migration/schema.graphql`) gains `version: String!` on `Query` to actually exercise the rule.
- **Lint-examples demo** (`test-workspace/lint-examples/schema/requireNullableResultInRoot.graphql`) and **docs page** updated to reflect the new firing condition (non-null *named* only; non-null lists are intentionally allowed).

## Why a built-in scalar in the fixture?

graphql-eslint has an upstream bug where the diagnostic message drops the inner type name when the wrapper is `NonNullType` of a custom `NamedType` (e.g. `user: User!` produces `Unexpected non-null result  in type "Query"` — note the double space). The bug doesn't trigger for built-in scalars, so `version: String!` lets us assert exact message parity without baking in a broken expectation. A custom-type case is still covered by our Rust unit tests.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- `cargo nextest run -p graphql-linter require_nullable_result` — unit tests reflect the new firing condition + message.
- `npm run test:unit --workspace=@graphql-analyzer/eslint-plugin` — parity test exercises the rule against graphql-eslint and asserts full position match.

## Related Issues

Follows on from #1008. Part of the broader push toward 1:1 parity with `@graphql-eslint/eslint-plugin` (closes part of #1004).