### PR TITLE
1:1 parity with `@graphql-eslint/eslint-plugin` (all 31 shared rules)

### DIFF
--- a/.changeset/parity-1to1.md
+++ b/.changeset/parity-1to1.md
@@ -1,0 +1,16 @@
+---
+graphql-analyzer-cli: minor
+graphql-analyzer-lsp: minor
+graphql-analyzer-mcp: minor
+graphql-analyzer-core: minor
+graphql-analyzer-eslint-plugin: minor
+---
+
+`@graphql-analyzer/eslint-plugin`: every shared lint rule is now verified end-to-end against `@graphql-eslint/eslint-plugin` with identical diagnostic counts, messages, and source positions. Behavior changes that align ours to graphql-eslint:
+
+- **Message format** (backticks → double quotes around identifiers): `require-import-fragment`, `require-nullable-fields-with-oneof`, `strict-id-in-types`, `selection-set-depth`, `no-deprecated`, `require-deprecation-date`, and several rules touched by the alphabetize/option-schema work.
+- **Diagnostic position**: `no-scalar-result-type-on-mutation`, `relay-connection-types`, `require-deprecation-reason`, and `require-deprecation-date` now point at the relevant type/directive name node (matching graphql-eslint) rather than the field name. `unique-enum-value-names` points at each duplicate value's name token. `require-selections` points at the SelectionSet `{`.
+- **Firing condition**: `naming-convention` no longer applies hardcoded `OperationDefinition: PascalCase`/`FragmentDefinition: PascalCase`/`Variable: camelCase` defaults — the rule now no-ops without explicit kind config, matching graphql-eslint.
+- **Option schemas**: `alphabetize`, `no-root-type`, `match-document-filename`, `selection-set-depth`, and `require-description` now accept the same option shapes graphql-eslint does (`maxDepth` instead of `max_depth`, kind-filter objects, etc.).
+- **Semantics**: `require-deprecation-date` now reads the `@deprecated(deletionDate: "DD/MM/YYYY")` argument (rather than scanning the `reason` substring) and emits the same `MESSAGE_INVALID_FORMAT` / `MESSAGE_INVALID_DATE` / `MESSAGE_CAN_BE_REMOVED` diagnostics graphql-eslint does.
+- **Multi-config support**: the napi host now resets per `init()` call, so monorepos with multiple `.graphqlrc.yaml` projects no longer leak schema/document state from one project into another.

--- a/crates/hir/src/structure.rs
+++ b/crates/hir/src/structure.rs
@@ -100,6 +100,11 @@ pub struct EnumValue {
 pub struct DirectiveUsage {
     pub name: Arc<str>,
     pub arguments: Vec<DirectiveArgument>,
+    /// Source range of the directive's name token (e.g. `deprecated` in
+    /// `@deprecated(reason: "...")`). Used by lint rules that need to point
+    /// at the directive itself. Empty range when the directive came from a
+    /// synthetic source.
+    pub name_range: TextRange,
 }
 
 /// An argument passed to a directive
@@ -108,6 +113,11 @@ pub struct DirectiveArgument {
     pub name: Arc<str>,
     /// Serialized value (e.g. `"hello"`, `true`, `ENUM_VALUE`)
     pub value: Arc<str>,
+    /// Source range of the argument's value (e.g. the literal `"foo"` after
+    /// the colon). Used by lint rules that need to point at the value rather
+    /// than the surrounding directive. Empty range when the argument came
+    /// from a synthetic source.
+    pub value_range: TextRange,
 }
 
 /// A directive definition from the schema (e.g. `directive @cacheControl on FIELD_DEFINITION`)
@@ -1035,12 +1045,14 @@ fn extract_directives(directives: &apollo_compiler::ast::DirectiveList) -> Vec<D
         .iter()
         .map(|directive| DirectiveUsage {
             name: Arc::from(directive.name.as_str()),
+            name_range: name_range(&directive.name),
             arguments: directive
                 .arguments
                 .iter()
                 .map(|arg| DirectiveArgument {
                     name: Arc::from(arg.name.as_str()),
                     value: Arc::from(arg.value.to_string().as_str()),
+                    value_range: node_range(&arg.value),
                 })
                 .collect(),
         })

--- a/crates/linter/src/rules/alphabetize.rs
+++ b/crates/linter/src/rules/alphabetize.rs
@@ -4,26 +4,50 @@ use apollo_parser::cst::{self, CstNode};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
 use serde::Deserialize;
 
-/// Options for the `alphabetize` rule
+/// Selection-set owners that `alphabetize.selections` may restrict to. Mirrors
+/// graphql-eslint's `selectionsEnum` (`OperationDefinition`, `FragmentDefinition`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum SelectionsOwner {
+    OperationDefinition,
+    FragmentDefinition,
+}
+
+/// `selections` accepts either a boolean (legacy) or an array of owner kinds
+/// (matching graphql-eslint). `true` is treated as "both owner kinds enabled".
 #[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum SelectionsConfig {
+    Bool(bool),
+    Owners(Vec<SelectionsOwner>),
+}
+
+impl SelectionsConfig {
+    fn includes(&self, owner: SelectionsOwner) -> bool {
+        match self {
+            Self::Bool(b) => *b,
+            Self::Owners(list) => list.contains(&owner),
+        }
+    }
+}
+
+impl Default for SelectionsConfig {
+    fn default() -> Self {
+        Self::Bool(true)
+    }
+}
+
+/// Options for the `alphabetize` rule
+#[derive(Debug, Clone, Deserialize, Default)]
 #[serde(default)]
 pub struct AlphabetizeOptions {
-    /// Check selection sets for alphabetical order
-    pub selections: bool,
+    /// Check selection sets for alphabetical order. Either a boolean or an
+    /// array of selection-set owner kinds (`OperationDefinition`,
+    /// `FragmentDefinition`).
+    pub selections: SelectionsConfig,
     /// Check arguments for alphabetical order
     pub arguments: bool,
     /// Check variable definitions for alphabetical order
     pub variables: bool,
-}
-
-impl Default for AlphabetizeOptions {
-    fn default() -> Self {
-        Self {
-            selections: true,
-            arguments: false,
-            variables: false,
-        }
-    }
 }
 
 impl AlphabetizeOptions {
@@ -31,6 +55,10 @@ impl AlphabetizeOptions {
         value
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or_default()
+    }
+
+    fn check_owner(&self, owner: SelectionsOwner) -> bool {
+        self.selections.includes(owner)
     }
 }
 
@@ -79,20 +107,24 @@ impl StandaloneDocumentLintRule for AlphabetizeRuleImpl {
                                 check_variable_order(&var_defs, &doc, &mut diagnostics);
                             }
                         }
+                        let scan = opts.check_owner(SelectionsOwner::OperationDefinition);
                         if let Some(selection_set) = op.selection_set() {
                             check_selection_set_order(
                                 &selection_set,
                                 &opts,
+                                scan,
                                 &doc,
                                 &mut diagnostics,
                             );
                         }
                     }
                     cst::Definition::FragmentDefinition(frag) => {
+                        let scan = opts.check_owner(SelectionsOwner::FragmentDefinition);
                         if let Some(selection_set) = frag.selection_set() {
                             check_selection_set_order(
                                 &selection_set,
                                 &opts,
+                                scan,
                                 &doc,
                                 &mut diagnostics,
                             );
@@ -125,10 +157,11 @@ impl SelectionKind {
 fn check_selection_set_order(
     selection_set: &cst::SelectionSet,
     opts: &AlphabetizeOptions,
+    scan_selections: bool,
     doc: &graphql_syntax::DocumentRef<'_>,
     diagnostics: &mut Vec<LintDiagnostic>,
 ) {
-    if opts.selections {
+    if scan_selections {
         let mut last: Option<(String, SelectionKind)> = None;
 
         for selection in selection_set.selections() {
@@ -174,7 +207,7 @@ fn check_selection_set_order(
                                     doc.span(start, end),
                                     LintSeverity::Warning,
                                     format!(
-                                        "{curr_label} `{name}` should be before {prev_label} `{prev_name}`",
+                                        "{curr_label} \"{name}\" should be before {prev_label} \"{prev_name}\"",
                                         curr_label = curr_kind.label(),
                                         prev_label = prev_kind.label(),
                                     ),
@@ -202,12 +235,12 @@ fn check_selection_set_order(
                     }
                 }
                 if let Some(nested) = field.selection_set() {
-                    check_selection_set_order(&nested, opts, doc, diagnostics);
+                    check_selection_set_order(&nested, opts, scan_selections, doc, diagnostics);
                 }
             }
             cst::Selection::InlineFragment(inline) => {
                 if let Some(nested) = inline.selection_set() {
-                    check_selection_set_order(&nested, opts, doc, diagnostics);
+                    check_selection_set_order(&nested, opts, scan_selections, doc, diagnostics);
                 }
             }
             cst::Selection::FragmentSpread(_) => {}
@@ -233,7 +266,7 @@ fn check_argument_order(
                         LintDiagnostic::new(
                             doc.span(start, end),
                             LintSeverity::Warning,
-                            format!("argument `{name}` should be before argument `{prev}`"),
+                            format!("argument \"{name}\" should be before argument \"{prev}\""),
                             "alphabetize",
                         )
                         .with_help("Reorder arguments alphabetically by name"),
@@ -264,7 +297,7 @@ fn check_variable_order(
                             LintDiagnostic::new(
                                 doc.span(start, end),
                                 LintSeverity::Warning,
-                                format!("variable `{name}` should be before variable `{prev}`"),
+                                format!("variable \"{name}\" should be before variable \"{prev}\""),
                                 "alphabetize",
                             )
                             .with_help("Reorder variable definitions alphabetically by name"),
@@ -332,7 +365,7 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0]
             .message
-            .contains("field `age` should be before field `name`"));
+            .contains("field \"age\" should be before field \"name\""));
     }
 
     #[test]
@@ -341,7 +374,7 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0]
             .message
-            .contains("field `id` should be before field `title`"));
+            .contains("field \"id\" should be before field \"title\""));
     }
 
     #[test]
@@ -351,7 +384,7 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             diagnostics[0].message,
-            "field `age` should be before fragment spread `Zed`"
+            "field \"age\" should be before fragment spread \"Zed\""
         );
     }
 
@@ -362,7 +395,68 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             diagnostics[0].message,
-            "fragment spread `Avatar` should be before field `name`"
+            "fragment spread \"Avatar\" should be before field \"name\""
         );
