### PR TITLE
Match graphql-eslint's start-only `loc` for `no-hashtag-description`

### DIFF
--- a/.changeset/no-hashtag-loc-parity.md
+++ b/.changeset/no-hashtag-loc-parity.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-eslint-plugin: patch
+---
+
+`no-hashtag-description` diagnostics now report a single-position `loc` (start-only) when surfaced through `@graphql-analyzer/eslint-plugin`, matching `@graphql-eslint/eslint-plugin` exactly. The underlying analyzer diagnostic still carries the full comment range — that richness remains visible to the LSP and CLI; only the ESLint adapter strips the end position to mirror graphql-eslint's reporting shape.

--- a/packages/eslint-plugin/src/rules.ts
+++ b/packages/eslint-plugin/src/rules.ts
@@ -27,7 +27,17 @@ function diagnosticsFor(filePath: string, source: string): binding.JsDiagnostic[
   return fresh;
 }
 
+// Rules where graphql-eslint reports a single-position `loc` (start only) so
+// `endLine`/`endColumn` come back `undefined`. Our underlying diagnostic
+// always carries a full range — useful for LSP/CLI consumers — but for these
+// specific rules the eslint adapter strips the end so the message shape
+// matches graphql-eslint exactly. Add a rule here only when graphql-eslint's
+// own implementation is intentionally start-only (e.g. `no-hashtag-description`
+// passes `loc: { line, column }` rather than `{ start, end }`).
+const START_ONLY_RULES = new Set(["noHashtagDescription"]);
+
 function makeRule(analyzerRuleName: string, description: string): Rule.RuleModule {
+  const startOnly = START_ONLY_RULES.has(analyzerRuleName);
   return {
     meta: {
       type: "problem",
@@ -40,13 +50,13 @@ function makeRule(analyzerRuleName: string, description: string): Rule.RuleModul
           const diagnostics = diagnosticsFor(context.filename, context.sourceCode.text);
           for (const d of diagnostics) {
             if (d.rule !== analyzerRuleName) continue;
-            context.report({
-              message: d.message,
-              loc: {
-                start: { line: d.line, column: d.column - 1 },
-                end: { line: d.endLine, column: d.endColumn - 1 },
-              },
-            });
+            const loc = startOnly
+              ? { line: d.line, column: d.column - 1 }
+              : {
+                  start: { line: d.line, column: d.column - 1 },
+                  end: { line: d.endLine, column: d.endColumn - 1 },
+                };
+            context.report({ message: d.message, loc });
           }
         },
       };

--- a/packages/eslint-plugin/test/parity.test.mjs
+++ b/packages/eslint-plugin/test/parity.test.mjs
@@ -122,20 +122,16 @@ test("no unexpected extra rules vs graphql-eslint", () => {
 
 // Rules whose output is verified against graphql-eslint, keyed by rule name.
 //
-//   span: "line" — compare diagnostic count, messages, and firing line. Used
-//     for rules where we agree on what to flag and roughly where, but
-//     graphql-eslint doesn't emit `endLine`/`endColumn` (e.g. comment-attached
-//     diagnostics).
-//   span: "full" — also compare column/endLine/endColumn. Use for rules whose
-//     position parity has been deliberately aligned, so column-level fixes
-//     (e.g. reporting on the inner named type rather than the type wrapper)
-//     stay verified.
+//   span: "line" — compare diagnostic count, messages, and firing line.
+//   span: "full" — also compare column/endLine/endColumn (or assert that
+//     both sides emit the same single-position loc — `endLine` and
+//     `endColumn` may be `undefined` if graphql-eslint reports start-only).
 //
 // Adding a rule here is the single point where parity coverage is declared.
 const EXERCISED = {
   "no-anonymous-operations": { file: "src/operations.graphql", severity: 2, span: "line" },
   "no-duplicate-fields": { file: "src/operations.graphql", severity: 2, span: "line" },
-  "no-hashtag-description": { file: "schema.graphql", severity: 1, span: "line" },
+  "no-hashtag-description": { file: "schema.graphql", severity: 1, span: "full" },
   // Position parity verified after #1008 (TypeRef.name_range). The
   // `require-nullable-result-in-root` rule isn't here yet — graphql-eslint
   // skips non-null list types and emits a different message format


### PR DESCRIPTION
## Summary

Closes the third parity drift surfaced by #1008's parity test: `@graphql-eslint/eslint-plugin` deliberately reports a single-position `loc` for `no-hashtag-description` (its rule passes `loc: { line, column }` rather than `{ start, end }`). Ours emitted a full range, producing different squiggle widths from the same source. Aligns the ESLint adapter to match.

## Changes

- **`packages/eslint-plugin/src/rules.ts`**: introduce a `START_ONLY_RULES` set. For rules in the set, the adapter calls `context.report` with `loc: { line, column }`, leaving `endLine`/`endColumn` `undefined` in the resulting message — matching graphql-eslint exactly. The underlying analyzer diagnostic still carries the full comment range, so LSP and CLI consumers keep the richer position info.
- **`packages/eslint-plugin/test/parity.test.mjs`**: promote `no-hashtag-description` from `span: "line"` to `span: "full"` so the stripped end is verified against graphql-eslint going forward.

## Why a separate set instead of changing the rule's Rust span?

Two reasons:

1. The Rust rule's full comment range is genuinely useful info — LSP `textDocument/publishDiagnostics` uses it to highlight the whole comment, and the CLI's text output uses it for caret-line generation. Stripping it on the data layer would degrade both.
2. graphql-eslint's start-only choice is a per-rule presentation decision, not a data-model fact. Modeling it on the eslint adapter side keeps the abstraction in the right layer.

Reference: graphql-eslint's `no-hashtag-description/index.js` calls `context.report({ ..., loc: { line, column: column - 1 } })` — see [their source](https://github.com/dimaMachina/graphql-eslint/blob/master/packages/plugin/src/rules/no-hashtag-description/index.ts).

## Consulted SME Agents

- N/A

## Manual Testing Plan

- `npm run test:unit --workspace=@graphql-analyzer/eslint-plugin` — parity test now compares full positions (incl. `endLine`/`endColumn`) for `no-hashtag-description` and passes.

## Related Issues

Part of the broader push toward 1:1 parity with `@graphql-eslint/eslint-plugin` (closes part of #1004). Independent of #1012 (`require-nullable-result-in-root`); either order is fine to merge.