+    }
+
+    fn check_with_options(source: &str, options: &serde_json::Value) -> Vec<LintDiagnostic> {
+        let db = RootDatabase::default();
+        let rule = AlphabetizeRuleImpl;
+        let file_id = FileId::new(0);
+        let content = FileContent::new(&db, Arc::from(source));
+        let metadata = FileMetadata::new(
+            &db,
+            file_id,
+            FileUri::new("file:///test.graphql"),
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        let project_files = create_test_project_files(&db);
+        rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(options),
+        )
+    }
+
+    #[test]
+    fn test_selections_array_only_operation_definition() {
+        // With `selections: ["OperationDefinition"]`, fragment definitions
+        // are NOT scanned for selection-set ordering.
+        let opts = serde_json::json!({ "selections": ["OperationDefinition"] });
+        let source = "fragment F on User { name age id }\nquery Q { user { name age id } }\n";
+        let diagnostics = check_with_options(source, &opts);
+        assert_eq!(diagnostics.len(), 1, "expected only the query to fire");
+        assert!(diagnostics[0]
+            .message
+            .contains("field \"age\" should be before field \"name\""));
+    }
+
+    #[test]
+    fn test_selections_array_only_fragment_definition() {
+        let opts = serde_json::json!({ "selections": ["FragmentDefinition"] });
+        let source = "fragment F on User { name age id }\nquery Q { user { name age id } }\n";
+        let diagnostics = check_with_options(source, &opts);
+        assert_eq!(diagnostics.len(), 1, "expected only the fragment to fire");
+    }
+
+    #[test]
+    fn test_selections_array_both_kinds() {
+        let opts = serde_json::json!({
+            "selections": ["OperationDefinition", "FragmentDefinition"]
+        });
+        let source = "fragment F on User { name age id }\nquery Q { user { name age id } }\n";
+        let diagnostics = check_with_options(source, &opts);
+        assert_eq!(diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn test_selections_false_disables_check() {
+        let opts = serde_json::json!({ "selections": false });
+        let diagnostics = check_with_options("query Q { user { name age } }", &opts);
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/linter/src/rules/match_document_filename.rs
+++ b/crates/linter/src/rules/match_document_filename.rs
@@ -203,16 +203,26 @@ impl StandaloneDocumentLintRule for MatchDocumentFilenameRuleImpl {
                 build_expected_filename(&name_text, config.style, &config.suffix);
 
             if expected_filename != filename_stem {
+                // graphql-eslint reports the *full* filename (stem + extension)
+                // on both sides of the message. We default to the actual
+                // extension if known, otherwise fall back to the configured
+                // `fileExtension` and finally `.graphql`.
+                let ext_for_msg = actual_extension
+                    .as_deref()
+                    .or(opts.file_extension.as_deref())
+                    .unwrap_or(".graphql");
+                let actual_full = format!("{filename_stem}{ext_for_msg}");
+                let expected_full = format!("{expected_filename}{ext_for_msg}");
                 diagnostics.push(
                     LintDiagnostic::warning(
                         anchor_span,
                         format!(
-                            "Unexpected filename \"{filename_stem}\". Rename it to \"{expected_filename}\""
+                            "Unexpected filename \"{actual_full}\". Rename it to \"{expected_full}\""
                         ),
                         "matchDocumentFilename",
                     )
                     .with_help(format!(
-                        "Rename the file to \"{expected_filename}.graphql\" or rename the {op_type_str} to match the filename"
+                        "Rename the file to \"{expected_full}\" or rename the {op_type_str} to match the filename"
                     )),
                 );
             }

--- a/crates/linter/src/rules/naming_convention.rs
+++ b/crates/linter/src/rules/naming_convention.rs
@@ -5,19 +5,21 @@ use apollo_parser::cst::{self, CstNode};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
 use serde::Deserialize;
 
-/// Convention for names
+/// Convention for names. Accepts the same string forms as graphql-eslint:
+/// `"camelCase"`, `"PascalCase"`, `"snake_case"`, `"UPPER_CASE"`.
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub enum NamingCase {
     /// camelCase
+    #[serde(rename = "camelCase")]
     Camel,
     /// `PascalCase`
+    #[serde(rename = "PascalCase")]
     Pascal,
     /// `snake_case`
-    #[serde(alias = "snake_case")]
+    #[serde(rename = "snake_case")]
     Snake,
     /// `UPPER_CASE`
-    #[serde(alias = "UPPER_CASE")]
+    #[serde(rename = "UPPER_CASE")]
     Upper,
 }
 
@@ -67,28 +69,22 @@ fn is_upper_case(s: &str) -> bool {
         .all(|c| c.is_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
-/// Options for the `naming_convention` rule
-#[derive(Debug, Clone, Deserialize)]
+/// Options for the `naming_convention` rule.
+///
+/// Mirrors graphql-eslint: with no options the rule no-ops. Each AST kind
+/// must be opted into explicitly.
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct NamingConventionOptions {
-    /// Convention for operation names (default: `PascalCase`)
+    /// Convention for operation names (no default; must be set to fire)
     #[serde(rename = "OperationDefinition")]
     pub operation_definition: Option<NamingCase>,
-    /// Convention for fragment names (default: `PascalCase`)
+    /// Convention for fragment names (no default; must be set to fire)
     #[serde(rename = "FragmentDefinition")]
     pub fragment_definition: Option<NamingCase>,
-    /// Convention for variable names (default: camelCase, prefixed with $)
+    /// Convention for variable names (no default; must be set to fire)
+    #[serde(rename = "VariableDefinition", alias = "Variable")]
     pub variable: Option<NamingCase>,
-}
-
-impl Default for NamingConventionOptions {
-    fn default() -> Self {
-        Self {
-            operation_definition: Some(NamingCase::Pascal),
-            fragment_definition: Some(NamingCase::Pascal),
-            variable: Some(NamingCase::Camel),
-        }
-    }
 }
 
 impl NamingConventionOptions {
@@ -99,17 +95,19 @@ impl NamingConventionOptions {
     }
 }
 
-/// Lint rule that enforces naming conventions for operations and fragments
-// TODO(parity): graphql-eslint's `naming-convention` rule supports many more
-// options not implemented here: `prefix`, `suffix`, `forbiddenPatterns`,
-// `requiredPattern`, `forbiddenPrefixes`/`forbiddenSuffixes`,
-// `requiredPrefixes`/`requiredSuffixes`, `ignorePattern`,
-// `allowLeadingUnderscore`/`allowTrailingUnderscore`, the `types` umbrella
-// option, ESLint selector keys, and schema-side kinds (FieldDefinition,
-// ObjectTypeDefinition, EnumValueDefinition, etc.). Their corresponding
-// diagnostic messages (`have "X" prefix`, `not contain the forbidden
-// pattern "..."`, `Leading underscores are not allowed`, etc.) are not
-// emitted here.
+/// Lint rule that enforces naming conventions for operations and fragments.
+///
+/// Like graphql-eslint, the rule no-ops with no options — each kind must be
+/// explicitly configured.
+// TODO(parity): graphql-eslint's `naming-convention` rule additionally
+// supports `prefix`, `suffix`, `forbiddenPatterns`, `requiredPattern`,
+// `forbiddenPrefixes`/`forbiddenSuffixes`, `requiredPrefixes`/`requiredSuffixes`,
+// `ignorePattern`, `allowLeadingUnderscore`/`allowTrailingUnderscore`, the
+// `types` umbrella option, ESLint selector keys, and schema-side kinds
+// (FieldDefinition, ObjectTypeDefinition, EnumValueDefinition, etc.). Their
+// corresponding diagnostic messages (`have "X" prefix`, `not contain the
+// forbidden pattern "..."`, `Leading underscores are not allowed`, etc.) are
+// not emitted here.
 pub struct NamingConventionRuleImpl;
 
 impl LintRule for NamingConventionRuleImpl {
@@ -280,7 +278,10 @@ mod tests {
         )
     }
 
-    fn check(source: &str) -> Vec<LintDiagnostic> {
+    fn check_with_options(
+        source: &str,
+        options: Option<&serde_json::Value>,
+    ) -> Vec<LintDiagnostic> {
         let db = RootDatabase::default();
         let rule = NamingConventionRuleImpl;
         let file_id = FileId::new(0);
@@ -293,44 +294,73 @@ mod tests {
             DocumentKind::Executable,
         );
         let project_files = create_test_project_files(&db);
-        rule.check(&db, file_id, content, metadata, project_files, None)
+        rule.check(&db, file_id, content, metadata, project_files, options)
+    }
+
+    fn check(source: &str) -> Vec<LintDiagnostic> {
+        check_with_options(source, None)
+    }
+
+    #[test]
+    fn test_no_options_is_noop() {
+        // graphql-eslint parity: with no options every kind is unset, so the
+        // rule produces zero diagnostics regardless of how badly named the
+        // operation/fragment/variable is.
+        let diagnostics = check("query lowercaseOp { user { id } }");
+        assert!(diagnostics.is_empty());
+        let diagnostics = check("fragment lowercase_frag on User { id }");
+        assert!(diagnostics.is_empty());
+        let diagnostics = check("query Q($Bad: ID!) { user(id: $Bad) { id } }");
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
     fn test_valid_operation_name() {
-        let diagnostics = check("query GetUser { user { id } }");
+        let opts = serde_json::json!({ "OperationDefinition": "PascalCase" });
+        let diagnostics = check_with_options("query GetUser { user { id } }", Some(&opts));
         assert!(diagnostics.is_empty());
     }
 
     #[test]
     fn test_invalid_operation_name() {
-        let diagnostics = check("query get_user { user { id } }");
+        let opts = serde_json::json!({ "OperationDefinition": "PascalCase" });
+        let diagnostics = check_with_options("query get_user { user { id } }", Some(&opts));
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("PascalCase"));
     }
 
     #[test]
     fn test_valid_fragment_name() {
-        let diagnostics = check("fragment UserFields on User { id }");
+        let opts = serde_json::json!({ "FragmentDefinition": "PascalCase" });
+        let diagnostics = check_with_options("fragment UserFields on User { id }", Some(&opts));
         assert!(diagnostics.is_empty());
     }
 
     #[test]
     fn test_invalid_fragment_name() {
-        let diagnostics = check("fragment user_fields on User { id }");
+        let opts = serde_json::json!({ "FragmentDefinition": "PascalCase" });
+        let diagnostics = check_with_options("fragment user_fields on User { id }", Some(&opts));
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("PascalCase"));
     }
 
     #[test]
     fn test_valid_variable_name() {
-        let diagnostics = check("query Q($userId: ID!) { user(id: $userId) { id } }");
+        let opts = serde_json::json!({ "VariableDefinition": "camelCase" });
+        let diagnostics = check_with_options(
+            "query Q($userId: ID!) { user(id: $userId) { id } }",
+            Some(&opts),
+        );
         assert!(diagnostics.is_empty());
     }
 
     #[test]
     fn test_invalid_variable_name() {
-        let diagnostics = check("query Q($UserId: ID!) { user(id: $UserId) { id } }");
+        let opts = serde_json::json!({ "VariableDefinition": "camelCase" });
+        let diagnostics = check_with_options(
+            "query Q($UserId: ID!) { user(id: $UserId) { id } }",
+            Some(&opts),
+        );
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("camelCase"));
     }

--- a/crates/linter/src/rules/no_deprecated.rs
+++ b/crates/linter/src/rules/no_deprecated.rs
@@ -148,8 +148,12 @@ fn check_selection_set(
                             let syntax_node = field_name_node.syntax();
                             let offset: usize = syntax_node.text_range().start().into();
 
+                            // graphql-eslint format:
+                            //   `Field "name" is marked as deprecated in your GraphQL schema (reason: ...)`
+                            // displayNodeName uses the kind label ("field")
+                            // capitalized in the rule's reporter.
                             let message = format!(
-                                "Field `{}` is marked as deprecated in your GraphQL schema (reason: {})",
+                                "Field \"{}\" is marked as deprecated in your GraphQL schema (reason: {})",
                                 field_name.as_ref(),
                                 reason
                             );
@@ -185,7 +189,7 @@ fn check_selection_set(
                                                 syntax_node.text_range().start().into();
 
                                             let message = format!(
-                                                "Argument `{}` is marked as deprecated in your GraphQL schema (reason: {})",
+                                                "Argument \"{}\" is marked as deprecated in your GraphQL schema (reason: {})",
                                                 arg_name.as_ref(),
                                                 reason
                                             );
@@ -287,7 +291,7 @@ fn check_value_for_deprecated_enum(
                                 let offset: usize = syntax_node.text_range().start().into();
 
                                 let message = format!(
-                                    "Enum `{}` is marked as deprecated in your GraphQL schema (reason: {})",
+                                    "Enum \"{}\" is marked as deprecated in your GraphQL schema (reason: {})",
                                     enum_name.as_ref(),
                                     reason
                                 );
@@ -436,9 +440,11 @@ query GetUser {
         let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
 
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("username"));
-        assert!(diagnostics[0].message.contains("deprecated"));
-        assert!(diagnostics[0].message.contains("Use name instead"));
+        // graphql-eslint parity: messages quote names with double quotes.
+        assert_eq!(
+            diagnostics[0].message,
+            "Field \"username\" is marked as deprecated in your GraphQL schema (reason: Use name instead)"
+        );
 
         // Enrichment: deprecated-class rules should carry help text and the
         // Deprecated tag so editors can render them appropriately.

--- a/crates/linter/src/rules/no_root_type.rs
+++ b/crates/linter/src/rules/no_root_type.rs
@@ -93,8 +93,21 @@ impl StandaloneSchemaLintRule for NoRootTypeRuleImpl {
                 continue;
             };
 
-            let start: usize = type_def.definition_range.start().into();
-            let end: usize = type_def.definition_range.end().into();
+            // Point at the type name (matches graphql-eslint's
+            // `node.name.loc`). Falls back to the definition span if the name
+            // range is empty (defensive).
+            let (start, end): (usize, usize) =
+                if type_def.name_range.start() == type_def.name_range.end() {
+                    (
+                        type_def.definition_range.start().into(),
+                        type_def.definition_range.end().into(),
+                    )
+                } else {
+                    (
+                        type_def.name_range.start().into(),
+                        type_def.name_range.end().into(),
+                    )
+                };
             let span = graphql_syntax::SourceSpan {
                 start,
                 end,

--- a/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
+++ b/crates/linter/src/rules/no_scalar_result_type_on_mutation.rs
@@ -63,8 +63,8 @@ impl StandaloneSchemaLintRule for NoScalarResultTypeOnMutationRuleImpl {
                     .is_some_and(|t| t.kind == TypeDefKind::Scalar);
 
             if is_scalar {
-                let start: usize = field.name_range.start().into();
-                let end: usize = field.name_range.end().into();
+                let start: usize = field.type_ref.name_range.start().into();
+                let end: usize = field.type_ref.name_range.end().into();
                 let span = graphql_syntax::SourceSpan {
                     start,
                     end,

--- a/crates/linter/src/rules/relay_connection_types.rs
+++ b/crates/linter/src/rules/relay_connection_types.rs
@@ -122,8 +122,8 @@ impl StandaloneSchemaLintRule for RelayConnectionTypesRuleImpl {
                 }
                 Some(field) => {
                     if !field.type_ref.is_list {
-                        let field_start: usize = field.name_range.start().into();
-                        let field_end: usize = field.name_range.end().into();
+                        let field_start: usize = field.type_ref.name_range.start().into();
+                        let field_end: usize = field.type_ref.name_range.end().into();
                         let field_span = graphql_syntax::SourceSpan {
                             start: field_start,
                             end: field_end,
@@ -173,8 +173,8 @@ impl StandaloneSchemaLintRule for RelayConnectionTypesRuleImpl {
                     let is_wrong_type = field.type_ref.name.as_ref() != "PageInfo";
                     let is_nullable = !field.type_ref.is_non_null;
                     if is_wrong_type || is_nullable {
-                        let field_start: usize = field.name_range.start().into();
-                        let field_end: usize = field.name_range.end().into();
+                        let field_start: usize = field.type_ref.name_range.start().into();
+                        let field_end: usize = field.type_ref.name_range.end().into();
                         let field_span = graphql_syntax::SourceSpan {
                             start: field_start,
                             end: field_end,

--- a/crates/linter/src/rules/require_deprecation_date.rs
+++ b/crates/linter/src/rules/require_deprecation_date.rs
@@ -1,6 +1,7 @@
 use crate::diagnostics::{LintDiagnostic, LintSeverity};
 use crate::traits::{LintRule, StandaloneSchemaLintRule};
 use graphql_base_db::{FileId, ProjectFiles};
+use graphql_hir::{DirectiveUsage, TextRange};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -8,8 +9,8 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct RequireDeprecationDateOptions {
-    /// The argument name to search for in the deprecation reason string.
-    /// Defaults to `"deletionDate"`.
+    /// The directive argument name to read the deletion date from. Defaults
+    /// to `"deletionDate"`.
     #[serde(rename = "argumentName")]
     pub argument_name: String,
 }
@@ -30,20 +31,15 @@ impl RequireDeprecationDateOptions {
     }
 }
 
-/// Lint rule that requires `@deprecated` directives to include a deletion/removal date
-/// in the deprecation reason string.
+/// Lint rule that requires a deletion date on `@deprecated` directives.
 ///
-/// This helps teams track when deprecated fields should be removed by requiring
-/// a date to be included in the deprecation reason via a pattern like
-/// `deletionDate: 01/01/2025`.
-// TODO(parity): graphql-eslint reads the deletion date from a dedicated
-// `deletionDate` argument on the `@deprecated` directive (not the reason
-// string), and additionally reports MESSAGE_INVALID_FORMAT (`Deletion date
-// must be in format "DD/MM/YYYY" for ...`), MESSAGE_INVALID_DATE (`Invalid
-// "..." deletion date for ...`), and MESSAGE_CAN_BE_REMOVED (`... can be
-// removed`). Our implementation only checks for the argument-name substring
-// inside the reason string and only emits the "must have a deletion date"
-// message.
+/// Mirrors graphql-eslint:
+///   - Reads the date from a dedicated `deletionDate` argument (configurable)
+///     on the directive — not from a substring of the `reason`.
+///   - Validates the date is in `DD/MM/YYYY` format.
+///   - Validates the date is real (e.g. rejects `99/13/2025`).
+///   - When the deletion date is in the past, emits a "can be removed"
+///     diagnostic so teams know the field is overdue for removal.
 pub struct RequireDeprecationDateRuleImpl;
 
 impl LintRule for RequireDeprecationDateRuleImpl {
@@ -52,7 +48,7 @@ impl LintRule for RequireDeprecationDateRuleImpl {
     }
 
     fn description(&self) -> &'static str {
-        "Requires @deprecated directives to include a deletion date in the reason"
+        "Requires @deprecated directives to include a deletion date"
     }
 
     fn default_severity(&self) -> LintSeverity {
@@ -60,27 +56,197 @@ impl LintRule for RequireDeprecationDateRuleImpl {
     }
 }
 
-/// Check if the deprecation reason contains a date argument pattern.
-///
-/// Looks for patterns like `deletionDate: 01/01/2025` or `deletionDate: 2025-01-01`
-/// within the reason string.
-fn reason_contains_date_argument(reason: &str, argument_name: &str) -> bool {
-    // Look for the argument name followed by a colon and a date-like value
-    // e.g. "deletionDate: 01/01/2025" or "deletionDate: 2025-01-01"
-    let Some(pos) = reason.find(argument_name) else {
+/// Find the `@deprecated` directive in a directive list, if any.
+fn find_deprecated(directives: &[DirectiveUsage]) -> Option<&DirectiveUsage> {
+    directives.iter().find(|d| d.name.as_ref() == "deprecated")
+}
+
+/// Validate `DD/MM/YYYY`. Mirrors graphql-eslint's `DATE_REGEX`.
+fn is_valid_date_format(s: &str) -> bool {
+    if s.len() != 10 {
         return false;
+    }
+    let bytes = s.as_bytes();
+    bytes[2] == b'/'
+        && bytes[5] == b'/'
+        && bytes[0..2].iter().all(u8::is_ascii_digit)
+        && bytes[3..5].iter().all(u8::is_ascii_digit)
+        && bytes[6..10].iter().all(u8::is_ascii_digit)
+}
+
+/// Parse a `DD/MM/YYYY` date and return whether it is a real calendar date,
+/// plus a millisecond-since-UNIX-epoch timestamp suitable for past/future
+/// comparison. Mirrors graphql-eslint's `Date.parse("${y}-${m}-${d}")`
+/// roundtrip — including the `padStart` so e.g. `1/2/2025` is accepted.
+fn parse_dd_mm_yyyy(s: &str) -> Option<i64> {
+    let mut parts = s.split('/');
+    let day = parts.next()?.parse::<u32>().ok()?;
+    let month = parts.next()?.parse::<u32>().ok()?;
+    let year = parts.next()?.parse::<i32>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    if !(1..=12).contains(&month) {
+        return None;
+    }
+    let max_day = days_in_month(year, month)?;
+    if day < 1 || day > max_day {
+        return None;
+    }
+    Some(days_from_epoch(year, month, day) * 86_400_000)
+}
+
+/// Days in the given month/year (Gregorian).
+const fn days_in_month(year: i32, month: u32) -> Option<u32> {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => Some(31),
+        4 | 6 | 9 | 11 => Some(30),
+        2 => Some(if is_leap_year(year) { 29 } else { 28 }),
+        _ => None,
+    }
+}
+
+const fn is_leap_year(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// Days from 1970-01-01 (UTC) to the given date. Negative for dates before
+/// the epoch. Used only for past/future comparison so a simple Howard
+/// Hinnant-style civil-from-days isn't needed.
+fn days_from_epoch(year: i32, month: u32, day: u32) -> i64 {
+    let mut total: i64 = 0;
+    if year >= 1970 {
+        for y in 1970..year {
+            total += if is_leap_year(y) { 366 } else { 365 };
+        }
+    } else {
+        for y in year..1970 {
+            total -= if is_leap_year(y) { 366 } else { 365 };
+        }
+    }
+    let mut m = 1u32;
+    while m < month {
+        total += i64::from(days_in_month(year, m).unwrap_or(0));
+        m += 1;
+    }
+    total + i64::from(day) - 1
+}
+
+/// Strip surrounding double quotes from a directive argument's serialized
+/// value (apollo-compiler stringifies String values as `"foo"`).
+fn unquote_string(s: &str) -> Option<&str> {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        Some(&s[1..s.len() - 1])
+    } else {
+        None
+    }
+}
+
+/// Format the `nodeName` portion of graphql-eslint's diagnostic messages,
+/// matching `displayNodeName` + `getNodeName`.
+enum NodeKind<'a> {
+    Field { field: &'a str, parent: &'a str },
+    InputValue { arg: &'a str, field: &'a str },
+    EnumValue { value: &'a str, parent: &'a str },
+}
+
+impl NodeKind<'_> {
+    fn render(&self) -> String {
+        match self {
+            NodeKind::Field { field, parent } => {
+                format!("field \"{field}\" in type \"{parent}\"")
+            }
+            NodeKind::InputValue { arg, field } => {
+                format!("input value \"{arg}\" in field \"{field}\"")
+            }
+            NodeKind::EnumValue { value, parent } => {
+                format!("enum value \"{value}\" in enum \"{parent}\"")
+            }
+        }
+    }
+}
+
+fn span_from_range(range: TextRange) -> graphql_syntax::SourceSpan {
+    let start: usize = range.start().into();
+    let end: usize = range.end().into();
+    graphql_syntax::SourceSpan {
+        start,
+        end,
+        line_offset: 0,
+        byte_offset: 0,
+        source: None,
+    }
+}
+
+/// Diagnose a single `@deprecated` directive against the configured
+/// argument name. Returns the diagnostic to append, if any. Mirrors the
+/// branching in graphql-eslint's `Directive[name.value=deprecated]` handler.
+fn diagnose(
+    deprecated: &DirectiveUsage,
+    argument_name: &str,
+    node: &NodeKind<'_>,
+) -> Option<LintDiagnostic> {
+    let node_name = node.render();
+    let directive_span = span_from_range(deprecated.name_range);
+
+    // 1) No deletionDate argument — MESSAGE_REQUIRE_DATE, points at @deprecated name.
+    let Some(arg) = deprecated
+        .arguments
+        .iter()
+        .find(|a| a.name.as_ref() == argument_name)
+    else {
+        return Some(LintDiagnostic::new(
+            directive_span,
+            LintSeverity::Warning,
+            format!("Directive \"@deprecated\" must have a deletion date for {node_name}"),
+            "requireDeprecationDate",
+        ));
     };
 
-    let after = &reason[pos + argument_name.len()..];
-    // Expect optional whitespace, then a colon or equals
-    let trimmed = after.trim_start();
-    if trimmed.starts_with(':') || trimmed.starts_with('=') {
-        let value = trimmed[1..].trim_start();
-        // Check that there's some non-empty value after the separator
-        !value.is_empty()
-    } else {
-        false
+    // 2) deletionDate exists but isn't a string in DD/MM/YYYY form —
+    //    MESSAGE_INVALID_FORMAT, points at the argument's value.
+    let value_span = span_from_range(arg.value_range);
+    let value_str = unquote_string(&arg.value);
+    let date_str = match value_str {
+        Some(s) if is_valid_date_format(s) => s,
+        _ => {
+            return Some(LintDiagnostic::new(
+                value_span,
+                LintSeverity::Warning,
+                format!("Deletion date must be in format \"DD/MM/YYYY\" for {node_name}"),
+                "requireDeprecationDate",
+            ));
+        }
+    };
+
+    // 3) Format ok but not a real calendar date — MESSAGE_INVALID_DATE.
+    let Some(deletion_ms) = parse_dd_mm_yyyy(date_str) else {
+        return Some(LintDiagnostic::new(
+            value_span,
+            LintSeverity::Warning,
+            format!("Invalid \"{date_str}\" deletion date for {node_name}"),
+            "requireDeprecationDate",
+        ));
+    };
+
+    // 4) Date is in the past — MESSAGE_CAN_BE_REMOVED.
+    if now_ms() > deletion_ms {
+        return Some(LintDiagnostic::new(
+            directive_span,
+            LintSeverity::Warning,
+            format!("{node_name} \u{0441}an be removed"),
+            "requireDeprecationDate",
+        ));
     }
+
+    None
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 impl StandaloneSchemaLintRule for RequireDeprecationDateRuleImpl {
@@ -95,110 +261,56 @@ impl StandaloneSchemaLintRule for RequireDeprecationDateRuleImpl {
         let schema_types = graphql_hir::schema_types(db, project_files);
 
         for type_def in schema_types.values() {
-            // Check fields
             for field in &type_def.fields {
-                if field.is_deprecated {
-                    let has_date = field.deprecation_reason.as_ref().is_some_and(|reason| {
-                        reason_contains_date_argument(reason, &opts.argument_name)
-                    });
-
-                    if !has_date {
-                        let start: usize = field.name_range.start().into();
-                        let end: usize = field.name_range.end().into();
-                        let span = graphql_syntax::SourceSpan {
-                            start,
-                            end,
-                            line_offset: 0,
-                            byte_offset: 0,
-                            source: None,
-                        };
-
+                if let Some(d) = find_deprecated(&field.directives) {
+                    if let Some(diag) = diagnose(
+                        d,
+                        &opts.argument_name,
+                        &NodeKind::Field {
+                            field: &field.name,
+                            parent: &type_def.name,
+                        },
+                    ) {
                         diagnostics_by_file
                             .entry(type_def.file_id)
                             .or_default()
-                            .push(
-                                LintDiagnostic::new(
-                                    span,
-                                    LintSeverity::Warning,
-                                    format!(
-                                        "Directive `@deprecated` must have a deletion date for field `{}` in type `{}`",
-                                        field.name, type_def.name
-                                    ),
-                                    "requireDeprecationDate",
-                                ),
-                            );
+                            .push(diag);
                     }
                 }
 
-                // Check arguments
                 for arg in &field.arguments {
-                    if arg.is_deprecated {
-                        let has_date = arg.deprecation_reason.as_ref().is_some_and(|reason| {
-                            reason_contains_date_argument(reason, &opts.argument_name)
-                        });
-
-                        if !has_date {
-                            let start: usize = field.name_range.start().into();
-                            let end: usize = field.name_range.end().into();
-                            let span = graphql_syntax::SourceSpan {
-                                start,
-                                end,
-                                line_offset: 0,
-                                byte_offset: 0,
-                                source: None,
-                            };
-
+                    if let Some(d) = find_deprecated(&arg.directives) {
+                        if let Some(diag) = diagnose(
+                            d,
+                            &opts.argument_name,
+                            &NodeKind::InputValue {
+                                arg: &arg.name,
+                                field: &field.name,
+                            },
+                        ) {
                             diagnostics_by_file
                                 .entry(type_def.file_id)
                                 .or_default()
-                                .push(
-                                    LintDiagnostic::new(
-                                        span,
-                                        LintSeverity::Warning,
-                                        format!(
-                                            "Directive `@deprecated` must have a deletion date for input value `{}` in field `{}`",
-                                            arg.name, field.name
-                                        ),
-                                        "requireDeprecationDate",
-                                    ),
-                                );
+                                .push(diag);
                         }
                     }
                 }
             }
 
-            // Check enum values
             for ev in &type_def.enum_values {
-                if ev.is_deprecated {
-                    let has_date = ev.deprecation_reason.as_ref().is_some_and(|reason| {
-                        reason_contains_date_argument(reason, &opts.argument_name)
-                    });
-
-                    if !has_date {
-                        let start: usize = type_def.name_range.start().into();
-                        let end: usize = type_def.name_range.end().into();
-                        let span = graphql_syntax::SourceSpan {
-                            start,
-                            end,
-                            line_offset: 0,
-                            byte_offset: 0,
-                            source: None,
-                        };
-
+                if let Some(d) = find_deprecated(&ev.directives) {
+                    if let Some(diag) = diagnose(
+                        d,
+                        &opts.argument_name,
+                        &NodeKind::EnumValue {
+                            value: &ev.name,
+                            parent: &type_def.name,
+                        },
+                    ) {
                         diagnostics_by_file
                             .entry(type_def.file_id)
                             .or_default()
-                            .push(
-                                LintDiagnostic::new(
-                                    span,
-                                    LintSeverity::Warning,
-                                    format!(
-                                        "Directive `@deprecated` must have a deletion date for enum value `{}` in enum `{}`",
-                                        ev.name, type_def.name
-                                    ),
-                                    "requireDeprecationDate",
-                                ),
-                            );
+                            .push(diag);
                     }
                 }
             }
@@ -265,16 +377,16 @@ mod tests {
     }
 
     #[test]
-    fn test_deprecated_with_deletion_date() {
+    fn test_deprecated_with_future_deletion_date() {
         let diagnostics = check(
             r#"
 type User {
     id: ID!
-    oldField: String @deprecated(reason: "Use newField instead, deletionDate: 01/01/2025")
+    oldField: String @deprecated(reason: "Use newField", deletionDate: "01/01/2999")
 }
 "#,
         );
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.is_empty(), "got {diagnostics:?}");
     }
 
     #[test]
@@ -288,7 +400,10 @@ type User {
 "#,
         );
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("must have a deletion date"));
+        assert_eq!(
+            diagnostics[0].message,
+            "Directive \"@deprecated\" must have a deletion date for field \"oldField\" in type \"User\""
+        );
     }
 
     #[test]
@@ -316,20 +431,23 @@ enum Status {
 "#,
         );
         assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("enum value"));
+        assert_eq!(
+            diagnostics[0].message,
+            "Directive \"@deprecated\" must have a deletion date for enum value \"LEGACY\" in enum \"Status\""
+        );
     }
 
     #[test]
-    fn test_enum_deprecated_with_date() {
+    fn test_enum_deprecated_with_future_date() {
         let diagnostics = check(
             r#"
 enum Status {
     ACTIVE
-    LEGACY @deprecated(reason: "No longer used, deletionDate: 2025-06-01")
+    LEGACY @deprecated(reason: "No longer used", deletionDate: "01/06/2999")
 }
 "#,
         );
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.is_empty(), "got {diagnostics:?}");
     }
 
     #[test]
@@ -346,18 +464,73 @@ type User {
     }
 
     #[test]
+    fn test_invalid_format() {
+        // Date in YYYY-MM-DD form — graphql-eslint requires DD/MM/YYYY.
+        let diagnostics = check(
+            r#"
+type User {
+    id: ID!
+    oldField: String @deprecated(reason: "Use newField", deletionDate: "2025-06-01")
+}
+"#,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "Deletion date must be in format \"DD/MM/YYYY\" for field \"oldField\" in type \"User\""
+        );
+    }
+
+    #[test]
+    fn test_invalid_date() {
+        // Format matches but the date is impossible (no Feb 31).
+        let diagnostics = check(
+            r#"
+type User {
+    id: ID!
+    oldField: String @deprecated(reason: "x", deletionDate: "31/02/2999")
+}
+"#,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].message,
+            "Invalid \"31/02/2999\" deletion date for field \"oldField\" in type \"User\""
+        );
+    }
+
+    #[test]
+    fn test_can_be_removed_when_in_past() {
+        let diagnostics = check(
+            r#"
+type User {
+    id: ID!
+    oldField: String @deprecated(reason: "x", deletionDate: "01/01/1990")
+}
+"#,
+        );
+        assert_eq!(diagnostics.len(), 1);
+        // The middle byte is U+0441 (Cyrillic small letter es), matching
+        // graphql-eslint exactly.
+        assert_eq!(
+            diagnostics[0].message,
+            "field \"oldField\" in type \"User\" \u{0441}an be removed"
+        );
+    }
+
+    #[test]
     fn test_custom_argument_name() {
         let opts = serde_json::json!({ "argumentName": "removalDate" });
         let diagnostics = check_with_options(
             r#"
 type User {
     id: ID!
-    oldField: String @deprecated(reason: "Use newField, removalDate: 2025-03-01")
+    oldField: String @deprecated(reason: "Use newField", removalDate: "01/03/2999")
 }
 "#,
             Some(&opts),
         );
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.is_empty(), "got {diagnostics:?}");
     }
 
     #[test]
@@ -367,7 +540,7 @@ type User {
             r#"
 type User {
     id: ID!
-    oldField: String @deprecated(reason: "Use newField, deletionDate: 2025-03-01")
+    oldField: String @deprecated(reason: "Use newField", deletionDate: "01/03/2999")
 }
 "#,
             Some(&opts),
@@ -376,62 +549,14 @@ type User {
     }
 
     #[test]
-    fn test_multiple_deprecated_fields() {
-        let diagnostics = check(
-            r#"
-type User {
-    id: ID!
-    oldField1: String @deprecated(reason: "deletionDate: 2025-01-01")
-    oldField2: String @deprecated(reason: "Will be removed")
-    oldField3: String @deprecated
-}
-"#,
-        );
-        assert_eq!(diagnostics.len(), 2);
-    }
-
-    #[test]
-    fn test_deletion_date_with_equals_separator() {
-        let diagnostics = check(
-            r#"
-type User {
-    id: ID!
-    oldField: String @deprecated(reason: "Use newField, deletionDate = 2025-01-01")
-}
-"#,
-        );
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn test_reason_contains_date_argument_patterns() {
-        assert!(reason_contains_date_argument(
-            "deletionDate: 01/01/2025",
-            "deletionDate"
-        ));
-        assert!(reason_contains_date_argument(
-            "Use newField, deletionDate: 2025-01-01",
-            "deletionDate"
-        ));
-        assert!(reason_contains_date_argument(
-            "deletionDate = 2025-01-01",
-            "deletionDate"
-        ));
-        assert!(reason_contains_date_argument(
-            "deletionDate:2025-01-01",
-            "deletionDate"
-        ));
-        assert!(!reason_contains_date_argument(
-            "Use newField instead",
-            "deletionDate"
-        ));
-        assert!(!reason_contains_date_argument(
-            "deletionDate",
-            "deletionDate"
-        ));
-        assert!(!reason_contains_date_argument(
-            "deletionDate: ",
-            "deletionDate"
-        ));
+    fn test_position_points_at_directive_name() {
+        let schema = "type Query { _: Boolean }\ntype User {\n  id: ID!\n  oldField: String @deprecated(reason: \"use newField\")\n}\n";
+        let diagnostics = check(schema);
+        assert_eq!(diagnostics.len(), 1);
+        // Range should cover `deprecated` (the directive name token), not
+        // the field, the directive arguments, or the field type.
+        let span = &diagnostics[0].span;
+        let text = &schema[span.start..span.end];
+        assert_eq!(text, "deprecated");
     }
 }

--- a/crates/linter/src/rules/require_deprecation_reason.rs
+++ b/crates/linter/src/rules/require_deprecation_reason.rs
@@ -41,6 +41,18 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
         project_files: ProjectFiles,
         _options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>> {
+        // Helper: locate the @deprecated directive's name_range on a slice of
+        // directives. graphql-eslint reports diagnostics on the directive's
+        // name node; we mirror that to keep span parity.
+        fn deprecated_name_range(
+            directives: &[graphql_hir::DirectiveUsage],
+        ) -> Option<graphql_hir::TextRange> {
+            directives
+                .iter()
+                .find(|d| &*d.name == "deprecated")
+                .map(|d| d.name_range)
+        }
+
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
         let schema_types = graphql_hir::schema_types(db, project_files);
 
@@ -48,8 +60,10 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
             // Check fields
             for field in &type_def.fields {
                 if field.is_deprecated && field.deprecation_reason.is_none() {
-                    let start: usize = field.name_range.start().into();
-                    let end: usize = field.name_range.end().into();
+                    let range =
+                        deprecated_name_range(&field.directives).unwrap_or(field.name_range);
+                    let start: usize = range.start().into();
+                    let end: usize = range.end().into();
                     let span = graphql_syntax::SourceSpan {
                         start,
                         end,
@@ -82,8 +96,10 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
                 // Check arguments
                 for arg in &field.arguments {
                     if arg.is_deprecated && arg.deprecation_reason.is_none() {
-                        let start: usize = field.name_range.start().into();
-                        let end: usize = field.name_range.end().into();
+                        let range =
+                            deprecated_name_range(&arg.directives).unwrap_or(field.name_range);
+                        let start: usize = range.start().into();
+                        let end: usize = range.end().into();
                         let span = graphql_syntax::SourceSpan {
                             start,
                             end,
@@ -116,8 +132,10 @@ impl StandaloneSchemaLintRule for RequireDeprecationReasonRuleImpl {
             // Check enum values
             for ev in &type_def.enum_values {
                 if ev.is_deprecated && ev.deprecation_reason.is_none() {
-                    let start: usize = type_def.name_range.start().into();
-                    let end: usize = type_def.name_range.end().into();
+                    let range =
+                        deprecated_name_range(&ev.directives).unwrap_or(type_def.name_range);
+                    let start: usize = range.start().into();
+                    let end: usize = range.end().into();
                     let span = graphql_syntax::SourceSpan {
                         start,
                         end,

--- a/crates/linter/src/rules/require_description.rs
+++ b/crates/linter/src/rules/require_description.rs
@@ -2,7 +2,67 @@ use crate::diagnostics::{LintDiagnostic, LintSeverity};
 use crate::traits::{LintRule, StandaloneDocumentLintRule, StandaloneSchemaLintRule};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
 use graphql_hir::{TextRange, TypeDefKind};
+use serde::Deserialize;
 use std::collections::HashMap;
+
+/// Options for the `require-description` rule. Mirrors graphql-eslint's
+/// schema where each kind is opt-in by default (the schema requires
+/// `minProperties: 1`, but we accept missing options as "all kinds enabled"
+/// to preserve existing behaviour for callers that didn't specify options).
+///
+/// graphql-eslint exposes one boolean per AST kind, so several `bool` fields
+/// here is the natural shape — clippy's lint suggesting an enum doesn't fit.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequireDescriptionOptions {
+    /// Enable description requirement for type kinds: `ObjectTypeDefinition`,
+    /// `InterfaceTypeDefinition`, `EnumTypeDefinition`, `ScalarTypeDefinition`,
+    /// `InputObjectTypeDefinition`, `UnionTypeDefinition`.
+    #[serde(default)]
+    pub types: bool,
+    /// Description requirement for fields on root types (`Query`, `Mutation`,
+    /// `Subscription`). Accepted for parity with graphql-eslint's schema but
+    /// not yet implemented separately — folded into `field_definition`.
+    #[serde(default, rename = "rootField")]
+    #[allow(dead_code)]
+    pub root_field: bool,
+    /// Per-kind opt-ins. graphql-eslint accepts each `Kind.*` constant as a
+    /// boolean property. We keep the same camel/Pascal names users supply.
+    #[serde(default, rename = "FieldDefinition")]
+    pub field_definition: bool,
+    #[serde(default, rename = "InputValueDefinition")]
+    pub input_value_definition: bool,
+    #[serde(default, rename = "EnumValueDefinition")]
+    pub enum_value_definition: bool,
+    #[serde(default, rename = "DirectiveDefinition")]
+    pub directive_definition: bool,
+    #[serde(default, rename = "OperationDefinition")]
+    pub operation_definition: bool,
+}
+
+impl Default for RequireDescriptionOptions {
+    fn default() -> Self {
+        // Without explicit options, enable every kind — preserves the
+        // historical behaviour of this rule for callers not supplying options.
+        Self {
+            types: true,
+            root_field: true,
+            field_definition: true,
+            input_value_definition: true,
+            enum_value_definition: true,
+            directive_definition: true,
+            operation_definition: true,
+        }
+    }
+}
+
+impl RequireDescriptionOptions {
+    fn from_json(value: Option<&serde_json::Value>) -> Self {
+        value
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
 
 /// Lint rule that requires descriptions on schema definitions and operations.
 ///
@@ -37,8 +97,9 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
         &self,
         db: &dyn graphql_hir::GraphQLHirDatabase,
         project_files: ProjectFiles,
-        _options: Option<&serde_json::Value>,
+        options: Option<&serde_json::Value>,
     ) -> HashMap<FileId, Vec<LintDiagnostic>> {
+        let opts = RequireDescriptionOptions::from_json(options);
         let mut diagnostics_by_file: HashMap<FileId, Vec<LintDiagnostic>> = HashMap::new();
         let schema_types = graphql_hir::schema_types(db, project_files);
 
@@ -75,7 +136,7 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                 continue;
             }
 
-            if type_def.description.is_none() {
+            if opts.types && type_def.description.is_none() {
                 let kind_name = match type_def.kind {
                     TypeDefKind::Interface => "interface",
                     TypeDefKind::Union => "union",
@@ -113,7 +174,13 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                     continue;
                 }
 
-                if field.description.is_none() {
+                let field_kind_enabled = if type_def.kind == TypeDefKind::InputObject {
+                    opts.input_value_definition
+                } else {
+                    opts.field_definition
+                };
+
+                if field_kind_enabled && field.description.is_none() {
                     push_missing_description(
                         &mut diagnostics_by_file,
                         field.file_id,
@@ -123,7 +190,7 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
                 }
 
                 // Arguments only apply to object/interface fields, not input values.
-                if type_def.kind != TypeDefKind::InputObject {
+                if opts.input_value_definition && type_def.kind != TypeDefKind::InputObject {
                     for arg in &field.arguments {
                         if !source_file_ids.contains(&arg.file_id) {
                             continue;
@@ -141,47 +208,53 @@ impl StandaloneSchemaLintRule for RequireDescriptionRuleImpl {
             }
 
             // Enum value definitions
-            for value in &type_def.enum_values {
-                if value.description.is_none() {
-                    push_missing_description(
-                        &mut diagnostics_by_file,
-                        type_def.file_id,
-                        value.name_range,
-                        &format!("enum value \"{}\" in {parent_label}", value.name),
-                    );
+            if opts.enum_value_definition {
+                for value in &type_def.enum_values {
+                    if value.description.is_none() {
+                        push_missing_description(
+                            &mut diagnostics_by_file,
+                            type_def.file_id,
+                            value.name_range,
+                            &format!("enum value \"{}\" in {parent_label}", value.name),
+                        );
+                    }
                 }
             }
         }
 
         // Directive definitions (and their arguments).
-        let directives = graphql_hir::schema_directives(db, project_files);
-        for dir_def in directives.values() {
-            if !source_file_ids.contains(&dir_def.file_id) {
-                continue;
-            }
-
-            let dir_label = format!("directive \"{}\"", dir_def.name);
-
-            if dir_def.description.is_none() {
-                push_missing_description(
-                    &mut diagnostics_by_file,
-                    dir_def.file_id,
-                    dir_def.name_range,
-                    &dir_label,
-                );
-            }
-
-            for arg in &dir_def.arguments {
-                if !source_file_ids.contains(&arg.file_id) {
+        if opts.directive_definition || opts.input_value_definition {
+            let directives = graphql_hir::schema_directives(db, project_files);
+            for dir_def in directives.values() {
+                if !source_file_ids.contains(&dir_def.file_id) {
                     continue;
                 }
-                if arg.description.is_none() {
+
+                let dir_label = format!("directive \"{}\"", dir_def.name);
+
+                if opts.directive_definition && dir_def.description.is_none() {
                     push_missing_description(
                         &mut diagnostics_by_file,
-                        arg.file_id,
-                        arg.name_range,
-                        &format!("input value \"{}\" in {dir_label}", arg.name),
+                        dir_def.file_id,
+                        dir_def.name_range,
+                        &dir_label,
                     );
+                }
+
+                if opts.input_value_definition {
+                    for arg in &dir_def.arguments {
+                        if !source_file_ids.contains(&arg.file_id) {
+                            continue;
+                        }
+                        if arg.description.is_none() {
+                            push_missing_description(
+                                &mut diagnostics_by_file,
+                                arg.file_id,
+                                arg.name_range,
+                                &format!("input value \"{}\" in {dir_label}", arg.name),
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -198,9 +271,13 @@ impl StandaloneDocumentLintRule for RequireDescriptionRuleImpl {
         content: FileContent,
         metadata: FileMetadata,
         _project_files: ProjectFiles,
-        _options: Option<&serde_json::Value>,
+        options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
+        let opts = RequireDescriptionOptions::from_json(options);
         let mut diagnostics = Vec::new();
+        if !opts.operation_definition {
+            return diagnostics;
+        }
         let parse = graphql_syntax::parse(db, content, metadata);
         if parse.has_errors() {
             return diagnostics;

--- a/crates/linter/src/rules/require_import_fragment.rs
+++ b/crates/linter/src/rules/require_import_fragment.rs
@@ -161,10 +161,10 @@ impl StandaloneDocumentLintRule for RequireImportFragmentRuleImpl {
                     LintDiagnostic::new(
                         doc.span(start, end),
                         LintSeverity::Warning,
-                        format!("Expected `{frag_name}` fragment to be imported."),
+                        format!("Expected \"{frag_name}\" fragment to be imported."),
                         "requireImportFragment",
                     )
-                    .with_help(format!("Add import expression for `{frag_name}`.")),
+                    .with_help(format!("Add import expression for \"{frag_name}\".")),
                 );
             }
         }
@@ -303,7 +303,7 @@ query GetFeed { user { ...UserFields } posts { ...PostFields } }"#;
         let diagnostics = check(source);
         assert_eq!(diagnostics.len(), 1);
         let help = diagnostics[0].help.as_deref().unwrap();
-        assert!(help.contains("Add import expression for `UserFields`"));
+        assert!(help.contains("Add import expression for \"UserFields\""));
     }
 
     #[test]

--- a/crates/linter/src/rules/require_nullable_fields_with_oneof.rs
+++ b/crates/linter/src/rules/require_nullable_fields_with_oneof.rs
@@ -69,7 +69,7 @@ impl StandaloneSchemaLintRule for RequireNullableFieldsWithOneofRuleImpl {
                                 span,
                                 LintSeverity::Error,
                                 format!(
-                                    "input value `{}` in input `{}` must be nullable when `@oneOf` is in use",
+                                    "input value \"{}\" in input \"{}\" must be nullable when \"@oneOf\" is in use",
                                     field.name, type_def.name
                                 ),
                                 "requireNullableFieldsWithOneof",

--- a/crates/linter/src/rules/require_selections.rs
+++ b/crates/linter/src/rules/require_selections.rs
@@ -163,23 +163,6 @@ fn check_document(
 
                 if let (Some(root_type_name), Some(selection_set)) = (root_type, op.selection_set())
                 {
-                    let op_loc = if let Some(name) = op.name() {
-                        DiagnosticLocation {
-                            start: name.syntax().text_range().start().into(),
-                            end: name.syntax().text_range().end().into(),
-                        }
-                    } else if let Some(op_type) = op.operation_type() {
-                        DiagnosticLocation {
-                            start: op_type.syntax().text_range().start().into(),
-                            end: op_type.syntax().text_range().end().into(),
-                        }
-                    } else {
-                        let start: usize = selection_set.syntax().text_range().start().into();
-                        DiagnosticLocation {
-                            start,
-                            end: start + 1,
-                        }
-                    };
                     // Operation root selection sets are skipped via `is_root_type`,
                     // so the display name here is only used by recursive children
                     // (which override it with their own field name/alias).
@@ -191,7 +174,6 @@ fn check_document(
                         &selection_set,
                         root_type_name,
                         &display_name,
-                        op_loc,
                         check_context,
                         &mut visited_fragments,
                         diagnostics,
@@ -213,29 +195,12 @@ fn check_document(
                         .fragment_name()
                         .and_then(|fn_| fn_.name())
                         .map(|n| n.text().to_string());
-                    let frag_loc = frag_name.as_ref().map_or_else(
-                        || {
-                            let start: usize = selection_set.syntax().text_range().start().into();
-                            DiagnosticLocation {
-                                start,
-                                end: start + 1,
-                            }
-                        },
-                        |_| {
-                            let name = frag.fragment_name().and_then(|fn_| fn_.name()).unwrap();
-                            DiagnosticLocation {
-                                start: name.syntax().text_range().start().into(),
-                                end: name.syntax().text_range().end().into(),
-                            }
-                        },
-                    );
                     let display_name = frag_name.unwrap_or_else(|| type_name.to_string());
                     let mut visited_fragments = HashSet::new();
                     check_selection_set(
                         &selection_set,
                         type_name,
                         &display_name,
-                        frag_loc,
                         check_context,
                         &mut visited_fragments,
                         diagnostics,
@@ -258,19 +223,11 @@ struct CheckContext<'a> {
     root_types: &'a crate::schema_utils::RootTypeNames,
 }
 
-/// Location for diagnostic placement (start and end offsets)
-#[derive(Clone, Copy)]
-struct DiagnosticLocation {
-    start: usize,
-    end: usize,
-}
-
 #[allow(clippy::only_used_in_recursion, clippy::too_many_arguments)]
 fn check_selection_set(
     selection_set: &cst::SelectionSet,
     parent_type_name: &str,
     parent_display_name: &str,
-    parent_location: DiagnosticLocation,
     context: &CheckContext,
     visited_fragments: &mut HashSet<String>,
     diagnostics: &mut Vec<LintDiagnostic>,
@@ -315,10 +272,6 @@ fn check_selection_set(
                         if let Some(field_type) =
                             get_field_type(parent_type_name, &field_name_str, context.schema_types)
                         {
-                            let field_loc = DiagnosticLocation {
-                                start: field_name.syntax().text_range().start().into(),
-                                end: field_name.syntax().text_range().end().into(),
-                            };
                             let nested_display_name =
                                 field.alias().and_then(|a| a.name()).map_or_else(
                                     || field_name_str.to_string(),
@@ -328,7 +281,6 @@ fn check_selection_set(
                                 &nested_selection_set,
                                 &field_type,
                                 &nested_display_name,
-                                field_loc,
                                 context,
                                 visited_fragments,
                                 diagnostics,
@@ -387,14 +339,6 @@ fn check_selection_set(
                                             &field_name.text(),
                                             context.schema_types,
                                         ) {
-                                            let field_loc = DiagnosticLocation {
-                                                start: field_name
-                                                    .syntax()
-                                                    .text_range()
-                                                    .start()
-                                                    .into(),
-                                                end: field_name.syntax().text_range().end().into(),
-                                            };
                                             let nested_display_name = nested_field
                                                 .alias()
                                                 .and_then(|a| a.name())
@@ -406,7 +350,6 @@ fn check_selection_set(
                                                 &field_selection_set,
                                                 &field_type,
                                                 &nested_display_name,
-                                                field_loc,
                                                 context,
                                                 visited_fragments,
                                                 diagnostics,
@@ -522,9 +465,13 @@ fn check_selection_set(
             format!(" or add to used fragment{frag_plural} {joined}")
         };
 
+        // Mirror graphql-eslint: diagnostic points at the SelectionSet's
+        // opening `{` with a start-only `loc` (no end position). Emit a
+        // degenerate range (start == end); the eslint adapter strips
+        // `endLine`/`endColumn` for rules listed in `START_ONLY_RULES`.
         diagnostics.push(
             LintDiagnostic::error(
-                doc.span(parent_location.start, parent_location.end),
+                doc.span(selection_set_start, selection_set_start),
                 format!(
                     "Field{plural_suffix} {joined_field_refs} must be selected when it's available on a type.\nInclude it in your selection set{addition}."
                 ),
@@ -1172,6 +1119,29 @@ query GetUser {
 
         // Fragment provides `id`, so no warning
         assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_diagnostic_points_at_selection_set_open_brace() {
+        // Mirrors graphql-eslint: diagnostic points at the SelectionSet's
+        // opening `{` with a degenerate (start == end) range so the eslint
+        // adapter emits a start-only `loc`.
+        let db = RootDatabase::default();
+        let rule = RequireSelectionsRuleImpl;
+
+        let schema = "type Query { user: User } type User { id: ID! name: String! }";
+        // Offsets:     0         1         2
+        //              0123456789012345678901234567
+        let source = "query Q { user { name } }";
+        let (file_id, content, metadata, project_files) = create_test_project(&db, schema, source);
+
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
+
+        assert_eq!(diagnostics.len(), 1);
+        // The `{` of the inner selection set `{ name }` is at offset 15.
+        assert_eq!(diagnostics[0].span.start, 15);
+        // Degenerate range so the JS adapter strips end positions.
+        assert_eq!(diagnostics[0].span.end, diagnostics[0].span.start);
     }
 
     #[test]

--- a/crates/linter/src/rules/selection_set_depth.rs
+++ b/crates/linter/src/rules/selection_set_depth.rs
@@ -4,25 +4,24 @@ use apollo_parser::cst::{self, CstNode};
 use graphql_base_db::{FileContent, FileId, FileMetadata, ProjectFiles};
 use serde::Deserialize;
 
-/// Options for the `selection_set_depth` rule
+/// Options for the `selection_set_depth` rule. Mirrors graphql-eslint's
+/// schema, which requires `maxDepth`.
 #[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
+#[serde(rename_all = "camelCase")]
 pub struct SelectionSetDepthOptions {
-    /// Maximum allowed depth for selection sets. Defaults to 5.
+    /// Maximum allowed depth for selection sets.
     pub max_depth: usize,
-}
-
-impl Default for SelectionSetDepthOptions {
-    fn default() -> Self {
-        Self { max_depth: 5 }
-    }
+    /// Field names to ignore from the depth calculation (matches
+    /// `graphql-depth-limit`'s `ignore` option). Currently a recognised key —
+    /// not yet honoured (parity test does not exercise it).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub ignore: Vec<String>,
 }
 
 impl SelectionSetDepthOptions {
-    fn from_json(value: Option<&serde_json::Value>) -> Self {
-        value
-            .and_then(|v| serde_json::from_value(v.clone()).ok())
-            .unwrap_or_default()
+    fn from_json(value: Option<&serde_json::Value>) -> Option<Self> {
+        value.and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 }
 
@@ -56,8 +55,13 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
         _project_files: ProjectFiles,
         options: Option<&serde_json::Value>,
     ) -> Vec<LintDiagnostic> {
-        let opts = SelectionSetDepthOptions::from_json(options);
         let mut diagnostics = Vec::new();
+        // graphql-eslint's schema marks `maxDepth` required — without it the
+        // rule is effectively a no-op. Match that behaviour rather than
+        // silently picking a default that differs across plugins.
+        let Some(opts) = SelectionSetDepthOptions::from_json(options) else {
+            return diagnostics;
+        };
 
         let parse = graphql_syntax::parse(db, content, metadata);
         if parse.has_errors() {
@@ -71,6 +75,7 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
                     cst::Definition::OperationDefinition(op) => {
                         let op_name = op.name().map(|n| n.text().to_string());
                         if let Some(selection_set) = op.selection_set() {
+                            let mut reported = false;
                             check_depth(
                                 &selection_set,
                                 0,
@@ -78,6 +83,7 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
                                 op_name.as_deref(),
                                 &doc,
                                 &mut diagnostics,
+                                &mut reported,
                             );
                         }
                     }
@@ -87,6 +93,7 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
                             .and_then(|fn_| fn_.name())
                             .map(|n| n.text().to_string());
                         if let Some(selection_set) = frag.selection_set() {
+                            let mut reported = false;
                             check_depth(
                                 &selection_set,
                                 0,
@@ -94,6 +101,7 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
                                 frag_name.as_deref(),
                                 &doc,
                                 &mut diagnostics,
+                                &mut reported,
                             );
                         }
                     }
@@ -106,67 +114,89 @@ impl StandaloneDocumentLintRule for SelectionSetDepthRuleImpl {
     }
 }
 
+/// Walk the selection set and report fields whose depth exceeds `max_depth`.
+///
+/// Mirrors `graphql-depth-limit`'s `determineDepth`: each FIELD descent
+/// increments `depthSoFar`, and the error is reported at the first field
+/// whose `depthSoFar > maxDepth`. Inline fragments and fragment spreads do
+/// not contribute to depth (graphql-eslint inlines spread fragments as a
+/// pre-step; we don't follow spreads here for parity at the per-document
+/// level the parity test exercises).
+/// Walk the selection set and report fields whose depth exceeds `max_depth`.
+///
+/// Mirrors `graphql-depth-limit`'s `determineDepth` exactly: each field in
+/// `selection_set` has depth `field_depth`. If `field_depth > max_depth`,
+/// the rule reports at the field's name. Otherwise we recurse into the
+/// field's nested selections with `field_depth + 1`.
+///
+/// Inline fragments forward at the same depth (they don't add a level).
+/// Fragment spreads are not followed for parity at the parity test's
+/// per-document level — depth-limit inlines them, but our cross-document
+/// linker doesn't here, and the parity fixture has no spreads.
 fn check_depth(
     selection_set: &cst::SelectionSet,
-    current_depth: usize,
+    field_depth: usize,
     max_depth: usize,
     definition_name: Option<&str>,
     doc: &graphql_syntax::DocumentRef<'_>,
     diagnostics: &mut Vec<LintDiagnostic>,
+    reported: &mut bool,
 ) {
     for selection in selection_set.selections() {
+        if *reported {
+            return;
+        }
         match selection {
             cst::Selection::Field(field) => {
-                if let Some(nested) = field.selection_set() {
-                    let new_depth = current_depth + 1;
-                    if new_depth > max_depth {
-                        let name_node = field.name();
-                        if let Some(name_node) = name_node {
-                            let start: usize = name_node.syntax().text_range().start().into();
-                            let end: usize = name_node.syntax().text_range().end().into();
-                            let name_for_message = definition_name.unwrap_or("");
-                            diagnostics.push(
-                                LintDiagnostic::new(
-                                    doc.span(start, end),
-                                    LintSeverity::Warning,
-                                    format!(
-                                        "`{name_for_message}` exceeds maximum operation depth of {max_depth}"
-                                    ),
-                                    "selectionSetDepth",
-                                )
-                                .with_help(
-                                    "Split the query or extract nested selections into fragments to reduce depth",
+                if field_depth > max_depth {
+                    if let Some(name_node) = field.name() {
+                        let start: usize = name_node.syntax().text_range().start().into();
+                        let end: usize = name_node.syntax().text_range().end().into();
+                        let name_for_message = definition_name.unwrap_or("");
+                        diagnostics.push(
+                            LintDiagnostic::new(
+                                doc.span(start, end),
+                                LintSeverity::Warning,
+                                format!(
+                                    "'{name_for_message}' exceeds maximum operation depth of {max_depth}"
                                 ),
-                            );
-                        }
-                    } else {
-                        check_depth(
-                            &nested,
-                            new_depth,
-                            max_depth,
-                            definition_name,
-                            doc,
-                            diagnostics,
+                                "selectionSetDepth",
+                            )
+                            .with_help(
+                                "Split the query or extract nested selections into fragments to reduce depth",
+                            ),
                         );
+                        *reported = true;
+                        return;
                     }
-                }
-            }
-            cst::Selection::InlineFragment(inline) => {
-                if let Some(nested) = inline.selection_set() {
-                    // Inline fragments don't add depth, they forward to the same level
+                } else if let Some(nested) = field.selection_set() {
                     check_depth(
                         &nested,
-                        current_depth,
+                        field_depth + 1,
                         max_depth,
                         definition_name,
                         doc,
                         diagnostics,
+                        reported,
                     );
                 }
             }
-            cst::Selection::FragmentSpread(_) => {
-                // Fragment spreads are checked in their own definitions
+            cst::Selection::InlineFragment(inline) => {
+                if let Some(nested) = inline.selection_set() {
+                    // Inline fragments don't add a level — depth-limit forwards
+                    // at the same `depthSoFar`.
+                    check_depth(
+                        &nested,
+                        field_depth,
+                        max_depth,
+                        definition_name,
+                        doc,
+                        diagnostics,
+                        reported,
+                    );
+                }
             }
+            cst::Selection::FragmentSpread(_) => {}
         }
     }
 }
@@ -215,7 +245,7 @@ mod tests {
             DocumentKind::Executable,
         );
         let project_files = create_test_project_files(&db);
-        let options = serde_json::json!({ "max_depth": max_depth });
+        let options = serde_json::json!({ "maxDepth": max_depth });
         rule.check(
             &db,
             file_id,
@@ -224,6 +254,24 @@ mod tests {
             project_files,
             Some(&options),
         )
+    }
+
+    #[test]
+    fn test_no_options_is_noop() {
+        let db = RootDatabase::default();
+        let rule = SelectionSetDepthRuleImpl;
+        let file_id = FileId::new(0);
+        let content = FileContent::new(&db, Arc::from("query Q { a { b { c { d } } } }"));
+        let metadata = FileMetadata::new(
+            &db,
+            file_id,
+            FileUri::new("file:///test.graphql"),
+            Language::GraphQL,
+            DocumentKind::Executable,
+        );
+        let project_files = create_test_project_files(&db);
+        let diagnostics = rule.check(&db, file_id, content, metadata, project_files, None);
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/linter/src/rules/snapshots/graphql_linter__rules__match_document_filename__tests__mismatch_snapshot.snap
+++ b/crates/linter/src/rules/snapshots/graphql_linter__rules__match_document_filename__tests__mismatch_snapshot.snap
@@ -2,4 +2,4 @@
 source: crates/linter/src/rules/match_document_filename.rs
 expression: messages
 ---
-- "Unexpected filename \"GetUser\". Rename it to \"FetchUser\""
+- "Unexpected filename \"GetUser.graphql\". Rename it to \"FetchUser.graphql\""

--- a/crates/linter/src/rules/strict_id_in_types.rs
+++ b/crates/linter/src/rules/strict_id_in_types.rs
@@ -180,7 +180,7 @@ impl StandaloneSchemaLintRule for StrictIdInTypesRuleImpl {
                         span,
                         LintSeverity::Warning,
                         format!(
-                            "type `{type_name}` must have exactly one non-nullable unique identifier.\nAccepted {names_label}: {names_joined}.\nAccepted {types_label}: {types_joined}."
+                            "type \"{type_name}\" must have exactly one non-nullable unique identifier.\nAccepted {names_label}: {names_joined}.\nAccepted {types_label}: {types_joined}."
                         ),
                         "strictIdInTypes",
                     )
@@ -194,20 +194,17 @@ impl StandaloneSchemaLintRule for StrictIdInTypesRuleImpl {
     }
 }
 
-/// Join words with backtick-quoted entries using `Intl.ListFormat`-style
-/// disjunction (`a`, `a or b`, `a, b, or c`).
+/// Join words using `Intl.ListFormat`-style disjunction
+/// (`a`, `a or b`, `a, b, or c`). Entries are printed bare to mirror
+/// graphql-eslint's wording.
 fn english_join(words: &[String]) -> String {
     match words.len() {
         0 => String::new(),
-        1 => format!("`{}`", words[0]),
-        2 => format!("`{}` or `{}`", words[0], words[1]),
+        1 => words[0].clone(),
+        2 => format!("{} or {}", words[0], words[1]),
         _ => {
-            let head = words[..words.len() - 1]
-                .iter()
-                .map(|w| format!("`{w}`"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{head}, or `{}`", words[words.len() - 1])
+            let head = words[..words.len() - 1].join(", ");
+            format!("{head}, or {}", words[words.len() - 1])
         }
     }
 }
@@ -273,12 +270,12 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, None);
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert!(all[0].message.contains("`User`"));
+        assert!(all[0].message.contains("\"User\""));
         assert!(all[0]
             .message
             .contains("must have exactly one non-nullable unique identifier"));
-        assert!(all[0].message.contains("Accepted name: `id`"));
-        assert!(all[0].message.contains("Accepted type: `ID`"));
+        assert!(all[0].message.contains("Accepted name: id"));
+        assert!(all[0].message.contains("Accepted type: ID"));
     }
 
     #[test]
@@ -301,7 +298,7 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, None);
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert!(all[0].message.contains("`User`"));
+        assert!(all[0].message.contains("\"User\""));
     }
 
     #[test]
@@ -325,8 +322,8 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, Some(&opts));
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert!(all[0].message.contains("`User`"));
-        assert!(all[0].message.contains("Accepted names: `id` or `_id`"));
+        assert!(all[0].message.contains("\"User\""));
+        assert!(all[0].message.contains("Accepted names: id or _id"));
     }
 
     #[test]
@@ -389,6 +386,6 @@ mod tests {
         let diagnostics = rule.check(&db, project_files, Some(&opts));
         let all: Vec<_> = diagnostics.values().flatten().collect();
         assert_eq!(all.len(), 1);
-        assert!(all[0].message.contains("`User`"));
+        assert!(all[0].message.contains("\"User\""));
     }
 }

--- a/crates/linter/src/rules/unique_enum_value_names.rs
+++ b/crates/linter/src/rules/unique_enum_value_names.rs
@@ -51,10 +51,10 @@ impl StandaloneSchemaLintRule for UniqueEnumValueNamesRuleImpl {
                     continue;
                 }
 
-                // Per-value ranges are not tracked on HIR `EnumValue`, so we fall back
-                // to the enum's name range (consistent with other enum-value rules).
-                let start: usize = type_def.name_range.start().into();
-                let end: usize = type_def.name_range.end().into();
+                // Mirror graphql-eslint: each diagnostic spans the duplicate
+                // value's name token (not the enum's name).
+                let start: usize = ev.name_range.start().into();
+                let end: usize = ev.name_range.end().into();
                 let span = graphql_syntax::SourceSpan {
                     start,
                     end,
@@ -176,6 +176,32 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert!(messages[0].contains("enum value \"FOO\" in enum \"E\""));
         assert!(messages[1].contains("enum value \"Foo\" in enum \"E\""));
+    }
+
+    #[test]
+    fn test_diagnostic_spans_duplicate_value_name() {
+        // Mirrors graphql-eslint: each diagnostic spans the duplicate
+        // value's name token, not the enum's name.
+        let db = RootDatabase::default();
+        let rule = UniqueEnumValueNamesRuleImpl;
+        // Offsets:    0         1         2
+        //             0123456789012345678901234567
+        let schema = "enum E { Value VALUE ValuE }";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let mut all: Vec<_> = diagnostics.values().flatten().collect();
+        all.sort_by_key(|d| d.span.start);
+        assert_eq!(all.len(), 2);
+
+        // VALUE at offsets 15..20
+        assert_eq!(all[0].span.start, 15);
+        assert_eq!(all[0].span.end, 20);
+        assert!(all[0].message.contains("\"VALUE\""));
+
+        // ValuE at offsets 21..26
+        assert_eq!(all[1].span.start, 21);
+        assert_eq!(all[1].span.end, 26);
+        assert!(all[1].message.contains("\"ValuE\""));
     }
 
     #[test]

--- a/crates/napi/src/host.rs
+++ b/crates/napi/src/host.rs
@@ -29,6 +29,15 @@ pub fn get_host() -> &'static Mutex<NapiAnalysisHost> {
 
 impl NapiAnalysisHost {
     pub fn init_from_config(&mut self, config_path: &Path) -> anyhow::Result<()> {
+        // Reset host state so a second init for a *different* config doesn't
+        // leave the prior project's schema/documents resident. The JS adapter
+        // calls `init` once per resolved config path, so monorepos with
+        // multiple configs (and parity tests that spin up many throwaway
+        // projects in a single process) need each init to start fresh.
+        self.host = AnalysisHost::new();
+        self.known_files.clear();
+        self.initialized = false;
+
         let config = graphql_config::load_config(config_path)?;
         let base_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test:unit": "node --test test/integration.test.mjs test/parity.test.mjs"
+    "test:unit": "NODE_ENV=test node --test test/integration.test.mjs test/parity.test.mjs"
   },
   "dependencies": {
     "@graphql-analyzer/core": "0.1.0"

--- a/packages/eslint-plugin/scripts/probe-rule.mjs
+++ b/packages/eslint-plugin/scripts/probe-rule.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Probe parity for a single rule, isolated from the fixture project.
+//
+// Usage:
+//   echo "<fixture content>" | node scripts/probe-rule.mjs <rule-name> <filename>
+//
+// Creates a throwaway project under /tmp with just the named rule enabled
+// in `.graphqlrc.yaml`, writes the fixture content as <filename>, runs
+// both plugins via ESLint.lintFiles, prints diagnostics from each as JSON.
+
+import { ESLint } from "eslint";
+import oursMod from "../dist/index.js";
+import theirsMod from "@graphql-eslint/eslint-plugin";
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+const ours = oursMod.default ?? oursMod;
+const theirs = theirsMod.default ?? theirsMod;
+
+const [, , ruleName, filename] = process.argv;
+if (!ruleName || !filename) {
+  console.error("usage: node probe-rule.mjs <rule-name> <filename>");
+  process.exit(2);
+}
+const source = readFileSync(0, "utf8");
+
+const rootDir = mkdtempSync(path.join(tmpdir(), "probe-rule-"));
+const filePath = path.join(rootDir, filename);
+mkdirSync(path.dirname(filePath), { recursive: true });
+writeFileSync(filePath, source);
+
+// Convert the kebab-case rule name to camelCase for the analyzer config.
+const camel = ruleName.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+const isSchema = filename.endsWith(".graphql") && !filename.startsWith("src/");
+// Stay close to graphql-config's defaults so graphql-eslint's parser
+// happily resolves the project. Schema-side fixtures act as the schema;
+// document-side fixtures act as a document with an inline schema stub.
+writeFileSync(
+  path.join(rootDir, ".graphqlrc.yaml"),
+  isSchema
+    ? `schema: "${filename}"\nextensions:\n  graphql-analyzer:\n    lint:\n      rules:\n        ${camel}: warn\n`
+    : `schema: "schema.graphql"\ndocuments: "${filename}"\nextensions:\n  graphql-analyzer:\n    lint:\n      rules:\n        ${camel}: warn\n`,
+);
+if (!isSchema) {
+  // For document-side rules, write a minimal Query so graphql-eslint can
+  // parse with type info. Tests that need richer schemas can pass a
+  // larger fixture as the schema file directly.
+  writeFileSync(path.join(rootDir, "schema.graphql"), `type Query { _: Boolean }\n`);
+}
+
+async function run(plugin, scope) {
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    cwd: rootDir,
+    overrideConfig: [
+      {
+        files: ["**/*.graphql", "**/*.ts", "**/*.tsx", "**/*.js"],
+        languageOptions: { parser: plugin.parser },
+        plugins: { [scope]: plugin },
+        rules: { [`${scope}/${ruleName}`]: 1 },
+      },
+    ],
+  });
+  const [r] = await eslint.lintFiles([filename]);
+  return r.messages.filter((m) => m.ruleId === `${scope}/${ruleName}`);
+}
+
+const project = (d) => ({
+  line: d.line,
+  column: d.column,
+  endLine: d.endLine,
+  endColumn: d.endColumn,
+  message: d.message,
+});
+
+try {
+  const oursDiag = (await run(ours, "@graphql-analyzer")).map(project);
+  const theirsDiag = (await run(theirs, "@graphql-eslint")).map(project);
+
+  console.log(
+    JSON.stringify(
+      {
+        rule: ruleName,
+        filename,
+        ours: { count: oursDiag.length, diagnostics: oursDiag },
+        theirs: { count: theirsDiag.length, diagnostics: theirsDiag },
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  rmSync(rootDir, { recursive: true, force: true });
+}

--- a/packages/eslint-plugin/src/rules.ts
+++ b/packages/eslint-plugin/src/rules.ts
@@ -34,7 +34,22 @@ function diagnosticsFor(filePath: string, source: string): binding.JsDiagnostic[
 // matches graphql-eslint exactly. Add a rule here only when graphql-eslint's
 // own implementation is intentionally start-only (e.g. `no-hashtag-description`
 // passes `loc: { line, column }` rather than `{ start, end }`).
-const START_ONLY_RULES = new Set(["noHashtagDescription"]);
+const START_ONLY_RULES = new Set([
+  "noHashtagDescription",
+  "requireSelections",
+  "matchDocumentFilename",
+  "selectionSetDepth",
+]);
+
+// Universally permissive options schema. graphql-eslint declares per-rule
+// JSON Schemas (often `additionalProperties: false`); we don't need to
+// duplicate those validators here because the Rust side already deserialises
+// into typed structs and ignores unknown keys. Allowing any object lets users
+// pass the same options graphql-eslint accepts (and a superset) without
+// ESLint's flat-config validator rejecting calls to rules with options.
+const OPTIONS_SCHEMA: Rule.RuleMetaData["schema"] = [
+  { type: "object", additionalProperties: true },
+];
 
 function makeRule(analyzerRuleName: string, description: string): Rule.RuleModule {
   const startOnly = START_ONLY_RULES.has(analyzerRuleName);
@@ -42,7 +57,7 @@ function makeRule(analyzerRuleName: string, description: string): Rule.RuleModul
     meta: {
       type: "problem",
       docs: { description },
-      schema: [],
+      schema: OPTIONS_SCHEMA,
     },
     create(context) {
       return {

--- a/packages/eslint-plugin/test/_lint-theirs.mjs
+++ b/packages/eslint-plugin/test/_lint-theirs.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Child-process runner: lint a file with @graphql-eslint/eslint-plugin and
+// print the resulting diagnostics as JSON.
+//
+// graphql-eslint caches its parsed `graphQLConfig` at module scope; running
+// each parity probe in a fresh process bypasses that and prevents
+// rule-N's state from leaking into rule-(N+1)'s diagnostics.
+//
+// Args (positional, JSON-encoded for transparency):
+//   1: cwd (the throwaway project root)
+//   2: rule (kebab-case)
+//   3: target file (relative to cwd)
+//   4: severity (1 or 2)
+//   5: optional rule options as JSON string ("undefined" for none)
+
+process.env.NODE_ENV = "test";
+import { ESLint } from "eslint";
+import theirsMod from "@graphql-eslint/eslint-plugin";
+const theirs = theirsMod.default ?? theirsMod;
+
+const [, , cwd, rule, target, severity, optionsRaw] = process.argv;
+const options = optionsRaw && optionsRaw !== "undefined" ? JSON.parse(optionsRaw) : undefined;
+const ruleEntry = options !== undefined ? [Number(severity), options] : Number(severity);
+
+const eslint = new ESLint({
+  overrideConfigFile: true,
+  cwd,
+  overrideConfig: [
+    {
+      files: ["**/*.graphql"],
+      languageOptions: { parser: theirs.parser },
+      plugins: { "@graphql-eslint": theirs },
+      rules: { [`@graphql-eslint/${rule}`]: ruleEntry },
+    },
+  ],
+});
+
+const [r] = await eslint.lintFiles([target]);
+const messages = r.messages.filter((m) => m.ruleId === `@graphql-eslint/${rule}`);
+process.stdout.write(JSON.stringify(messages));

--- a/packages/eslint-plugin/test/parity.test.mjs
+++ b/packages/eslint-plugin/test/parity.test.mjs
@@ -3,34 +3,49 @@
 // Enforces that:
 //   1. Rules we already expose have the same name as graphql-eslint's
 //      counterpart (drop-in migration is find-and-replace on the plugin name).
-//   2. For rule names shared between the two plugins, both fire on the same
-//      fixture files — the migration produces "equivalent" diagnostics, not
-//      necessarily identical wording.
+//   2. Every shared rule fires identically on a per-rule isolated fixture —
+//      same diagnostic count, same messages, same source positions.
+//
+// Each rule in EXERCISED carries its own fixture (inline strings); the
+// runner builds a throwaway project per probe, writes the fixture, runs both
+// plugins with the named rule enabled, and compares. This keeps fixtures from
+// cross-firing (rule X's fixture won't accidentally trip rule Y's parity
+// test) and means adding a new rule's coverage doesn't perturb existing
+// fixtures.
+//
+// The "every shared rule is parity-verified" test below fails if a rule is
+// added to either plugin without landing in EXERCISED. So new shared rules
+// force a parity decision on first sight.
 //
 // Intentional gaps (see docs/src/content/docs/linting/eslint-plugin.mdx):
 //   - Validation-category rules from graphql-js (`known-type-names`,
-//     `fields-on-correct-type`, etc.) are not exposed as lint rules in
-//     graphql-analyzer. They run as part of the analyzer's validation pass.
-//     `KNOWN_MISSING` captures this so we fail CI when graphql-eslint adds a
-//     non-validation rule we should have.
+//     `fields-on-correct-type`, etc.) run inside the analyzer's validation
+//     pass, not as configurable lint rules. `KNOWN_MISSING` captures these
+//     so we fail CI when graphql-eslint adds a non-validation rule we should
+//     have.
 //   - A handful of linter-specific rules we have that graphql-eslint doesn't
 //     (`operation-name-suffix`, `redundant-fields`, `require-id-field`, etc.).
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { ESLint } from "eslint";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import * as path from "node:path";
-import { ESLint } from "eslint";
 
 import ours from "../dist/index.js";
 import theirsNs from "@graphql-eslint/eslint-plugin";
 
 const theirs = theirsNs.default ?? theirsNs;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const fixtureRoot = path.resolve(__dirname, "../../../test-workspace/eslint-migration");
+// graphql-eslint caches its parsed `graphQLConfig` at module scope. Running
+// each `theirs` probe in a fresh child process bypasses the cache and
+// prevents rule-N's project state from leaking into rule-(N+1)'s diagnostics.
+const THEIRS_RUNNER = path.join(__dirname, "_lint-theirs.mjs");
 
-// graphql-eslint rules we intentionally don't ship. Keep this list
-// alphabetized and note the reason.
+// graphql-eslint rules we intentionally don't ship.
 const KNOWN_MISSING = new Set([
   // GraphQL-spec validation rules (from graphql-js `specifiedRules`). They
   // run inside the analyzer's validation pass rather than as configurable
@@ -65,9 +80,7 @@ const KNOWN_MISSING = new Set([
   "value-literals-of-correct-type",
   "variables-are-input-types",
   "variables-in-allowed-position",
-  // Naming mismatch tracked separately (see KNOWN_NAMING_MISMATCH below) —
-  // treat these as "not present under graphql-eslint's name" so the strict
-  // parity check still has a signal.
+  // Naming mismatch tracked separately (see KNOWN_NAMING_MISMATCH below).
   "no-unused-fields",
   "no-unused-fragments",
   "no-unused-variables",
@@ -81,9 +94,7 @@ const KNOWN_NAMING_MISMATCH = new Map([
   ["unused-variables", "no-unused-variables"],
 ]);
 
-// Rules we ship that graphql-eslint doesn't. OK to extend the surface, but
-// surprising additions should be deliberate — the allowlist catches
-// accidental ones.
+// Rules we ship that graphql-eslint doesn't.
 const KNOWN_EXTRA = new Set([
   "operation-name-suffix",
   "redundant-fields",
@@ -120,78 +131,468 @@ test("no unexpected extra rules vs graphql-eslint", () => {
   );
 });
 
-// Rules whose output is verified against graphql-eslint, keyed by rule name.
+// Convert kebab-case (rule names) to camelCase (analyzer config keys).
+const camelCase = (s) => s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+
+// Each entry describes a per-rule isolated fixture and the parity assertion
+// applied to the resulting diagnostics.
 //
-//   span: "line" — compare diagnostic count, messages, and firing line.
-//   span: "full" — also compare column/endLine/endColumn (or assert that
-//     both sides emit the same single-position loc — `endLine` and
-//     `endColumn` may be `undefined` if graphql-eslint reports start-only).
+//   files: { "<relpath>": "<contents>", ... }
+//     The set of files written into the throwaway project. `schema.graphql` is
+//     loaded as the project schema; everything under `src/` is treated as a
+//     document. At least one file must be the lint target (`target`).
 //
-// Adding a rule here is the single point where parity coverage is declared.
+//   target: "<relpath>"
+//     The single file we run ESLint against — diagnostics are filtered by
+//     `ruleId === <scope>/<rule>` so this rule's parity is measured in
+//     isolation even when a fixture also trips other rules.
+//
+//   options: <any> (optional)
+//     Passed as the rule's option payload to BOTH plugins. Use this when
+//     graphql-eslint's rule schema requires options or when the only sensible
+//     parity is at non-default options. Ours must accept the same shape.
+//
+//   severity: 1 | 2
+//
+//   span: "line" | "full"
+//     "full" compares { line, column, endLine, endColumn }; "line" only
+//     compares the firing line. Use "full" wherever both plugins produce
+//     well-defined ranges.
 const EXERCISED = {
-  "no-anonymous-operations": { file: "src/operations.graphql", severity: 2, span: "line" },
-  "no-duplicate-fields": { file: "src/operations.graphql", severity: 2, span: "line" },
-  "no-hashtag-description": { file: "schema.graphql", severity: 1, span: "full" },
-  // Position parity verified after #1008 (TypeRef.name_range).
+  // ----- already-verified rules from prior PRs (#1008, #1011, #1012, #1013, #1014) -----
+
+  "no-anonymous-operations": {
+    files: {
+      "schema.graphql": "type Query { hello: String }\n",
+      "src/op.graphql": "query { hello }\nquery { hello }\n",
+    },
+    target: "src/op.graphql",
+    severity: 2,
+    span: "line",
+  },
+
+  "no-duplicate-fields": {
+    files: {
+      "schema.graphql": "type Query { user: User } type User { id: ID! email: String }\n",
+      "src/op.graphql": "query Q { user { id email id } }\n",
+    },
+    target: "src/op.graphql",
+    severity: 2,
+    span: "line",
+  },
+
+  "no-hashtag-description": {
+    files: {
+      "schema.graphql": "# Don't use this as a description\ntype Query { hello: String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "description-style": {
+    files: {
+      "schema.graphql": '"A type"\ntype Query { id: ID! }\n',
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
   "require-field-of-type-query-in-mutation-result": {
-    file: "schema.graphql",
+    files: {
+      "schema.graphql":
+        "type Query { hello: String }\n" +
+        "type Mutation { createUser: CreateUserResult }\n" +
+        "type CreateUserResult { user: User }\n" +
+        "type User { id: ID! }\n",
+    },
+    target: "schema.graphql",
     severity: 1,
     span: "full",
   },
-  // Firing condition aligned (skip non-null lists) and message format
-  // aligned (`in type "Query"`) to match graphql-eslint exactly.
+
   "require-nullable-result-in-root": {
-    file: "schema.graphql",
+    files: {
+      "schema.graphql": "type Query { version: String! }\n",
+    },
+    target: "schema.graphql",
     severity: 1,
     span: "full",
   },
-  // Coverage extended to nested nodes in #1011 (matches graphql-eslint's
-  // `getNodeName`-shaped diagnostic).
-  "description-style": { file: "schema.graphql", severity: 1, span: "full" },
+
+  // ----- newly verified rules (this PR) -----
+
+  alphabetize: {
+    // graphql-eslint requires explicit options (`minProperties: 1`).
+    options: { selections: ["OperationDefinition"] },
+    files: {
+      "schema.graphql": "type Query { user: User } type User { id: ID! name: String! age: Int }\n",
+      "src/op.graphql": "query Q { user { name age id } }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "input-name": {
+    files: {
+      "schema.graphql":
+        "type Query { _: Boolean }\n" + "type Mutation { setMessage(message: String): String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "lone-executable-definition": {
+    files: {
+      "schema.graphql": "type Query { hello: String }\n",
+      "src/op.graphql": "query A { hello }\nquery B { hello }\nfragment F on Query { hello }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "match-document-filename": {
+    options: { query: "PascalCase" },
+    files: {
+      "schema.graphql": "type Query { hello: String }\n",
+      "src/operation.graphql": "query SomethingElse { hello }\n",
+    },
+    target: "src/operation.graphql",
+    severity: 1,
+    span: "line",
+  },
+
+  "naming-convention": {
+    // Both plugins no-op without explicit kind config; this fixture just
+    // exercises that the no-config behavior matches.
+    files: {
+      "schema.graphql": "type Query { hello: String }\n",
+      "src/op.graphql": "query lowercaseOp { hello }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-deprecated": {
+    files: {
+      "schema.graphql":
+        "type Query { user: User }\n" +
+        "type User {\n" +
+        "  id: ID!\n" +
+        '  oldField: String @deprecated(reason: "use newField")\n' +
+        "  newField: String\n" +
+        "}\n",
+      "src/op.graphql": "query GetUser { user { id oldField } }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-one-place-fragments": {
+    files: {
+      "schema.graphql": "type Query { hello: String }\n",
+      "src/op.graphql": "fragment F on Query { hello }\nquery Q { ...F }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-root-type": {
+    options: { disallow: ["mutation", "subscription"] },
+    files: {
+      "schema.graphql":
+        "type Query { hello: String }\n" + "type Mutation { setHello(s: String): String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-scalar-result-type-on-mutation": {
+    files: {
+      "schema.graphql":
+        "type Query { ok: Boolean }\n" + "type Mutation {\n  deleteUser: Boolean!\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-typename-prefix": {
+    files: {
+      "schema.graphql":
+        "type Query { user: User }\ntype User {\n  userId: ID!\n  name: String\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "no-unreachable-types": {
+    files: {
+      "schema.graphql":
+        "type Query { me: User }\n" + "type User { id: ID! }\n" + "type Orphan { name: String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "relay-arguments": {
+    files: {
+      "schema.graphql":
+        "type Query {\n  posts: PostConnection\n}\n\n" +
+        "type PostConnection { edges: [PostEdge] pageInfo: PageInfo! }\n" +
+        "type PostEdge { node: Post cursor: String! }\n" +
+        "type Post { id: ID! }\n" +
+        "type PageInfo { hasPreviousPage: Boolean! hasNextPage: Boolean! startCursor: String endCursor: String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "relay-connection-types": {
+    files: {
+      "schema.graphql":
+        "type Query { users: UserConnection }\n\n" +
+        "type UserConnection {\n  edges: UserEdge\n  pageInfo: PageInfo\n}\n\n" +
+        "type UserEdge { node: User cursor: String! }\n" +
+        "type User { id: ID! }\n" +
+        "type PageInfo { hasPreviousPage: Boolean! hasNextPage: Boolean! startCursor: String endCursor: String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "relay-edge-types": {
+    files: {
+      "schema.graphql":
+        "type Query { users: UserConnection }\n\n" +
+        "type UserConnection { edges: [UserItem] pageInfo: PageInfo! }\n\n" +
+        "type UserItem {\n  cursor: String!\n}\n\n" +
+        "type User { id: ID! }\n" +
+        "type PageInfo { hasPreviousPage: Boolean! hasNextPage: Boolean! startCursor: String endCursor: String }\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "relay-page-info": {
+    files: {
+      "schema.graphql":
+        "type Query { hello: String }\n\n" +
+        "type PageInfo {\n  hasPreviousPage: Boolean\n  hasNextPage: String\n  startCursor: String\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-deprecation-date": {
+    files: {
+      "schema.graphql":
+        "type Query { _: Boolean }\n" +
+        "type User {\n" +
+        "  id: ID!\n" +
+        '  oldField: String @deprecated(reason: "use newField")\n' +
+        "}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-deprecation-reason": {
+    files: {
+      "schema.graphql":
+        "type Query { _: Boolean }\n" +
+        "type User {\n  id: ID!\n  oldField: String @deprecated\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-description": {
+    options: { types: true },
+    files: {
+      "schema.graphql": "type Query { _: Boolean }\n\ntype Undocumented {\n  id: ID!\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-import-fragment": {
+    files: {
+      "schema.graphql": "type Query { user: User } type User { id: ID! name: String }\n",
+      "src/op.graphql": "query GetUser { user { ...UserFields } }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-nullable-fields-with-oneof": {
+    files: {
+      "schema.graphql":
+        "directive @oneOf on INPUT_OBJECT | OBJECT\n" +
+        "type Query { _: Boolean }\n" +
+        "input Foo @oneOf {\n  a: String!\n  b: Int\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-selections": {
+    files: {
+      "schema.graphql": "type Query { user: User }\n" + "type User { id: ID! name: String! }\n",
+      "src/op.graphql": "query Q { user { name } }\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "require-type-pattern-with-oneof": {
+    files: {
+      "schema.graphql":
+        "directive @oneOf on INPUT_OBJECT | OBJECT\n" +
+        "type Query { _: Boolean }\n" +
+        "type Result @oneOf {\n  success: String\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "selection-set-depth": {
+    options: { maxDepth: 2 },
+    files: {
+      "schema.graphql":
+        "type Query { a: A } type A { b: B } type B { c: C } type C { d: String }\n",
+      "src/op.graphql": "query Q {\n  a { b { c { d } } }\n}\n",
+    },
+    target: "src/op.graphql",
+    severity: 1,
+    span: "line",
+  },
+
+  "strict-id-in-types": {
+    files: {
+      "schema.graphql": "type Query { user: User }\ntype User {\n  name: String!\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
+
+  "unique-enum-value-names": {
+    files: {
+      "schema.graphql":
+        "type Query { e: MyEnum }\n" + "enum MyEnum {\n  Value\n  VALUE\n  ValuE\n}\n",
+    },
+    target: "schema.graphql",
+    severity: 1,
+    span: "full",
+  },
 };
 
-test("rules shared with graphql-eslint fire on the same fixture files", async () => {
-  // Build both plugins against the same fixture config so differences are
-  // attributable to analyzer behavior, not config drift.
-  const sharedRules = [...ourRules()].filter((r) => theirRules().has(r));
-  assert.ok(sharedRules.length > 0, "expected at least one shared rule");
+test("every shared rule is parity-verified", () => {
+  // Inverts the default: any shared rule must appear in EXERCISED with a
+  // verified parity assertion. New rules added to either plugin force a
+  // decision on first sight.
+  const shared = [...ourRules()].filter((r) => theirRules().has(r));
+  const exercised = new Set(Object.keys(EXERCISED));
 
-  for (const [rule, { file, severity }] of Object.entries(EXERCISED)) {
-    const ourDiag = await lintOne("ours", rule, severity, file);
-    const theirDiag = await lintOne("theirs", rule, severity, file);
+  const unaccounted = shared.filter((r) => !exercised.has(r)).sort();
+  assert.deepEqual(
+    unaccounted,
+    [],
+    "Shared rules without parity coverage. Add to EXERCISED with a fixture:\n  " +
+      unaccounted.join("\n  "),
+  );
 
-    assert.ok(ourDiag.length > 0, `our plugin didn't fire ${rule} on ${file}`);
-    assert.ok(
-      theirDiag.length > 0,
-      `graphql-eslint didn't fire ${rule} on ${file} — fixture may need updating`,
-    );
-  }
+  const stale = [...exercised].filter((r) => !shared.includes(r)).sort();
+  assert.deepEqual(
+    stale,
+    [],
+    `EXERCISED entries that aren't shared rules — remove them:\n  ${stale.join("\n  ")}`,
+  );
 });
 
 test("messages, counts, and source positions match graphql-eslint exactly", async () => {
-  // Hard parity: same diagnostic count, same messages, and source positions
-  // matching to the granularity declared in `EXERCISED[rule].span`.
-  for (const [rule, { file, severity, span }] of Object.entries(EXERCISED)) {
-    const ourDiag = await lintOne("ours", rule, severity, file);
-    const theirDiag = await lintOne("theirs", rule, severity, file);
-
-    assert.equal(
-      ourDiag.length,
-      theirDiag.length,
-      `${rule} diagnostic count drift: ours=${ourDiag.length} theirs=${theirDiag.length}`,
-    );
-
-    const ourMessages = ourDiag.map((d) => d.message).sort();
-    const theirMessages = theirDiag.map((d) => d.message).sort();
-    assert.deepEqual(ourMessages, theirMessages, `${rule} message text drift on ${file}`);
-
-    assert.deepEqual(
-      sortedPositions(ourDiag, span),
-      sortedPositions(theirDiag, span),
-      `${rule} source-position drift on ${file} (span=${span})`,
-    );
+  // Hard parity: same diagnostic count, same messages, same positions
+  // (granularity per cfg.span). All rules are checked; failures are
+  // collected so a single failing rule doesn't mask drifts in others.
+  //
+  // Both plugins lint the SAME tmp project per rule, so messages that
+  // happen to embed the document path (e.g. `no-one-place-fragments`'s
+  // "Inline him in '<path>'.") match between the two runs.
+  const errors = [];
+  for (const [rule, cfg] of Object.entries(EXERCISED)) {
+    await withProject(rule, cfg, async (root) => {
+      let ourDiag, theirDiag;
+      try {
+        ourDiag = await lintInProject(root, ours, "@graphql-analyzer", rule, cfg);
+      } catch (err) {
+        errors.push(`${rule}: ours threw: ${err.message.split("\n")[0]}`);
+        return;
+      }
+      try {
+        theirDiag = lintTheirsInChild(root, rule, cfg);
+      } catch (err) {
+        errors.push(`${rule}: theirs threw: ${err.message.split("\n")[0]}`);
+        return;
+      }
+      if (ourDiag.length === 0 && theirDiag.length === 0) {
+        // Both fire zero — trivially at parity. (Some rules no-op at default
+        // options on purpose, e.g. `naming-convention` requires explicit
+        // kind config in both plugins.)
+        return;
+      }
+      if (ourDiag.length > 0 && theirDiag.length === 0) {
+        errors.push(`${rule}: ours fired (${ourDiag.length}) but theirs didn't`);
+        return;
+      }
+      if (theirDiag.length > 0 && ourDiag.length === 0) {
+        errors.push(`${rule}: theirs fired (${theirDiag.length}) but ours didn't`);
+        return;
+      }
+      const drift = parityDiff(ourDiag, theirDiag, cfg.span);
+      if (drift) errors.push(`${rule}: ${drift}`);
+    });
   }
+  assert.deepEqual(errors, [], `parity drift:\n  ${errors.join("\n  ")}`);
 });
+
+function parityDiff(ours, theirs, span) {
+  if (ours.length !== theirs.length) {
+    return `count drift: ours=${ours.length} theirs=${theirs.length}`;
+  }
+  const oursMsgs = ours.map((d) => d.message).sort();
+  const theirsMsgs = theirs.map((d) => d.message).sort();
+  if (JSON.stringify(oursMsgs) !== JSON.stringify(theirsMsgs)) {
+    return `message drift\n    ours:   ${JSON.stringify(oursMsgs)}\n    theirs: ${JSON.stringify(theirsMsgs)}`;
+  }
+  const oursPos = sortedPositions(ours, span);
+  const theirsPos = sortedPositions(theirs, span);
+  if (JSON.stringify(oursPos) !== JSON.stringify(theirsPos)) {
+    return `position drift (span=${span})\n    ours:   ${JSON.stringify(oursPos)}\n    theirs: ${JSON.stringify(theirsPos)}`;
+  }
+  return null;
+}
 
 function sortedPositions(diagnostics, span) {
   const project =
@@ -203,21 +604,66 @@ function sortedPositions(diagnostics, span) {
     .sort((a, b) => a.line - b.line || (a.column ?? 0) - (b.column ?? 0));
 }
 
-async function lintOne(which, rule, severity, file) {
-  const plugin = which === "ours" ? ours : theirs;
-  const scope = which === "ours" ? "@graphql-analyzer" : "@graphql-eslint";
+async function withProject(rule, cfg, fn) {
+  const root = mkdtempSync(path.join(tmpdir(), `parity-${rule}-`));
+  try {
+    // Write fixture files.
+    for (const [relpath, content] of Object.entries(cfg.files)) {
+      const abs = path.join(root, relpath);
+      mkdirSync(path.dirname(abs), { recursive: true });
+      writeFileSync(abs, content);
+    }
+
+    // Write `.graphqlrc.yaml` so the analyzer binding fires the rule and
+    // graphql-config resolves the project (graphql-eslint relies on this
+    // to know which file is schema vs document).
+    const lines = [];
+    if (cfg.files["schema.graphql"]) lines.push(`schema: "schema.graphql"`);
+    const docs = Object.keys(cfg.files).filter((p) => p.startsWith("src/"));
+    if (docs.length > 0) lines.push(`documents: "src/**/*"`);
+    lines.push(`extensions:`);
+    lines.push(`  graphql-analyzer:`);
+    lines.push(`    lint:`);
+    lines.push(`      rules:`);
+    if (cfg.options !== undefined) {
+      lines.push(`        ${camelCase(rule)}:`);
+      lines.push(`          - warn`);
+      lines.push(`          - ${JSON.stringify(cfg.options)}`);
+    } else {
+      lines.push(`        ${camelCase(rule)}: warn`);
+    }
+    writeFileSync(path.join(root, ".graphqlrc.yaml"), lines.join("\n") + "\n");
+
+    return await fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function lintInProject(root, plugin, scope, rule, cfg) {
+  const ruleEntry = cfg.options !== undefined ? [cfg.severity, cfg.options] : cfg.severity;
   const eslint = new ESLint({
     overrideConfigFile: true,
-    cwd: fixtureRoot,
+    cwd: root,
     overrideConfig: [
       {
         files: ["**/*.graphql"],
         languageOptions: { parser: plugin.parser },
         plugins: { [scope]: plugin },
-        rules: { [`${scope}/${rule}`]: severity },
+        rules: { [`${scope}/${rule}`]: ruleEntry },
       },
     ],
   });
-  const [result] = await eslint.lintFiles([file]);
-  return result.messages.filter((m) => m.ruleId === `${scope}/${rule}`);
+  const [r] = await eslint.lintFiles([cfg.target]);
+  return r.messages.filter((m) => m.ruleId === `${scope}/${rule}`);
+}
+
+function lintTheirsInChild(root, rule, cfg) {
+  const optionsRaw = cfg.options !== undefined ? JSON.stringify(cfg.options) : "undefined";
+  const out = execFileSync(
+    process.execPath,
+    [THEIRS_RUNNER, root, rule, cfg.target, String(cfg.severity), optionsRaw],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
+  );
+  return JSON.parse(out);
 }

--- a/test-workspace/eslint-migration/.graphqlrc.yaml
+++ b/test-workspace/eslint-migration/.graphqlrc.yaml
@@ -3,10 +3,38 @@ documents: "src/**/*.graphql"
 extensions:
   graphql-analyzer:
     lint:
+      # All rules enabled for parity probing. ESLint filters per-test by
+      # which rule(s) are configured in its config; the analyzer binding
+      # only emits diagnostics for rules listed here.
       rules:
-        noHashtagDescription: warn
-        noAnonymousOperations: error
-        noDuplicateFields: error
-        requireNullableResultInRoot: warn
-        requireFieldOfTypeQueryInMutationResult: warn
+        alphabetize: warn
         descriptionStyle: warn
+        inputName: warn
+        loneExecutableDefinition: warn
+        matchDocumentFilename: warn
+        namingConvention: warn
+        noAnonymousOperations: error
+        noDeprecated: warn
+        noDuplicateFields: error
+        noHashtagDescription: warn
+        noOnePlaceFragments: warn
+        noRootType: warn
+        noScalarResultTypeOnMutation: warn
+        noTypenamePrefix: warn
+        noUnreachableTypes: warn
+        relayArguments: warn
+        relayConnectionTypes: warn
+        relayEdgeTypes: warn
+        relayPageInfo: warn
+        requireDeprecationDate: warn
+        requireDeprecationReason: warn
+        requireDescription: warn
+        requireFieldOfTypeQueryInMutationResult: warn
+        requireImportFragment: warn
+        requireNullableFieldsWithOneof: warn
+        requireNullableResultInRoot: warn
+        requireSelections: warn
+        requireTypePatternWithOneof: warn
+        selectionSetDepth: warn
+        strictIdInTypes: warn
+        uniqueEnumValueNames: warn

--- a/test-workspace/lint-examples/schema/requireDeprecationDate.graphql
+++ b/test-workspace/lint-examples/schema/requireDeprecationDate.graphql
@@ -1,6 +1,6 @@
 # Demonstrates: requireDeprecationDate
-# Deprecated fields and enum values should include a deletion date
-# in the deprecation reason string (e.g. "deletionDate: 01/01/2025").
+# `@deprecated` directives must declare a `deletionDate` argument in
+# `DD/MM/YYYY` format (matching graphql-eslint's rule).
 
 """
 User account
@@ -19,9 +19,9 @@ type DeprecationDateExample {
   """
   oldName: String @deprecated(reason: "Use 'name' instead")
   """
-  Legacy field - deprecated with deletion date
+  Legacy field - deprecated with a future deletion date
   """
-  legacyField: String @deprecated(reason: "Use 'name' instead, deletionDate: 01/01/2025")
+  legacyField: String @deprecated(reason: "Use 'name' instead", deletionDate: "01/01/2999")
 }
 
 """


### PR DESCRIPTION
## Summary

Closes the parity-coverage gap for **every** shared lint rule. Previously, `parity.test.mjs` exercised 6 of 31 shared rules, leaving 25 untested. This PR:

1. **Restructures the parity test** to use isolated per-rule fixtures (each rule's fixture lives inline in `EXERCISED`; the runner builds a throwaway project per probe), so cross-rule contamination is impossible and adding a new rule's coverage never perturbs an existing fixture.
2. **Adds a ratchet**: a "every shared rule is parity-verified" test that fails CI if a rule lands in either plugin without a parity entry. New shared rules force a parity decision on first sight.
3. **Drives all 31 shared rules to verified parity** — same diagnostic count, same messages, same source positions (line + column + endLine + endColumn for rules with well-defined ranges; line-only for rules where graphql-eslint deliberately reports start-only loc).

## How parity is enforced now

Each `EXERCISED[rule]` entry carries:
- `files`: an inline map of fixture paths → contents (the throwaway project).
- `target`: which file ESLint runs against (diagnostics filtered by `ruleId` so only this rule's output counts).
- `options` (optional): rule options passed to BOTH plugins.
- `severity`, `span` (`"line"` | `"full"`).

`ours` runs in-process; `theirs` runs in a child process per probe — necessary because graphql-eslint caches its parsed `graphQLConfig` at module scope (`process.env.NODE_ENV !== "test"` branch in `node_modules/@graphql-eslint/eslint-plugin/esm/graphql-config.js`), and that cache leaked rule N's project state into rule N+1's `theirs` invocation when run in-process.

## Behavior changes (user-visible)

These are deliberate alignments to graphql-eslint:

- **Quoting**: backticks → double quotes around identifiers in messages for `require-import-fragment`, `require-nullable-fields-with-oneof`, `strict-id-in-types`, `selection-set-depth`, `no-deprecated`, `require-deprecation-date`, and incidentally in rules touched by the option-schema work.
- **Position**: `no-scalar-result-type-on-mutation`, `relay-connection-types`, `require-deprecation-reason`, and `require-deprecation-date` now point at the type/directive name node (matching graphql-eslint) rather than the field name. `unique-enum-value-names` points at each duplicate value's name token. `require-selections` points at the `SelectionSet {`.
- **Firing**: `naming-convention` drops its hardcoded defaults (`OperationDefinition: PascalCase`, `FragmentDefinition: PascalCase`, `Variable: camelCase`) — without explicit kind config the rule now no-ops, matching graphql-eslint. Implementing the full graphql-eslint option surface (all kinds + prefix/suffix/forbiddenPatterns/etc.) is intentionally **not** in scope.
- **Options**: `alphabetize`, `no-root-type`, `match-document-filename`, `selection-set-depth`, and `require-description` now accept graphql-eslint's option shapes (`maxDepth` not `max_depth`, kind-filter objects, etc.). `packages/eslint-plugin/src/rules.ts` makes `meta.schema` permissive so options reach the Rust binding.
- **Semantics**: `require-deprecation-date` now reads the `@deprecated(deletionDate: "DD/MM/YYYY")` argument (rather than scanning the `reason` substring) and emits the same `MESSAGE_INVALID_FORMAT` / `MESSAGE_INVALID_DATE` / `MESSAGE_CAN_BE_REMOVED` diagnostics graphql-eslint does.

## Infrastructure changes (worth flagging for reviewers)

- **`crates/napi/src/host.rs`**: reset the host on each `init_from_config` call. The host was a process-singleton accumulating loaded files across configs; monorepos with multiple `.graphqlrc.yaml` projects (and parity tests that spin up many throwaway projects in one process) now get fresh state per init. **This is a correctness fix that benefits production users with monorepo configs**, not just the test.
- **`crates/hir/src/structure.rs`**: `DirectiveUsage` gained `name_range`; `DirectiveArgument` gained `value_range`. `EnumValue` already had `name_range` — the rule just wasn't using it.
- **`packages/eslint-plugin/test/_lint-theirs.mjs`**: child-process runner for `theirs` invocations.
- **`packages/eslint-plugin/src/rules.ts`**: `START_ONLY_RULES` extended with `requireSelections`, `matchDocumentFilename`, `selectionSetDepth` — graphql-eslint reports these with start-only `loc`, so the eslint adapter strips `endLine`/`endColumn` to match.
- **`packages/eslint-plugin/scripts/probe-rule.mjs`**: dev-time probe utility.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- `npm run test:unit --workspace=@graphql-analyzer/eslint-plugin` — all parity tests pass (≈28s wall-clock; 31 rules × 2 plugins × child-process startup).
- `cargo nextest run --workspace` — 1291 Rust unit tests pass.
- `cargo clippy -p graphql-linter -p graphql-analyzer-napi -p graphql-hir --all-targets` — no errors (preexisting `unwrap_used` warnings unchanged).
- Open `test-workspace/lint-examples/schema/requireDeprecationDate.graphql` in VS Code: confirm the new `@deprecated(deletionDate: "DD/MM/YYYY")` form fires correctly with format/expiry diagnostics.

## Related Issues

Closes the parity-test-coverage section of #1004 by driving the EXERCISED set to include every shared rule (with verified end-to-end parity). Previous PRs in this thread (#1008, #1011, #1012, #1013, #1014) covered 6 rules; this PR covers the remaining 25.