### PR TITLE
WASM LSP + Monaco web playground

### DIFF
--- a/.changeset/wasm-lsp-playground.md
+++ b/.changeset/wasm-lsp-playground.md
@@ -1,0 +1,7 @@
+---
+graphql-lsp: minor
+graphql-lsp-wasm: minor
+@graphql-analyzer/web-ide: minor
+---
+
+Add browser playground (`@graphql-analyzer/web-ide`) backed by a wasm build of the language server. The LSP can now compile to `wasm32-unknown-unknown` via the new `graphql-lsp-wasm` crate.

--- a/.changeset/wasm-lsp-playground.md
+++ b/.changeset/wasm-lsp-playground.md
@@ -1,7 +1,5 @@
 ---
-graphql-lsp: minor
-graphql-lsp-wasm: minor
-@graphql-analyzer/web-ide: minor
+graphql-analyzer-lsp: minor
 ---
 
 Add browser playground (`@graphql-analyzer/web-ide`) backed by a wasm build of the language server. The LSP can now compile to `wasm32-unknown-unknown` via the new `graphql-lsp-wasm` crate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,18 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep, web]
+      [
+        test,
+        lint,
+        build,
+        check,
+        dogfood,
+        vscode-extension,
+        eslint-plugin,
+        format,
+        release-prep,
+        web,
+      ]
     steps:
       - name: Check all jobs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,65 @@ jobs:
       - name: Simulate knope's release-prep
         run: node scripts/check-release-prep.mjs
 
+  web:
+    name: Web Playground
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        run: |
+          rustup show
+          rustup target add wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "ci-web"
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@1222bc9d54bca5582f30a2aac6829eeb5fccf68b # v2
+        with:
+          tool: wasm-pack
+
+      - name: Check wasm-feature build of graphql-lsp
+        run: cargo check -p graphql-lsp --no-default-features --features wasm
+
+      - name: Check graphql-lsp-wasm for wasm32-unknown-unknown
+        run: cargo check -p graphql-lsp-wasm --target wasm32-unknown-unknown
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Build wasm bundle (release)
+        run: wasm-pack build crates/lsp-wasm --target web --out-dir packages/web-ide/src/wasm --release
+
+      - name: TypeScript check
+        working-directory: packages/web-ide
+        run: npx tsc --noEmit
+
+      - name: Build playground (Vite)
+        run: npm --workspace=packages/web-ide run build
+
+      - name: Install Playwright browsers
+        working-directory: packages/web-ide
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm --workspace=packages/web-ide run test:e2e
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
     needs:
-      [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep]
+      [test, lint, build, check, dogfood, vscode-extension, eslint-plugin, format, release-prep, web]
     steps:
       - name: Check all jobs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
         run: npm ci
 
       - name: Build wasm bundle (release)
-        run: wasm-pack build crates/lsp-wasm --target web --out-dir packages/web-ide/src/wasm --release
+        run: wasm-pack build crates/lsp-wasm --target web --out-dir $GITHUB_WORKSPACE/packages/web-ide/src/wasm --release
 
       - name: TypeScript check
         working-directory: packages/web-ide

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ node_modules/
 /dist/
 *.tsbuildinfo
 
+# wasm-pack output
+crates/lsp-wasm/pkg/
+
 # Test artifacts
 *.profraw
 *.profdata

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,6 +7,7 @@
     "Cargo.toml",
     "dist-workspace.toml",
     "editors/vscode/package.json",
+    "packages/web-ide/src/wasm/**",
     "renovate.json",
     "test-workspace/starwars/src/multilineTagExample.ts"
   ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,7 +1349,6 @@ version = "0.1.0"
 dependencies = [
  "graphql-analysis",
  "graphql-base-db",
- "graphql-extract",
  "graphql-hir",
  "graphql-syntax",
  "salsa",
@@ -1398,7 +1407,6 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror 2.0.18",
  "threadpool",
  "tokio",
@@ -1422,6 +1430,22 @@ dependencies = [
  "graphql-ide-db",
  "graphql-syntax",
  "salsa",
+]
+
+[[package]]
+name = "graphql-lsp-wasm"
+version = "0.0.1"
+dependencies = [
+ "console_error_panic_hook",
+ "crossbeam-channel",
+ "graphql-lsp",
+ "js-sys",
+ "lsp-server",
+ "lsp-types",
+ "serde_json",
+ "tracing",
+ "tracing-wasm",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4363,6 +4387,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "tracing",
  "tracing-wasm",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -2167,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2282,16 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "mio"
@@ -2479,6 +2496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4678,6 +4696,45 @@ checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/mcp",
   "crates/napi",
   "crates/apollo-ext",
+  "crates/lsp-wasm",
   "benches",
   ".husky",
   "xtask",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,6 +181,38 @@ cargo watch -p graphql-analyzer-napi -s 'npm run build:debug --workspace=@graphq
 npm run dev --workspace=@graphql-analyzer/eslint-plugin
 ```
 
+## Web Playground
+
+The `packages/web-ide` package hosts a Monaco-based browser playground wired to a wasm build of the language server. Useful for demos, prototyping, and validating cross-target behavior without spinning up VS Code.
+
+### Prerequisites
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+### Build and run
+
+```bash
+cargo xtask web --dev    # opens http://localhost:5173 with hot reload
+cargo xtask web          # static build under packages/web-ide/dist/
+```
+
+`xtask web` runs `wasm-pack build` for `crates/lsp-wasm` and then either `npm run dev` (when `--dev`) or `npm run build` against `packages/web-ide`. Vite serves the worker, the wasm bundle, and Monaco from a single dev server.
+
+### End-to-end tests
+
+The playground has a small Playwright suite at `packages/web-ide/tests/web-ide.spec.ts`:
+
+```bash
+cd packages/web-ide
+npx playwright install chromium
+npm run test:e2e
+```
+
+The tests run against the same Vite dev server as `xtask web --dev`.
+
 ## Benchmarking
 
 ```bash

--- a/crates/analysis/Cargo.toml
+++ b/crates/analysis/Cargo.toml
@@ -11,15 +11,20 @@ categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
 graphql-base-db = { path = "../base-db" }
-graphql-syntax = { path = "../syntax" }
-graphql-hir = { path = "../hir" }
-graphql-linter = { path = "../linter" }
+graphql-syntax = { path = "../syntax", default-features = false }
+graphql-hir = { path = "../hir", default-features = false }
+graphql-linter = { path = "../linter", default-features = false }
 salsa = { workspace = true }
 apollo-compiler = { workspace = true }
 apollo-parser = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 text-size = "1.1"
+
+[features]
+default = ["extract"]
+extract = ["graphql-syntax/extract", "graphql-hir/extract", "graphql-linter/extract"]
+native = ["graphql-syntax/native", "graphql-hir/native", "graphql-linter/native"]
 
 [dev-dependencies]
 graphql-test-utils = { path = "../test-utils" }

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -142,6 +142,25 @@ impl GraphQLConfig {
         Self::get_file_type_for_project(doc_path, workspace_root, config)
     }
 
+    /// Determine the file type for a file given its workspace-relative path string.
+    ///
+    /// Useful for non-`file://` URIs (wasm/in-memory documents) where filesystem
+    /// path conversion isn't available; the caller supplies a path string derived
+    /// from the URI directly.
+    #[must_use]
+    pub fn get_file_type_by_rel_path(
+        &self,
+        rel_path: &str,
+        project_name: &str,
+    ) -> Option<crate::FileType> {
+        let config = match self {
+            Self::Single(config) if project_name == "default" => config,
+            Self::Single(_) => return None,
+            Self::Multi { projects } => projects.get(project_name)?,
+        };
+        Self::match_file_type(rel_path, config)
+    }
+
     /// Internal helper to determine file type for a specific project config.
     fn get_file_type_for_project(
         doc_path: &Path,
@@ -150,28 +169,28 @@ impl GraphQLConfig {
     ) -> Option<crate::FileType> {
         let rel_path = doc_path.strip_prefix(workspace_root).ok()?;
         let rel_path_str = rel_path.to_string_lossy();
+        Self::match_file_type(&rel_path_str, config)
+    }
+
+    /// Pattern-match a relative path string against a project's compiled globs.
+    fn match_file_type(rel_path: &str, config: &ProjectConfig) -> Option<crate::FileType> {
         let compiled = config.compiled_patterns();
 
-        // Check explicit excludes first
-        if compiled.exclude.iter().any(|p| p.matches(&rel_path_str)) {
+        if compiled.exclude.iter().any(|p| p.matches(rel_path)) {
             return None;
         }
 
-        // Check if file is in include scope
         let in_include_scope =
-            config.include.is_none() || compiled.include.iter().any(|p| p.matches(&rel_path_str));
-
+            config.include.is_none() || compiled.include.iter().any(|p| p.matches(rel_path));
         if !in_include_scope {
             return None;
         }
 
-        // Check schema patterns first
-        if compiled.schema.iter().any(|p| p.matches(&rel_path_str)) {
+        if compiled.schema.iter().any(|p| p.matches(rel_path)) {
             return Some(crate::FileType::Schema);
         }
 
-        // Check document patterns
-        if compiled.documents.iter().any(|p| p.matches(&rel_path_str)) {
+        if compiled.documents.iter().any(|p| p.matches(rel_path)) {
             return Some(crate::FileType::Document);
         }
 

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -11,11 +11,16 @@ categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
 graphql-base-db = { path = "../base-db" }
-graphql-syntax = { path = "../syntax" }
+graphql-syntax = { path = "../syntax", default-features = false }
 salsa = { workspace = true }
 apollo-parser = { workspace = true }
 apollo-compiler = { workspace = true }
 text-size = "1.1"
+
+[features]
+default = ["extract"]
+extract = ["graphql-syntax/extract"]
+native = ["graphql-syntax/native"]
 
 [dev-dependencies]
 graphql-test-utils = { path = "../test-utils" }

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -22,7 +22,7 @@ salsa = { workspace = true }
 
 [features]
 default = ["extract"]
-extract = ["graphql-syntax/extract"]
+extract = ["graphql-syntax/extract", "graphql-hir/extract"]
 
 [lints]
 workspace = true

--- a/crates/ide-db/Cargo.toml
+++ b/crates/ide-db/Cargo.toml
@@ -17,11 +17,12 @@ graphql-syntax = { path = "../syntax" }
 graphql-hir = { path = "../hir" }
 graphql-analysis = { path = "../analysis" }
 
-# For ExtractConfig in GraphQLSyntaxDatabase
-graphql-extract = { path = "../extract" }
-
 # Salsa for incremental computation
 salsa = { workspace = true }
+
+[features]
+default = ["extract"]
+extract = ["graphql-syntax/extract"]
 
 [lints]
 workspace = true

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -38,7 +38,8 @@ graphql-extract = { path = "../extract", optional = true }
 graphql-introspect = { path = "../introspect", optional = true }
 
 [features]
-default = ["extract", "introspect"]
+default = ["native", "extract", "introspect"]
+native = []
 extract = ["dep:graphql-extract", "graphql-syntax/extract", "graphql-ide-db/extract"]
 introspect = ["dep:graphql-introspect"]
 

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -34,8 +34,13 @@ graphql-syntax = { path = "../syntax" }
 graphql-hir = { path = "../hir" }
 graphql-analysis = { path = "../analysis" }
 graphql-linter = { path = "../linter" }
-graphql-extract = { path = "../extract" }
-graphql-introspect = { path = "../introspect" }
+graphql-extract = { path = "../extract", optional = true }
+graphql-introspect = { path = "../introspect", optional = true }
+
+[features]
+default = ["extract", "introspect"]
+extract = ["dep:graphql-extract", "graphql-syntax/extract", "graphql-ide-db/extract"]
+introspect = ["dep:graphql-introspect"]
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -30,17 +30,17 @@ anyhow = { workspace = true }
 
 # Internal crates (query-based layers)
 graphql-base-db = { path = "../base-db" }
-graphql-syntax = { path = "../syntax" }
-graphql-hir = { path = "../hir" }
-graphql-analysis = { path = "../analysis" }
-graphql-linter = { path = "../linter" }
+graphql-syntax = { path = "../syntax", default-features = false }
+graphql-hir = { path = "../hir", default-features = false }
+graphql-analysis = { path = "../analysis", default-features = false }
+graphql-linter = { path = "../linter", default-features = false }
 graphql-extract = { path = "../extract", optional = true }
 graphql-introspect = { path = "../introspect", optional = true }
 
 [features]
 default = ["native", "extract", "introspect"]
-native = []
-extract = ["dep:graphql-extract", "graphql-syntax/extract", "graphql-ide-db/extract"]
+native = ["graphql-syntax/native", "graphql-hir/native", "graphql-analysis/native", "graphql-linter/native"]
+extract = ["dep:graphql-extract", "graphql-syntax/extract", "graphql-hir/extract", "graphql-analysis/extract", "graphql-linter/extract", "graphql-ide-db/extract"]
 introspect = ["dep:graphql-introspect"]
 
 [dev-dependencies]

--- a/crates/ide/src/database.rs
+++ b/crates/ide/src/database.rs
@@ -24,6 +24,7 @@ pub(crate) struct LintConfigInput {
 /// - Automatic invalidation (only config-dependent queries re-run on changes)
 /// - No deadlock risk (Salsa manages all locking internally)
 /// - Snapshot isolation (config is immutable in Analysis snapshots)
+#[cfg(feature = "extract")]
 #[salsa::input]
 pub(crate) struct ExtractConfigInput {
     pub config: Arc<graphql_extract::ExtractConfig>,
@@ -42,6 +43,7 @@ pub(crate) struct ExtractConfigInput {
 pub(crate) struct IdeDatabase {
     pub(crate) storage: salsa::Storage<Self>,
     pub(crate) lint_config_input: Option<LintConfigInput>,
+    #[cfg(feature = "extract")]
     pub(crate) extract_config_input: Option<ExtractConfigInput>,
     /// Project files input - stores the current `ProjectFiles` Salsa input directly.
     /// Unlike the old `Arc<RwLock<...>>` approach, this enables proper Salsa dependency
@@ -63,6 +65,7 @@ impl Default for IdeDatabase {
                 _ => {}
             }))),
             lint_config_input: None,
+            #[cfg(feature = "extract")]
             extract_config_input: None,
             project_files_input: None,
         };
@@ -72,10 +75,13 @@ impl Default for IdeDatabase {
             &db,
             Arc::new(graphql_linter::LintConfig::default()),
         ));
-        db.extract_config_input = Some(ExtractConfigInput::new(
-            &db,
-            Arc::new(graphql_extract::ExtractConfig::default()),
-        ));
+        #[cfg(feature = "extract")]
+        {
+            db.extract_config_input = Some(ExtractConfigInput::new(
+                &db,
+                Arc::new(graphql_extract::ExtractConfig::default()),
+            ));
+        }
 
         db
     }
@@ -86,6 +92,7 @@ impl salsa::Database for IdeDatabase {}
 
 #[salsa::db]
 impl graphql_syntax::GraphQLSyntaxDatabase for IdeDatabase {
+    #[cfg(feature = "extract")]
     fn extract_config(&self) -> Option<Arc<graphql_extract::ExtractConfig>> {
         self.extract_config_input
             .map(|input| input.config(self).clone())

--- a/crates/ide/src/discovery.rs
+++ b/crates/ide/src/discovery.rs
@@ -74,7 +74,7 @@ impl FileDiscoveryResult {
 pub fn discover_document_files(
     config: &graphql_config::ProjectConfig,
     workspace_path: &std::path::Path,
-    extract_config: &graphql_extract::ExtractConfig,
+    #[cfg(feature = "extract")] extract_config: &graphql_extract::ExtractConfig,
 ) -> FileDiscoveryResult {
     let Some(documents_config) = &config.documents else {
         return FileDiscoveryResult::default();
@@ -121,18 +121,26 @@ pub fn discover_document_files(
                                         // Validate content matches expected kind (Executable)
                                         // For TS/JS files, we need to extract GraphQL first
                                         let graphql_content = if language.requires_extraction() {
-                                            // Extract and concatenate all GraphQL blocks
-                                            graphql_extract::extract_from_source(
-                                                &content,
-                                                language,
-                                                extract_config,
-                                                &path_str,
-                                            )
-                                            .unwrap_or_default()
-                                            .iter()
-                                            .map(|block| block.source.as_str())
-                                            .collect::<Vec<_>>()
-                                            .join("\n")
+                                            #[cfg(feature = "extract")]
+                                            {
+                                                // Extract and concatenate all GraphQL blocks
+                                                graphql_extract::extract_from_source(
+                                                    &content,
+                                                    language,
+                                                    extract_config,
+                                                    &path_str,
+                                                )
+                                                .unwrap_or_default()
+                                                .iter()
+                                                .map(|block| block.source.as_str())
+                                                .collect::<Vec<_>>()
+                                                .join("\n")
+                                            }
+                                            #[cfg(not(feature = "extract"))]
+                                            {
+                                                // No extractor available; treat as no GraphQL.
+                                                String::new()
+                                            }
                                         } else {
                                             content.clone()
                                         };
@@ -258,6 +266,7 @@ pub(crate) fn path_to_file_path(path: &std::path::Path) -> FilePath {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "extract")]
     #[test]
     fn test_discover_document_files_skips_ts_without_graphql() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/ide/src/discovery.rs
+++ b/crates/ide/src/discovery.rs
@@ -263,10 +263,10 @@ pub(crate) fn path_to_file_path(path: &std::path::Path) -> FilePath {
 }
 
 #[cfg(test)]
+#[cfg(feature = "extract")]
 mod tests {
     use super::*;
 
-    #[cfg(feature = "extract")]
     #[test]
     fn test_discover_document_files_skips_ts_without_graphql() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/ide/src/host.rs
+++ b/crates/ide/src/host.rs
@@ -665,13 +665,14 @@ impl AnalysisHost {
                                             if language.requires_extraction() {
                                                 #[cfg(feature = "extract")]
                                                 {
-                                                    let blocks = graphql_extract::extract_from_source(
-                                                        &content,
-                                                        language,
-                                                        extract_config,
-                                                        &path_str,
-                                                    )
-                                                    .unwrap_or_default();
+                                                    let blocks =
+                                                        graphql_extract::extract_from_source(
+                                                            &content,
+                                                            language,
+                                                            extract_config,
+                                                            &path_str,
+                                                        )
+                                                        .unwrap_or_default();
                                                     if blocks.is_empty() {
                                                         continue;
                                                     }

--- a/crates/ide/src/host.rs
+++ b/crates/ide/src/host.rs
@@ -13,7 +13,9 @@ fn next_snapshot_id() -> u64 {
 }
 
 use crate::analysis::Analysis;
-use crate::database::{ExtractConfigInput, IdeDatabase, LintConfigInput};
+#[cfg(feature = "extract")]
+use crate::database::ExtractConfigInput;
+use crate::database::{IdeDatabase, LintConfigInput};
 use crate::discovery::{
     determine_document_file_kind, expand_braces, path_to_file_path, DiscoveredFile, LoadedFile,
 };
@@ -290,9 +292,11 @@ impl AnalysisHost {
                             match std::fs::read_to_string(&entry) {
                                 Ok(content) => {
                                     let file_uri = path_to_file_uri(&entry);
+                                    #[cfg(feature = "extract")]
                                     let language = graphql_extract::Language::from_path(&entry);
 
                                     // Check if this is a TS/JS file that needs extraction
+                                    #[cfg(feature = "extract")]
                                     if let Some(lang) = language {
                                         if lang.requires_extraction() {
                                             // Extract GraphQL from TS/JS file
@@ -379,6 +383,7 @@ impl AnalysisHost {
                                     }
 
                                     // JSON introspection result file support
+                                    #[cfg(feature = "introspect")]
                                     if entry.extension().and_then(|e| e.to_str()) == Some("json")
                                         && graphql_introspect::is_introspection_json(&content)
                                     {
@@ -567,6 +572,7 @@ impl AnalysisHost {
     ///
     /// This properly invalidates all queries that depend on extract config via Salsa's
     /// dependency tracking. Only extract-dependent queries will re-run when config changes.
+    #[cfg(feature = "extract")]
     pub fn set_extract_config(&mut self, config: graphql_extract::ExtractConfig) {
         if let Some(input) = self.db.extract_config_input {
             input.set_config(&mut self.db).to(Arc::new(config));
@@ -577,6 +583,7 @@ impl AnalysisHost {
     }
 
     /// Get the extract configuration for the project
+    #[cfg(feature = "extract")]
     pub fn get_extract_config(&self) -> graphql_extract::ExtractConfig {
         self.db
             .extract_config_input
@@ -607,7 +614,7 @@ impl AnalysisHost {
         &mut self,
         config: &graphql_config::ProjectConfig,
         workspace_path: &std::path::Path,
-        extract_config: &graphql_extract::ExtractConfig,
+        #[cfg(feature = "extract")] extract_config: &graphql_extract::ExtractConfig,
     ) -> (Vec<LoadedFile>, DocumentLoadResult) {
         let Some(documents_config) = &config.documents else {
             return (Vec::new(), DocumentLoadResult::default());
@@ -654,14 +661,22 @@ impl AnalysisHost {
 
                                             // Skip files that require extraction but contain no GraphQL
                                             if language.requires_extraction() {
-                                                let blocks = graphql_extract::extract_from_source(
-                                                    &content,
-                                                    language,
-                                                    extract_config,
-                                                    &path_str,
-                                                )
-                                                .unwrap_or_default();
-                                                if blocks.is_empty() {
+                                                #[cfg(feature = "extract")]
+                                                {
+                                                    let blocks = graphql_extract::extract_from_source(
+                                                        &content,
+                                                        language,
+                                                        extract_config,
+                                                        &path_str,
+                                                    )
+                                                    .unwrap_or_default();
+                                                    if blocks.is_empty() {
+                                                        continue;
+                                                    }
+                                                }
+                                                #[cfg(not(feature = "extract"))]
+                                                {
+                                                    // No extractor available; skip files that need extraction.
                                                     continue;
                                                 }
                                             }

--- a/crates/ide/src/host.rs
+++ b/crates/ide/src/host.rs
@@ -605,6 +605,8 @@ impl AnalysisHost {
     ///
     /// * `config` - The project configuration containing document patterns
     /// * `workspace_path` - The base directory for glob pattern resolution
+    /// * `extract_config` - Configuration for TS/JS GraphQL extraction
+    ///   (only present when the `extract` feature is enabled)
     ///
     /// # Returns
     ///

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -3429,6 +3429,7 @@ query GetUser {
         );
     }
 
+    #[cfg(feature = "extract")]
     #[test]
     fn test_typescript_graphql_extraction() {
         use graphql_extract::{extract_from_source, ExtractConfig, Language};
@@ -3653,6 +3654,7 @@ export const GET_POKEMON = gql`
         use super::*;
         use std::io::Write;
 
+        #[cfg(feature = "extract")]
         #[test]
         fn test_load_typescript_schema() {
             let temp_dir = tempfile::tempdir().unwrap();
@@ -5179,6 +5181,7 @@ export const RATE_LIMIT_QUERY = gql`
         );
     }
 
+    #[cfg(feature = "extract")]
     #[test]
     fn test_unused_fields_lint_with_config_loaded_typescript() {
         use std::io::Write;
@@ -5263,6 +5266,7 @@ export const RATE_LIMIT_QUERY = gql`
         );
     }
 
+    #[cfg(feature = "extract")]
     #[test]
     fn test_unused_fields_lint_simulating_save_after_open() {
         use std::io::Write;

--- a/crates/introspect/Cargo.toml
+++ b/crates/introspect/Cargo.toml
@@ -12,10 +12,17 @@ categories = ["development-tools", "web-programming"]
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
+# wasm tokio: only time is supported; no rt-multi-thread
+tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time"] }

--- a/crates/introspect/src/client.rs
+++ b/crates/introspect/src/client.rs
@@ -230,13 +230,14 @@ impl IntrospectionClient {
     /// Executes a single introspection request without retry logic.
     async fn execute_once(&self, url: &str) -> Result<IntrospectionResponse> {
         tracing::debug!("Creating HTTP client with timeouts");
-        let client = reqwest::Client::builder()
+        let builder = reqwest::Client::builder();
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder
             .timeout(self.timeout)
-            .connect_timeout(self.connect_timeout)
-            .build()
-            .map_err(|e| {
-                IntrospectionError::Network(format!("Failed to create HTTP client: {e}"))
-            })?;
+            .connect_timeout(self.connect_timeout);
+        let client = builder.build().map_err(|e| {
+            IntrospectionError::Network(format!("Failed to create HTTP client: {e}"))
+        })?;
 
         let query_body = serde_json::json!({
             "query": INTROSPECTION_QUERY
@@ -333,13 +334,14 @@ impl IntrospectionClient {
 
     /// Executes a single raw introspection request.
     async fn execute_raw_once(&self, url: &str) -> Result<serde_json::Value> {
-        let client = reqwest::Client::builder()
+        let builder = reqwest::Client::builder();
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder
             .timeout(self.timeout)
-            .connect_timeout(self.connect_timeout)
-            .build()
-            .map_err(|e| {
-                IntrospectionError::Network(format!("Failed to create HTTP client: {e}"))
-            })?;
+            .connect_timeout(self.connect_timeout);
+        let client = builder.build().map_err(|e| {
+            IntrospectionError::Network(format!("Failed to create HTTP client: {e}"))
+        })?;
 
         let query_body = serde_json::json!({
             "query": INTROSPECTION_QUERY

--- a/crates/introspect/src/query.rs
+++ b/crates/introspect/src/query.rs
@@ -1,6 +1,7 @@
 //! GraphQL introspection query execution.
 
 use crate::{IntrospectionError, IntrospectionResponse, Result};
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 /// Standard GraphQL introspection query.
@@ -144,9 +145,12 @@ fragment TypeRef on __Type {
 #[tracing::instrument]
 pub async fn execute_introspection(url: &str) -> Result<IntrospectionResponse> {
     tracing::debug!("Creating HTTP client with timeouts");
-    let client = reqwest::Client::builder()
+    let builder = reqwest::Client::builder();
+    #[cfg(not(target_arch = "wasm32"))]
+    let builder = builder
         .timeout(Duration::from_secs(30))
-        .connect_timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(10));
+    let client = builder
         .build()
         .map_err(|e| IntrospectionError::Network(format!("Failed to create HTTP client: {e}")))?;
 

--- a/crates/linter/Cargo.toml
+++ b/crates/linter/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 [dependencies]
 # Internal dependencies - NEW ARCHITECTURE
 graphql-base-db = { path = "../base-db" }
-graphql-syntax = { path = "../syntax" }
-graphql-hir = { path = "../hir" }
+graphql-syntax = { path = "../syntax", default-features = false }
+graphql-hir = { path = "../hir", default-features = false }
 graphql-apollo-ext = { path = "../apollo-ext" }
 
 # GraphQL parsing
@@ -26,6 +26,11 @@ serde_json = { workspace = true }
 
 # Logging
 tracing = "0.1"
+
+[features]
+default = ["extract"]
+extract = ["graphql-syntax/extract", "graphql-hir/extract"]
+native = ["graphql-syntax/native", "graphql-hir/native"]
 
 [dev-dependencies]
 serde-saphyr = { workspace = true }

--- a/crates/lsp-wasm/Cargo.toml
+++ b/crates/lsp-wasm/Cargo.toml
@@ -23,5 +23,9 @@ console_error_panic_hook = "0.1"
 tracing = { workspace = true }
 tracing-wasm = "0.2"
 
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/lsp-wasm/Cargo.toml
+++ b/crates/lsp-wasm/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "graphql-lsp-wasm"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Wasm bindings for the GraphQL language server"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+graphql-lsp = { path = "../lsp", default-features = false, features = ["wasm", "introspect"] }
+lsp-server = { workspace = true }
+lsp-types = { workspace = true }
+crossbeam-channel = { workspace = true }
+serde_json = { workspace = true }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+console_error_panic_hook = "0.1"
+tracing = { workspace = true }
+tracing-wasm = "0.2"
+
+[lints]
+workspace = true

--- a/crates/lsp-wasm/src/lib.rs
+++ b/crates/lsp-wasm/src/lib.rs
@@ -22,7 +22,10 @@ impl Server {
     pub fn new() -> Self {
         let (inbound_tx, inbound_rx) = crossbeam_channel::unbounded::<Message>();
         let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<Message>();
-        let connection = Connection { sender: outbound_tx, receiver: inbound_rx };
+        let connection = Connection {
+            sender: outbound_tx,
+            receiver: inbound_rx,
+        };
         let dispatcher: Box<dyn graphql_lsp::TaskDispatcher> =
             Box::new(graphql_lsp::InlineDispatcher);
         let (intro_req_tx, _) = crossbeam_channel::unbounded();
@@ -33,15 +36,20 @@ impl Server {
             intro_req_tx,
             intro_res_rx,
         );
-        Server { connection, state, inbound: inbound_tx, outbound: outbound_rx }
+        Server {
+            connection,
+            state,
+            inbound: inbound_tx,
+            outbound: outbound_rx,
+        }
     }
 
     /// Feed an inbound LSP JSON-RPC message (already unframed). Returns an array
     /// of outbound JSON strings the worker should write back to the client.
     #[wasm_bindgen(js_name = handleMessage)]
     pub fn handle_message(&mut self, json: &str) -> Result<js_sys::Array, JsValue> {
-        let msg: Message = serde_json::from_str(json)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let msg: Message =
+            serde_json::from_str(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
         // The `initialize` request is handled outside the normal dispatch loop
         // (native does it via Connection::initialize before the loop).
@@ -60,7 +68,9 @@ impl Server {
             }
         }
 
-        self.inbound.send(msg).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        self.inbound
+            .send(msg)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
         let _ = graphql_lsp::tick(&self.connection, &mut self.state);
         self.collect_outbound()
     }
@@ -68,8 +78,7 @@ impl Server {
     fn collect_outbound(&mut self) -> Result<js_sys::Array, JsValue> {
         let arr = js_sys::Array::new();
         while let Ok(out) = self.outbound.try_recv() {
-            let s = serde_json::to_string(&out)
-                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            let s = serde_json::to_string(&out).map_err(|e| JsValue::from_str(&e.to_string()))?;
             arr.push(&JsValue::from_str(&s));
         }
         Ok(arr)
@@ -107,8 +116,7 @@ impl Server {
                 version: Some(env!("CARGO_PKG_VERSION").to_string()),
             }),
         };
-        let value = serde_json::to_value(&result)
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let value = serde_json::to_value(&result).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let response = lsp_server::Response::new_ok(id, value);
         let out = serde_json::to_string(&Message::Response(response))
             .map_err(|e| JsValue::from_str(&e.to_string()))?;

--- a/crates/lsp-wasm/src/lib.rs
+++ b/crates/lsp-wasm/src/lib.rs
@@ -1,4 +1,5 @@
 use lsp_server::{Connection, Message};
+use std::path::Path;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
@@ -41,8 +42,30 @@ impl Server {
     pub fn handle_message(&mut self, json: &str) -> Result<js_sys::Array, JsValue> {
         let msg: Message = serde_json::from_str(json)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        // The `initialize` request is handled outside the normal dispatch loop
+        // (native does it via Connection::initialize before the loop).
+        // For wasm, intercept it here and respond directly.
+        if let Message::Request(ref req) = msg {
+            if req.method == "initialize" {
+                return self.handle_initialize(req.id.clone(), req.params.clone());
+            }
+        }
+
+        // The `initialized` notification triggers workspace bootstrap.
+        if let Message::Notification(ref not) = msg {
+            if not.method == "initialized" {
+                self.handle_initialized();
+                // Still push through tick so any state side-effects run.
+            }
+        }
+
         self.inbound.send(msg).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let _ = graphql_lsp::tick(&self.connection, &mut self.state);
+        self.collect_outbound()
+    }
+
+    fn collect_outbound(&mut self) -> Result<js_sys::Array, JsValue> {
         let arr = js_sys::Array::new();
         while let Ok(out) = self.outbound.try_recv() {
             let s = serde_json::to_string(&out)
@@ -50,6 +73,54 @@ impl Server {
             arr.push(&JsValue::from_str(&s));
         }
         Ok(arr)
+    }
+
+    fn handle_initialize(
+        &mut self,
+        id: lsp_server::RequestId,
+        params: serde_json::Value,
+    ) -> Result<js_sys::Array, JsValue> {
+        // Parse and store client capabilities + initializationOptions.
+        if let Ok(init_params) = serde_json::from_value::<lsp_types::InitializeParams>(params) {
+            self.state.client_capabilities = Some(init_params.capabilities);
+
+            if let Some(init_options) = init_params.initialization_options {
+                // Workspace root is virtual under wasm; use "inmemory://" as the root.
+                let workspace_uri = "inmemory://";
+                let workspace_path = Path::new("/");
+                if let Err(e) = graphql_lsp::install_workspace_from_init_options(
+                    &mut self.state,
+                    workspace_uri,
+                    workspace_path,
+                    init_options,
+                ) {
+                    tracing::warn!("failed to install workspace from init options: {e}");
+                }
+            }
+        }
+
+        let caps = graphql_lsp::build_server_capabilities();
+        let result = lsp_types::InitializeResult {
+            capabilities: caps,
+            server_info: Some(lsp_types::ServerInfo {
+                name: "graphql-analyzer".to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        };
+        let value = serde_json::to_value(&result)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let response = lsp_server::Response::new_ok(id, value);
+        let out = serde_json::to_string(&Message::Response(response))
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let arr = js_sys::Array::new();
+        arr.push(&JsValue::from_str(&out));
+        Ok(arr)
+    }
+
+    fn handle_initialized(&mut self) {
+        // After the handshake, load all files covered by the workspace config
+        // so diagnostics fire on didOpen.
+        graphql_lsp::load_wasm_workspace(&mut self.state);
     }
 }
 

--- a/crates/lsp-wasm/src/lib.rs
+++ b/crates/lsp-wasm/src/lib.rs
@@ -1,0 +1,60 @@
+use lsp_server::{Connection, Message};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default();
+}
+
+#[wasm_bindgen]
+pub struct Server {
+    connection: Connection,
+    state: graphql_lsp::GlobalState,
+    inbound: crossbeam_channel::Sender<Message>,
+    outbound: crossbeam_channel::Receiver<Message>,
+}
+
+#[wasm_bindgen]
+impl Server {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        let (inbound_tx, inbound_rx) = crossbeam_channel::unbounded::<Message>();
+        let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<Message>();
+        let connection = Connection { sender: outbound_tx, receiver: inbound_rx };
+        let dispatcher: Box<dyn graphql_lsp::TaskDispatcher> =
+            Box::new(graphql_lsp::InlineDispatcher);
+        let (intro_req_tx, _) = crossbeam_channel::unbounded();
+        let (_, intro_res_rx) = crossbeam_channel::unbounded();
+        let state = graphql_lsp::GlobalState::new(
+            connection.sender.clone(),
+            dispatcher,
+            intro_req_tx,
+            intro_res_rx,
+        );
+        Server { connection, state, inbound: inbound_tx, outbound: outbound_rx }
+    }
+
+    /// Feed an inbound LSP JSON-RPC message (already unframed). Returns an array
+    /// of outbound JSON strings the worker should write back to the client.
+    #[wasm_bindgen(js_name = handleMessage)]
+    pub fn handle_message(&mut self, json: &str) -> Result<js_sys::Array, JsValue> {
+        let msg: Message = serde_json::from_str(json)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        self.inbound.send(msg).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let _ = graphql_lsp::tick(&self.connection, &mut self.state);
+        let arr = js_sys::Array::new();
+        while let Ok(out) = self.outbound.try_recv() {
+            let s = serde_json::to_string(&out)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            arr.push(&JsValue::from_str(&s));
+        }
+        Ok(arr)
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/lsp-wasm/src/lib.rs
+++ b/crates/lsp-wasm/src/lib.rs
@@ -19,6 +19,7 @@ pub struct Server {
 #[wasm_bindgen]
 impl Server {
     #[wasm_bindgen(constructor)]
+    #[must_use]
     pub fn new() -> Self {
         let (inbound_tx, inbound_rx) = crossbeam_channel::unbounded::<Message>();
         let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<Message>();

--- a/crates/lsp-wasm/tests/initialize.rs
+++ b/crates/lsp-wasm/tests/initialize.rs
@@ -1,0 +1,32 @@
+use wasm_bindgen_test::*;
+wasm_bindgen_test_configure!(run_in_browser);
+
+// Runtime verification of `initialize` requires the wasm-side handshake bootstrap
+// that `tick` doesn't yet handle (native path uses `Connection::initialize` outside
+// the dispatch loop). This compiles to catch wasm-side type errors; the actual
+// round-trip will be exercised via Playwright e2e once the handshake is wired up.
+#[wasm_bindgen_test]
+#[ignore]
+fn initialize_roundtrip() {
+    let mut server = graphql_lsp_wasm::Server::new();
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "capabilities": {},
+            "processId": null,
+            "rootUri": null,
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "schema": "schema.graphql",
+                "documents": ["**/*.graphql"]
+            }
+        }
+    })
+    .to_string();
+    let outbound = server.handle_message(&init).unwrap();
+    assert_eq!(outbound.length(), 1, "expected one response");
+    let resp_str: String = outbound.get(0).as_string().unwrap();
+    assert!(resp_str.contains("\"capabilities\""));
+}

--- a/crates/lsp-wasm/tests/initialize.rs
+++ b/crates/lsp-wasm/tests/initialize.rs
@@ -1,10 +1,9 @@
 use wasm_bindgen_test::*;
 wasm_bindgen_test_configure!(run_in_browser);
 
-// Runtime verification of `initialize` requires the wasm-side handshake bootstrap
-// that `tick` doesn't yet handle (native path uses `Connection::initialize` outside
-// the dispatch loop). This compiles to catch wasm-side type errors; the actual
-// round-trip will be exercised via Playwright e2e once the handshake is wired up.
+// Logically correct but requires `wasm-pack test --headless --chrome` to run.
+// Playwright e2e provides equivalent coverage until that infrastructure is wired
+// into CI.
 #[wasm_bindgen_test]
 #[ignore]
 fn initialize_roundtrip() {

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "graphql-lsp"
 path = "src/main.rs"
+required-features = ["native"]
 
 [dependencies]
 # Internal deps (unconditional)
@@ -80,7 +81,7 @@ native = [
     "extract",
     "introspect",
 ]
-wasm = []
+wasm = [] # Placeholder for future wasm-only deps (tracing-wasm, etc.); current gating uses not(feature = "native")
 extract = ["dep:graphql-extract", "graphql-ide/extract", "graphql-syntax/extract"]
 introspect = ["dep:graphql-introspect", "graphql-ide/introspect"]
 

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -18,26 +18,28 @@ name = "graphql-lsp"
 path = "src/main.rs"
 
 [dependencies]
-# Internal dependencies
+# Internal deps (unconditional)
 graphql-linter = { path = "../linter" }
 graphql-config = { path = "../config" }
-graphql-extract = { path = "../extract" }
-graphql-ide = { path = "../ide" }
-graphql-syntax = { path = "../syntax" }
-graphql-introspect = { path = "../introspect" }
+graphql-ide = { path = "../ide", default-features = false }
+graphql-syntax = { path = "../syntax", default-features = false }
 
-# GraphQL
+# Optional based on feature
+graphql-extract = { path = "../extract", optional = true }
+graphql-introspect = { path = "../introspect", optional = true }
+
+# GraphQL (unconditional, both targets need parsing)
 apollo-compiler = { workspace = true }
 apollo-parser = { workspace = true }
 
-# LSP (sync server + types)
+# LSP transport
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
 crossbeam-channel = { workspace = true }
-threadpool = { workspace = true }
+threadpool = { workspace = true, optional = true }
 
-# Async - retained only for introspection HTTP calls
-tokio = { workspace = true, features = ["rt"] }
+# Async (introspection only)
+tokio = { workspace = true, features = ["rt"], optional = true }
 
 # Utilities
 serde = { workspace = true }
@@ -45,21 +47,42 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 
-# Logging and Tracing
+# Tracing (subset on wasm)
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing-chrome = "0.7"
-tracing-opentelemetry = { workspace = true }
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
-opentelemetry-semantic-conventions = { workspace = true }
+tracing-chrome = { version = "0.7", optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"], optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
 
-url = "2"
-glob.workspace = true
+# Native-only fs-related
+url = { version = "2", optional = true }
+glob = { workspace = true, optional = true }
 
 [build-dependencies]
 vergen-git2 = { version = "9.1", features = ["build", "cargo"] }
+
+[features]
+default = ["native"]
+native = [
+    "dep:threadpool",
+    "dep:tokio",
+    "dep:tracing-chrome",
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:url",
+    "dep:glob",
+    "extract",
+    "introspect",
+]
+wasm = []
+extract = ["dep:graphql-extract", "graphql-ide/extract", "graphql-syntax/extract"]
+introspect = ["dep:graphql-introspect", "graphql-ide/introspect"]
 
 [lints]
 workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["native"]
 
 [dependencies]
 # Internal deps (unconditional)
-graphql-linter = { path = "../linter" }
+graphql-linter = { path = "../linter", default-features = false }
 graphql-config = { path = "../config" }
 graphql-ide = { path = "../ide", default-features = false }
 graphql-syntax = { path = "../syntax", default-features = false }
@@ -82,7 +82,7 @@ native = [
     "introspect",
 ]
 wasm = [] # Placeholder for future wasm-only deps (tracing-wasm, etc.); current gating uses not(feature = "native")
-extract = ["dep:graphql-extract", "graphql-ide/extract", "graphql-syntax/extract"]
+extract = ["dep:graphql-extract", "graphql-ide/extract", "graphql-syntax/extract", "graphql-linter/extract"]
 introspect = ["dep:graphql-introspect", "graphql-ide/introspect"]
 
 [lints]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -55,9 +55,7 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = { workspace = true }
 
-# Temp files for TypeScript extraction
 url = "2"
-tempfile = "3.0"
 glob.workspace = true
 
 [build-dependencies]

--- a/crates/lsp/src/conversions.rs
+++ b/crates/lsp/src/conversions.rs
@@ -6,6 +6,7 @@
 //!
 //! These conversions are stateless and can be used from any LSP handler.
 
+#[cfg(feature = "native")]
 use std::path::PathBuf;
 
 use lsp_types::{
@@ -21,6 +22,7 @@ use lsp_types::{
 ///
 /// Delegates to the `url` crate for correct percent-decoding (including
 /// multi-byte UTF-8) and Windows drive-letter handling.
+#[cfg(feature = "native")]
 pub fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
     let url = url::Url::parse(uri.as_str()).ok()?;
     url.to_file_path().ok()

--- a/crates/lsp/src/dispatch.rs
+++ b/crates/lsp/src/dispatch.rs
@@ -171,7 +171,12 @@ mod tests {
         let (msg_sender, msg_receiver) = unbounded::<Message>();
         let (intro_req_sender, _intro_req_receiver) = unbounded();
         let (_intro_res_sender, intro_res_receiver) = unbounded();
-        let state = GlobalState::new(msg_sender, Box::new(crate::global_state::InlineDispatcher), intro_req_sender, intro_res_receiver);
+        let state = GlobalState::new(
+            msg_sender,
+            Box::new(crate::global_state::InlineDispatcher),
+            intro_req_sender,
+            intro_res_receiver,
+        );
         (state, msg_receiver)
     }
 

--- a/crates/lsp/src/dispatch.rs
+++ b/crates/lsp/src/dispatch.rs
@@ -171,7 +171,7 @@ mod tests {
         let (msg_sender, msg_receiver) = unbounded::<Message>();
         let (intro_req_sender, _intro_req_receiver) = unbounded();
         let (_intro_res_sender, intro_res_receiver) = unbounded();
-        let state = GlobalState::new(msg_sender, intro_req_sender, intro_res_receiver);
+        let state = GlobalState::new(msg_sender, Box::new(crate::global_state::InlineDispatcher), intro_req_sender, intro_res_receiver);
         (state, msg_receiver)
     }
 

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "native"))]
 mod dispatcher_tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -259,7 +259,12 @@ mod tests {
         let (msg_sender, _msg_receiver) = unbounded();
         let (intro_req_sender, _intro_req_receiver) = unbounded();
         let (_intro_res_sender, intro_res_receiver) = unbounded();
-        GlobalState::new(msg_sender, Box::new(InlineDispatcher), intro_req_sender, intro_res_receiver)
+        GlobalState::new(
+            msg_sender,
+            Box::new(InlineDispatcher),
+            intro_req_sender,
+            intro_res_receiver,
+        )
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -6,13 +6,10 @@ use lsp_types::Uri;
 
 use crate::workspace::WorkspaceManager;
 
-#[allow(dead_code)]
 pub trait TaskDispatcher: Send + Sync {
     fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>);
 }
 
-// Task 6 will wire GlobalState to use this in place of its bare ThreadPool field.
-#[allow(dead_code)]
 pub struct ThreadPoolDispatcher(threadpool::ThreadPool);
 
 impl TaskDispatcher for ThreadPoolDispatcher {
@@ -22,7 +19,6 @@ impl TaskDispatcher for ThreadPoolDispatcher {
 }
 
 impl ThreadPoolDispatcher {
-    #[allow(dead_code)]
     pub fn new(pool: threadpool::ThreadPool) -> Self {
         Self(pool)
     }
@@ -45,7 +41,7 @@ impl TaskDispatcher for InlineDispatcher {
 /// instead.
 pub struct GlobalState {
     pub sender: Sender<Message>,
-    pub threadpool: threadpool::ThreadPool,
+    pub dispatcher: Box<dyn TaskDispatcher>,
     pub workspace: WorkspaceManager,
     pub client_capabilities: Option<lsp_types::ClientCapabilities>,
     pub trace_capture: Option<crate::trace_capture::TraceCaptureManager>,
@@ -105,6 +101,7 @@ pub struct GlobalStateSnapshot {
 impl GlobalState {
     pub fn new(
         sender: Sender<Message>,
+        dispatcher: Box<dyn TaskDispatcher>,
         introspection_request_sender: Sender<IntrospectionRequest>,
         introspection_result_receiver: crossbeam_channel::Receiver<IntrospectionResult>,
     ) -> Self {
@@ -112,7 +109,7 @@ impl GlobalState {
 
         Self {
             sender,
-            threadpool: threadpool::ThreadPool::with_name("salsa-worker".into(), num_cpus()),
+            dispatcher,
             workspace: WorkspaceManager::new(),
             client_capabilities: None,
             trace_capture: None,
@@ -183,7 +180,7 @@ impl GlobalState {
         };
 
         let task_sender = self.task_sender.clone();
-        self.threadpool.execute(move || {
+        self.dispatcher.execute(Box::new(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(snap)));
             let response = match result {
                 Ok(value) => lsp_server::Response::new_ok(id, value),
@@ -196,7 +193,7 @@ impl GlobalState {
             let _ = task_sender.send(Task {
                 response: TaskResponse::Response(response),
             });
-        });
+        }));
     }
 
     /// Spawn a diagnostics computation for a single URI, tagged with the next
@@ -215,7 +212,7 @@ impl GlobalState {
         let captured_seq = *seq;
 
         let task_sender = self.task_sender.clone();
-        self.threadpool.execute(move || {
+        self.dispatcher.execute(Box::new(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
             if let Ok(diagnostics) = result {
                 let _ = task_sender.send(Task {
@@ -226,7 +223,7 @@ impl GlobalState {
                     },
                 });
             }
-        });
+        }));
     }
 
     /// Spawn a multi-URI diagnostics computation (e.g. project-wide on save).
@@ -236,21 +233,15 @@ impl GlobalState {
         F: FnOnce() -> Vec<(Uri, Vec<lsp_types::Diagnostic>)> + Send + 'static,
     {
         let task_sender = self.task_sender.clone();
-        self.threadpool.execute(move || {
+        self.dispatcher.execute(Box::new(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
             if let Ok(diagnostics) = result {
                 let _ = task_sender.send(Task {
                     response: TaskResponse::PublishDiagnosticsBatch(diagnostics),
                 });
             }
-        });
+        }));
     }
-}
-
-fn num_cpus() -> usize {
-    std::thread::available_parallelism()
-        .map(usize::from)
-        .unwrap_or(4)
 }
 
 #[cfg(test)]
@@ -265,7 +256,7 @@ mod tests {
         let (msg_sender, _msg_receiver) = unbounded();
         let (intro_req_sender, _intro_req_receiver) = unbounded();
         let (_intro_res_sender, intro_res_receiver) = unbounded();
-        GlobalState::new(msg_sender, intro_req_sender, intro_res_receiver)
+        GlobalState::new(msg_sender, Box::new(InlineDispatcher), intro_req_sender, intro_res_receiver)
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -6,6 +6,31 @@ use lsp_types::Uri;
 
 use crate::workspace::WorkspaceManager;
 
+#[allow(dead_code)]
+pub trait TaskDispatcher: Send + Sync {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>);
+}
+
+// Task 6 will wire GlobalState to use this in place of its bare ThreadPool field.
+#[allow(dead_code)]
+pub struct ThreadPoolDispatcher(pub threadpool::ThreadPool);
+
+impl TaskDispatcher for ThreadPoolDispatcher {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
+        self.0.execute(work);
+    }
+}
+
+// Used by the wasm target (no threads) and by tests; native always uses ThreadPoolDispatcher.
+#[allow(dead_code)]
+pub struct InlineDispatcher;
+
+impl TaskDispatcher for InlineDispatcher {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
+        work();
+    }
+}
+
 /// Owns all mutable server state. Lives exclusively on the main thread.
 ///
 /// Since the main thread is the only writer, no locks are needed for any
@@ -252,5 +277,42 @@ mod tests {
         assert_eq!(state.diagnostics_seq.get(b.as_str()).copied(), Some(1));
         // Independent counters: bumping b doesn't move a.
         assert_eq!(state.diagnostics_seq.get(a.as_str()).copied(), Some(2));
+    }
+}
+
+#[cfg(test)]
+mod dispatcher_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn inline_dispatcher_runs_work_synchronously() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let dispatcher = InlineDispatcher;
+        let c = Arc::clone(&counter);
+        dispatcher.execute(Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn threadpool_dispatcher_runs_work_eventually() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let pool = threadpool::ThreadPool::with_name("test".into(), 2);
+        let dispatcher = ThreadPoolDispatcher(pool);
+        let c = Arc::clone(&counter);
+        dispatcher.execute(Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        // Drain the pool by joining; trait doesn't expose join so we sleep+poll.
+        for _ in 0..100 {
+            if counter.load(Ordering::SeqCst) == 1 {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!("threadpool dispatcher never ran the task");
     }
 }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -13,11 +13,18 @@ pub trait TaskDispatcher: Send + Sync {
 
 // Task 6 will wire GlobalState to use this in place of its bare ThreadPool field.
 #[allow(dead_code)]
-pub struct ThreadPoolDispatcher(pub threadpool::ThreadPool);
+pub struct ThreadPoolDispatcher(threadpool::ThreadPool);
 
 impl TaskDispatcher for ThreadPoolDispatcher {
     fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
         self.0.execute(work);
+    }
+}
+
+impl ThreadPoolDispatcher {
+    #[allow(dead_code)]
+    pub fn new(pool: threadpool::ThreadPool) -> Self {
+        Self(pool)
     }
 }
 
@@ -301,7 +308,7 @@ mod dispatcher_tests {
     fn threadpool_dispatcher_runs_work_eventually() {
         let counter = Arc::new(AtomicUsize::new(0));
         let pool = threadpool::ThreadPool::with_name("test".into(), 2);
-        let dispatcher = ThreadPoolDispatcher(pool);
+        let dispatcher = ThreadPoolDispatcher::new(pool);
         let c = Arc::clone(&counter);
         dispatcher.execute(Box::new(move || {
             c.fetch_add(1, Ordering::SeqCst);

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -102,6 +102,7 @@ pub struct GlobalStateSnapshot {
 }
 
 impl GlobalState {
+    #[must_use]
     pub fn new(
         sender: Sender<Message>,
         dispatcher: Box<dyn TaskDispatcher>,

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -10,14 +10,17 @@ pub trait TaskDispatcher: Send + Sync {
     fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>);
 }
 
+#[cfg(feature = "native")]
 pub struct ThreadPoolDispatcher(threadpool::ThreadPool);
 
+#[cfg(feature = "native")]
 impl TaskDispatcher for ThreadPoolDispatcher {
     fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
         self.0.execute(work);
     }
 }
 
+#[cfg(feature = "native")]
 impl ThreadPoolDispatcher {
     pub fn new(pool: threadpool::ThreadPool) -> Self {
         Self(pool)

--- a/crates/lsp/src/handlers/document_sync.rs
+++ b/crates/lsp/src/handlers/document_sync.rs
@@ -2,12 +2,15 @@
 
 use crate::conversions::convert_ide_diagnostic;
 use crate::global_state::GlobalState;
+#[cfg(feature = "native")]
 use crate::loading;
 use graphql_ide::{DocumentKind, Language};
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, FileChangeType, Uri,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, Uri,
 };
+#[cfg(feature = "native")]
+use lsp_types::FileChangeType;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -192,58 +195,66 @@ pub(crate) fn handle_did_change_watched_files(
     state: &mut GlobalState,
     params: DidChangeWatchedFilesParams,
 ) {
-    tracing::debug!("Watched files changed: {} file(s)", params.changes.len());
+    #[cfg(feature = "native")]
+    {
+        tracing::debug!("Watched files changed: {} file(s)", params.changes.len());
 
-    for change in params.changes {
-        let uri = change.uri;
-        tracing::debug!("File changed: {} (type: {:?})", uri.path(), change.typ);
+        for change in params.changes {
+            let uri = change.uri;
+            tracing::debug!("File changed: {} (type: {:?})", uri.path(), change.typ);
 
-        let Some(config_path) = crate::conversions::uri_to_file_path(&uri) else {
-            tracing::warn!("Failed to convert URI to file path: {:?}", uri);
-            continue;
-        };
+            let Some(config_path) = crate::conversions::uri_to_file_path(&uri) else {
+                tracing::warn!("Failed to convert URI to file path: {:?}", uri);
+                continue;
+            };
 
-        let workspace_uri: Option<String> = state
-            .workspace
-            .config_paths
-            .iter()
-            .find(|(_, path)| **path == config_path)
-            .map(|(ws_uri, _)| ws_uri.clone());
+            let workspace_uri: Option<String> = state
+                .workspace
+                .config_paths
+                .iter()
+                .find(|(_, path)| **path == config_path)
+                .map(|(ws_uri, _)| ws_uri.clone());
 
-        if let Some(workspace_uri) = workspace_uri {
-            match change.typ {
-                FileChangeType::CREATED | FileChangeType::CHANGED => {
-                    tracing::info!("Config file changed for workspace: {}", workspace_uri);
-                    loading::reload_workspace_config(state, &workspace_uri);
+            if let Some(workspace_uri) = workspace_uri {
+                match change.typ {
+                    FileChangeType::CREATED | FileChangeType::CHANGED => {
+                        tracing::info!("Config file changed for workspace: {}", workspace_uri);
+                        loading::reload_workspace_config(state, &workspace_uri);
+                    }
+                    FileChangeType::DELETED => {
+                        tracing::warn!("Config file deleted for workspace: {}", workspace_uri);
+                        state.send_notification::<lsp_types::notification::ShowMessage>(
+                            lsp_types::ShowMessageParams {
+                                typ: lsp_types::MessageType::WARNING,
+                                message: "GraphQL config file was deleted".to_owned(),
+                            },
+                        );
+                    }
+                    _ => {}
                 }
-                FileChangeType::DELETED => {
-                    tracing::warn!("Config file deleted for workspace: {}", workspace_uri);
-                    state.send_notification::<lsp_types::notification::ShowMessage>(
-                        lsp_types::ShowMessageParams {
-                            typ: lsp_types::MessageType::WARNING,
-                            message: "GraphQL config file was deleted".to_owned(),
-                        },
-                    );
-                }
-                _ => {}
+                continue;
             }
-            continue;
-        }
 
-        let resolved_match: Option<(String, String)> = state
-            .workspace
-            .resolved_schema_paths
-            .iter()
-            .find(|(_, path)| **path == config_path)
-            .map(|((ws, proj), _)| (ws.clone(), proj.clone()));
+            let resolved_match: Option<(String, String)> = state
+                .workspace
+                .resolved_schema_paths
+                .iter()
+                .find(|(_, path)| **path == config_path)
+                .map(|((ws, proj), _)| (ws.clone(), proj.clone()));
 
-        if let Some((ws_uri, proj_name)) = resolved_match {
-            if matches!(
-                change.typ,
-                FileChangeType::CREATED | FileChangeType::CHANGED
-            ) {
-                loading::reload_resolved_schema(state, &ws_uri, &proj_name, &config_path);
+            if let Some((ws_uri, proj_name)) = resolved_match {
+                if matches!(
+                    change.typ,
+                    FileChangeType::CREATED | FileChangeType::CHANGED
+                ) {
+                    loading::reload_resolved_schema(state, &ws_uri, &proj_name, &config_path);
+                }
             }
         }
     }
+
+    // Under wasm the server has no access to the host filesystem, so watched-file
+    // notifications are a no-op. Config loading happens via init options instead.
+    #[cfg(not(feature = "native"))]
+    let _ = (state, params);
 }

--- a/crates/lsp/src/handlers/document_sync.rs
+++ b/crates/lsp/src/handlers/document_sync.rs
@@ -5,12 +5,12 @@ use crate::global_state::GlobalState;
 #[cfg(feature = "native")]
 use crate::loading;
 use graphql_ide::{DocumentKind, Language};
+#[cfg(feature = "native")]
+use lsp_types::FileChangeType;
 use lsp_types::{
     DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, Uri,
 };
-#[cfg(feature = "native")]
-use lsp_types::FileChangeType;
 use std::path::Path;
 use std::str::FromStr;
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -4,7 +4,6 @@
 //! server communicating over stdio. It uses a sync main loop with a thread pool
 //! for Salsa query execution.
 
-
 mod conversions;
 mod dispatch;
 mod global_state;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -22,6 +22,8 @@ pub(crate) mod server;
 pub mod trace_capture;
 mod workspace;
 
+pub use crate::loading::install_workspace_from_init_options;
+
 use std::path::PathBuf;
 
 use lsp_types::{

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -22,7 +22,9 @@ pub(crate) mod server;
 pub mod trace_capture;
 mod workspace;
 
+pub use crate::global_state::{GlobalState, InlineDispatcher, TaskDispatcher};
 pub use crate::loading::install_workspace_from_init_options;
+pub use crate::main_loop::{tick, ControlFlow};
 
 use std::path::PathBuf;
 
@@ -39,7 +41,6 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 
-use global_state::GlobalState;
 use server::{StatusNotification, StatusParams};
 
 /// Build a tracing `EnvFilter`, always suppressing Salsa's internal logs
@@ -261,7 +262,7 @@ fn build_server_capabilities() -> ServerCapabilities {
     }
 }
 
-#[cfg(feature = "introspect")]
+#[cfg(feature = "native")]
 fn spawn_introspection_thread(
     request_receiver: crossbeam_channel::Receiver<global_state::IntrospectionRequest>,
     result_sender: crossbeam_channel::Sender<global_state::IntrospectionResult>,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -4,6 +4,10 @@
 //! server communicating over stdio. It uses a sync main loop with a thread pool
 //! for Salsa query execution.
 
+// Under wasm, the native entrypoint (`run_server`) is gated out, so most items
+// appear dead until the wasm entrypoint (Task 10) provides a caller.
+#![cfg_attr(not(feature = "native"), allow(dead_code, unused_imports))]
+
 mod conversions;
 mod dispatch;
 mod global_state;
@@ -45,6 +49,7 @@ fn build_env_filter(default: &str) -> tracing_subscriber::EnvFilter {
 }
 
 /// Initialize tracing with OpenTelemetry support.
+#[cfg(feature = "native")]
 fn init_tracing_with_otel() -> Option<trace_capture::ReloadHandle> {
     use opentelemetry::trace::TracerProvider;
     use opentelemetry_otlp::WithExportConfig;
@@ -134,6 +139,7 @@ fn init_tracing_without_otel() -> Option<trace_capture::ReloadHandle> {
 
 #[must_use]
 pub fn init_tracing() -> Option<trace_capture::ReloadHandle> {
+    #[cfg(feature = "native")]
     if std::env::var("OTEL_TRACES_ENABLED").is_ok() {
         return init_tracing_with_otel();
     }
@@ -249,6 +255,7 @@ fn build_server_capabilities() -> ServerCapabilities {
     }
 }
 
+#[cfg(feature = "introspect")]
 fn spawn_introspection_thread(
     request_receiver: crossbeam_channel::Receiver<global_state::IntrospectionRequest>,
     result_sender: crossbeam_channel::Sender<global_state::IntrospectionResult>,
@@ -294,6 +301,7 @@ fn spawn_introspection_thread(
         .expect("spawn introspection thread");
 }
 
+#[cfg(feature = "native")]
 fn handle_initialized(state: &mut GlobalState) {
     let version = env!("CARGO_PKG_VERSION");
     let git_sha = option_env!("VERGEN_GIT_SHA").unwrap_or("unknown");
@@ -357,6 +365,7 @@ fn handle_initialized(state: &mut GlobalState) {
     register_file_watchers(state);
 }
 
+#[cfg(feature = "native")]
 fn register_file_watchers(state: &GlobalState) {
     use lsp_types::FileSystemWatcher;
 
@@ -415,6 +424,7 @@ fn register_file_watchers(state: &GlobalState) {
 }
 
 /// Run the GraphQL language server over stdio.
+#[cfg(feature = "native")]
 pub fn run_server() {
     let reload_handle = init_tracing();
     install_panic_hook();

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -26,6 +26,10 @@ pub use crate::global_state::{GlobalState, InlineDispatcher, TaskDispatcher};
 pub use crate::loading::install_workspace_from_init_options;
 pub use crate::main_loop::{tick, ControlFlow};
 
+/// No-op workspace bootstrap for the wasm path; documents are loaded
+/// lazily via `textDocument/didOpen` notifications instead.
+pub fn load_wasm_workspace(_state: &mut GlobalState) {}
+
 use std::path::PathBuf;
 
 use lsp_types::{
@@ -183,7 +187,7 @@ pub fn install_panic_hook() {
     }));
 }
 
-fn build_server_capabilities() -> ServerCapabilities {
+pub fn build_server_capabilities() -> ServerCapabilities {
     use lsp_types::CodeLensOptions;
 
     ServerCapabilities {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -181,6 +181,7 @@ pub fn install_panic_hook() {
     }));
 }
 
+#[must_use]
 pub fn build_server_capabilities() -> ServerCapabilities {
     use lsp_types::CodeLensOptions;
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -477,7 +477,7 @@ pub fn run_server() {
 
     handle_initialized(&mut state);
 
-    main_loop::main_loop(&connection, &mut state);
+    main_loop::run(&connection, &mut state);
 
     // Drop the state before joining IO threads to close channels
     drop(state);

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -6,6 +6,10 @@
 
 // Under wasm, the native entrypoint (`run_server`) is gated out, so most items
 // appear dead until the wasm entrypoint (Task 10) provides a caller.
+// This suppression should be removed once the wasm entrypoint in Task 10
+// (`crates/lsp-wasm`) provides a caller that reaches this crate's public API.
+// After Task 10 lands, verify removal:
+//   cargo check -p graphql-lsp --no-default-features --features wasm
 #![cfg_attr(not(feature = "native"), allow(dead_code, unused_imports))]
 
 mod conversions;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -4,13 +4,6 @@
 //! server communicating over stdio. It uses a sync main loop with a thread pool
 //! for Salsa query execution.
 
-// Under wasm, the native entrypoint (`run_server`) is gated out, so most items
-// appear dead until the wasm entrypoint (Task 10) provides a caller.
-// This suppression should be removed once the wasm entrypoint in Task 10
-// (`crates/lsp-wasm`) provides a caller that reaches this crate's public API.
-// After Task 10 lands, verify removal:
-//   cargo check -p graphql-lsp --no-default-features --features wasm
-#![cfg_attr(not(feature = "native"), allow(dead_code, unused_imports))]
 
 mod conversions;
 mod dispatch;
@@ -30,6 +23,7 @@ pub use crate::main_loop::{tick, ControlFlow};
 /// lazily via `textDocument/didOpen` notifications instead.
 pub fn load_wasm_workspace(_state: &mut GlobalState) {}
 
+#[cfg(feature = "native")]
 use std::path::PathBuf;
 
 use lsp_types::{
@@ -45,6 +39,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 
+#[cfg(feature = "native")]
 use server::{StatusNotification, StatusParams};
 
 /// Build a tracing `EnvFilter`, always suppressing Salsa's internal logs
@@ -464,12 +459,10 @@ pub fn run_server() {
     let (introspection_result_sender, introspection_result_receiver) =
         crossbeam_channel::unbounded();
 
-    let dispatcher: Box<dyn global_state::TaskDispatcher> = Box::new(
-        global_state::ThreadPoolDispatcher::new(threadpool::ThreadPool::with_name(
-            "salsa-worker".into(),
-            num_cpus(),
-        )),
-    );
+    let dispatcher: Box<dyn global_state::TaskDispatcher> =
+        Box::new(global_state::ThreadPoolDispatcher::new(
+            threadpool::ThreadPool::with_name("salsa-worker".into(), num_cpus()),
+        ));
     let mut state = global_state::GlobalState::new(
         connection.sender.clone(),
         dispatcher,
@@ -505,6 +498,7 @@ pub fn run_server() {
     io_threads.join().expect("io threads");
 }
 
+#[cfg(feature = "native")]
 fn num_cpus() -> usize {
     std::thread::available_parallelism()
         .map(usize::from)

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -443,8 +443,15 @@ pub fn run_server() {
     let (introspection_result_sender, introspection_result_receiver) =
         crossbeam_channel::unbounded();
 
+    let dispatcher: Box<dyn global_state::TaskDispatcher> = Box::new(
+        global_state::ThreadPoolDispatcher::new(threadpool::ThreadPool::with_name(
+            "salsa-worker".into(),
+            num_cpus(),
+        )),
+    );
     let mut state = global_state::GlobalState::new(
         connection.sender.clone(),
+        dispatcher,
         introspection_request_sender,
         introspection_result_receiver,
     );
@@ -475,4 +482,10 @@ pub fn run_server() {
     // Drop the state before joining IO threads to close channels
     drop(state);
     io_threads.join().expect("io threads");
+}
+
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4)
 }

--- a/crates/lsp/src/loading.rs
+++ b/crates/lsp/src/loading.rs
@@ -3,16 +3,23 @@
 //! Extracted from the old `server.rs` async methods into free sync functions
 //! that take `&mut GlobalState`.
 
+#[cfg(feature = "native")]
 use std::path::Path;
+#[cfg(feature = "native")]
 use std::str::FromStr;
 
+#[cfg(feature = "native")]
 use lsp_types::{Diagnostic, MessageType, Uri};
 
+#[cfg(feature = "native")]
 use crate::conversions::convert_ide_diagnostic;
+#[cfg(feature = "native")]
 use crate::global_state::{GlobalState, IntrospectionRequest};
+#[cfg(feature = "native")]
 use crate::server::validation_errors_to_diagnostics;
 
 /// Load a workspace config and all its projects.
+#[cfg(feature = "native")]
 pub fn load_workspace_config(state: &mut GlobalState, workspace_uri: &str, workspace_path: &Path) {
     tracing::debug!(path = ?workspace_path, "Loading GraphQL config");
 
@@ -118,6 +125,7 @@ pub fn load_workspace_config(state: &mut GlobalState, workspace_uri: &str, works
 }
 
 /// Load all project files from a config into their respective `AnalysisHost` instances.
+#[cfg(feature = "native")]
 fn load_all_project_files(
     state: &mut GlobalState,
     workspace_uri: &str,
@@ -348,6 +356,7 @@ fn load_all_project_files(
 }
 
 /// Reload configuration for a workspace.
+#[cfg(feature = "native")]
 pub fn reload_workspace_config(state: &mut GlobalState, workspace_uri: &str) {
     tracing::debug!("Reloading configuration for workspace: {}", workspace_uri);
 
@@ -374,6 +383,7 @@ pub fn reload_workspace_config(state: &mut GlobalState, workspace_uri: &str) {
 }
 
 /// Reload a resolved schema file that changed on disk.
+#[cfg(feature = "native")]
 pub fn reload_resolved_schema(
     state: &mut GlobalState,
     workspace_uri: &str,

--- a/crates/lsp/src/loading.rs
+++ b/crates/lsp/src/loading.rs
@@ -451,8 +451,10 @@ pub fn install_workspace_from_init_options(
     workspace_path: &Path,
     init_options: serde_json::Value,
 ) -> Result<(), String> {
-    let config: graphql_config::GraphQLConfig = serde_json::from_value(init_options)
-        .map_err(|e| format!("`initializationOptions` is not a valid graphql_config::GraphQLConfig: {e}"))?;
+    let config: graphql_config::GraphQLConfig =
+        serde_json::from_value(init_options).map_err(|e| {
+            format!("`initializationOptions` is not a valid graphql_config::GraphQLConfig: {e}")
+        })?;
     state
         .workspace
         .workspace_roots

--- a/crates/lsp/src/loading.rs
+++ b/crates/lsp/src/loading.rs
@@ -3,7 +3,6 @@
 //! Extracted from the old `server.rs` async methods into free sync functions
 //! that take `&mut GlobalState`.
 
-#[cfg(feature = "native")]
 use std::path::Path;
 #[cfg(feature = "native")]
 use std::str::FromStr;
@@ -13,8 +12,9 @@ use lsp_types::{Diagnostic, MessageType, Uri};
 
 #[cfg(feature = "native")]
 use crate::conversions::convert_ide_diagnostic;
+use crate::global_state::GlobalState;
 #[cfg(feature = "native")]
-use crate::global_state::{GlobalState, IntrospectionRequest};
+use crate::global_state::IntrospectionRequest;
 #[cfg(feature = "native")]
 use crate::server::validation_errors_to_diagnostics;
 
@@ -437,4 +437,29 @@ pub fn reload_resolved_schema(
             .collect();
         state.publish_diagnostics(file_uri, lsp_diagnostics, None);
     }
+}
+
+/// Install a workspace from LSP `initializationOptions` JSON, bypassing the on-disk
+/// `.graphqlrc.yaml` lookup. The JSON shape must deserialize to `graphql_config::GraphQLConfig`.
+///
+/// Used by the wasm entrypoint where the host page declares the project shape (schema +
+/// documents URIs) up front, rather than relying on filesystem discovery. Native callers
+/// can still use `load_workspace_config` to load from disk.
+pub fn install_workspace_from_init_options(
+    state: &mut GlobalState,
+    workspace_uri: &str,
+    workspace_path: &Path,
+    init_options: serde_json::Value,
+) -> Result<(), String> {
+    let config: graphql_config::GraphQLConfig = serde_json::from_value(init_options)
+        .map_err(|e| format!("`initializationOptions` is not a valid graphql_config::GraphQLConfig: {e}"))?;
+    state
+        .workspace
+        .workspace_roots
+        .insert(workspace_uri.to_string(), workspace_path.to_path_buf());
+    state
+        .workspace
+        .configs
+        .insert(workspace_uri.to_string(), config);
+    Ok(())
 }

--- a/crates/lsp/src/main.rs
+++ b/crates/lsp/src/main.rs
@@ -18,5 +18,12 @@ fn main() {
         return;
     }
 
+    #[cfg(feature = "native")]
     graphql_lsp::run_server();
+
+    // Without the native feature there is no stdio entrypoint. The binary
+    // target exists for completeness but is not intended to be run directly
+    // in this configuration.
+    #[cfg(not(feature = "native"))]
+    eprintln!("graphql-lsp: native feature is required to run the server");
 }

--- a/crates/lsp/src/main_loop.rs
+++ b/crates/lsp/src/main_loop.rs
@@ -7,40 +7,53 @@ use crate::handlers;
 use crate::server::{PingRequest, VirtualFileContentRequest};
 use crate::trace_capture::TraceCaptureRequest;
 
-pub fn main_loop(connection: &Connection, state: &mut GlobalState) {
+pub enum ControlFlow {
+    Continue,
+    Shutdown,
+}
+
+/// Process all currently buffered messages without blocking. Returns
+/// `ControlFlow::Shutdown` when the connection has closed.
+pub fn tick(connection: &Connection, state: &mut GlobalState) -> ControlFlow {
+    use crossbeam_channel::TryRecvError;
+
+    loop {
+        match connection.receiver.try_recv() {
+            Ok(Message::Request(req)) => {
+                if connection.handle_shutdown(&req).expect("shutdown") {
+                    return ControlFlow::Shutdown;
+                }
+                handle_request(state, req);
+            }
+            Ok(Message::Notification(not)) => handle_notification(state, not),
+            Ok(Message::Response(resp)) => tracing::debug!(id = ?resp.id, "client response"),
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return ControlFlow::Shutdown,
+        }
+    }
+
+    while let Ok(task) = state.task_receiver.try_recv() {
+        handle_task(state, task.response);
+    }
+
+    while let Ok(result) = state.introspection_result_receiver.try_recv() {
+        handle_introspection_result(state, result);
+    }
+
+    ControlFlow::Continue
+}
+
+/// Blocking main loop for the native server. Wakes on any incoming message,
+/// then drains all pending messages via `tick`.
+pub fn run(connection: &Connection, state: &mut GlobalState) {
     loop {
         select! {
-            recv(connection.receiver) -> msg => {
-                match msg {
-                    Ok(Message::Request(req)) => {
-                        if connection.handle_shutdown(&req).expect("shutdown") {
-                            return;
-                        }
-                        handle_request(state, req);
-                    }
-                    Ok(Message::Notification(not)) => {
-                        handle_notification(state, not);
-                    }
-                    Ok(Message::Response(resp)) => {
-                        tracing::debug!("got client response: {:?}", resp.id);
-                    }
-                    Err(_) => {
-                        return;
-                    }
-                }
-            }
-
-            recv(state.task_receiver) -> task => {
-                if let Ok(task) = task {
-                    handle_task(state, task.response);
-                }
-            }
-
-            recv(state.introspection_result_receiver) -> result => {
-                if let Ok(result) = result {
-                    handle_introspection_result(state, result);
-                }
-            }
+            recv(connection.receiver) -> _ => {}
+            recv(state.task_receiver) -> _ => {}
+            recv(state.introspection_result_receiver) -> _ => {}
+        }
+        if matches!(tick(connection, state), ControlFlow::Shutdown) {
+            return;
         }
     }
 }

--- a/crates/lsp/src/main_loop.rs
+++ b/crates/lsp/src/main_loop.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "native")]
 use crossbeam_channel::select;
 use lsp_server::{Connection, Message, Notification, Request};
 
@@ -45,6 +46,7 @@ pub fn tick(connection: &Connection, state: &mut GlobalState) -> ControlFlow {
 
 /// Blocking main loop for the native server. Wakes on any incoming message,
 /// then drains all pending messages via `tick`.
+#[cfg(feature = "native")]
 pub fn run(connection: &Connection, state: &mut GlobalState) {
     loop {
         select! {

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "native")]
 use lsp_types::Diagnostic;
 
 /// Parameters for the `graphql/virtualFileContent` custom request.
@@ -25,13 +26,16 @@ impl lsp_types::request::Request for PingRequest {
 }
 
 /// Custom notification sent from server to client to indicate loading status.
+#[cfg(feature = "native")]
 pub enum StatusNotification {}
 
+#[cfg(feature = "native")]
 impl lsp_types::notification::Notification for StatusNotification {
     type Params = StatusParams;
     const METHOD: &'static str = "graphql-analyzer/status";
 }
 
+#[cfg(feature = "native")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct StatusParams {
     pub status: String,
@@ -46,6 +50,7 @@ pub struct PingResponse {
 }
 
 /// Convert config validation errors to LSP diagnostics.
+#[cfg(feature = "native")]
 pub fn validation_errors_to_diagnostics(
     errors: &[graphql_config::ConfigValidationError],
     config_content: &str,

--- a/crates/lsp/src/trace_capture.rs
+++ b/crates/lsp/src/trace_capture.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Instant;
 
+#[cfg(feature = "native")]
 use tracing_chrome::ChromeLayerBuilder;
 use tracing_subscriber::Layer;
 
@@ -38,6 +39,7 @@ struct ActiveCapture {
     started_at: Instant,
     // The FlushGuard flushes and closes the trace file when dropped.
     // Stored as Option so we can take() it on stop.
+    #[cfg(feature = "native")]
     _flush_guard: tracing_chrome::FlushGuard,
 }
 
@@ -81,54 +83,65 @@ impl TraceCaptureManager {
     }
 
     pub fn start(&self) -> TraceCaptureResult {
-        let mut active = self.active.lock().unwrap();
-
-        if active.is_some() {
-            return TraceCaptureResult {
-                status: "error".to_string(),
-                path: None,
-                message: Some("Trace capture is already running".to_string()),
-                duration_ms: None,
-            };
-        }
-
-        let timestamp = chrono_timestamp();
-        let trace_file_path =
-            std::env::temp_dir().join(format!("graphql-analyzer-trace-{timestamp}.json"));
-
-        let (chrome_layer, flush_guard) = ChromeLayerBuilder::new()
-            .file(trace_file_path.clone())
-            .include_args(true)
-            .build();
-
-        // Don't use .with_filter() here — per-layer filtering requires
-        // registering a FilterId at subscriber build time, which can't
-        // happen for a layer created at runtime via reload. The chrome
-        // layer captures all spans; users can filter in the trace viewer.
-        let layer: BoxedLayer = Box::new(chrome_layer);
-
-        if let Err(e) = self.reload_handle.reload(layer) {
-            return TraceCaptureResult {
-                status: "error".to_string(),
-                path: None,
-                message: Some(format!("Failed to enable trace layer: {e}")),
-                duration_ms: None,
-            };
-        }
-
-        *active = Some(ActiveCapture {
-            trace_file_path: trace_file_path.clone(),
-            started_at: Instant::now(),
-            _flush_guard: flush_guard,
-        });
-
-        TraceCaptureResult {
-            status: "started".to_string(),
-            path: Some(trace_file_path.to_string_lossy().to_string()),
-            message: Some(format!(
-                "Trace capture started. Auto-stops after {AUTO_STOP_SECS}s."
-            )),
+        #[cfg(not(feature = "native"))]
+        return TraceCaptureResult {
+            status: "error".to_string(),
+            path: None,
+            message: Some("Trace capture is not supported on this platform".to_string()),
             duration_ms: None,
+        };
+
+        #[cfg(feature = "native")]
+        {
+            let mut active = self.active.lock().unwrap();
+
+            if active.is_some() {
+                return TraceCaptureResult {
+                    status: "error".to_string(),
+                    path: None,
+                    message: Some("Trace capture is already running".to_string()),
+                    duration_ms: None,
+                };
+            }
+
+            let timestamp = chrono_timestamp();
+            let trace_file_path =
+                std::env::temp_dir().join(format!("graphql-analyzer-trace-{timestamp}.json"));
+
+            let (chrome_layer, flush_guard) = ChromeLayerBuilder::new()
+                .file(trace_file_path.clone())
+                .include_args(true)
+                .build();
+
+            // Don't use .with_filter() here — per-layer filtering requires
+            // registering a FilterId at subscriber build time, which can't
+            // happen for a layer created at runtime via reload. The chrome
+            // layer captures all spans; users can filter in the trace viewer.
+            let layer: BoxedLayer = Box::new(chrome_layer);
+
+            if let Err(e) = self.reload_handle.reload(layer) {
+                return TraceCaptureResult {
+                    status: "error".to_string(),
+                    path: None,
+                    message: Some(format!("Failed to enable trace layer: {e}")),
+                    duration_ms: None,
+                };
+            }
+
+            *active = Some(ActiveCapture {
+                trace_file_path: trace_file_path.clone(),
+                started_at: Instant::now(),
+                _flush_guard: flush_guard,
+            });
+
+            TraceCaptureResult {
+                status: "started".to_string(),
+                path: Some(trace_file_path.to_string_lossy().to_string()),
+                message: Some(format!(
+                    "Trace capture started. Auto-stops after {AUTO_STOP_SECS}s."
+                )),
+                duration_ms: None,
+            }
         }
     }
 

--- a/crates/lsp/src/trace_capture.rs
+++ b/crates/lsp/src/trace_capture.rs
@@ -197,6 +197,7 @@ impl TraceCaptureManager {
     }
 }
 
+#[cfg(feature = "native")]
 fn chrono_timestamp() -> String {
     use std::time::SystemTime;
 
@@ -216,6 +217,7 @@ fn chrono_timestamp() -> String {
     format!("{year:04}-{month:02}-{day:02}T{hours:02}-{minutes:02}-{seconds:02}")
 }
 
+#[cfg(feature = "native")]
 fn epoch_days_to_date(days: u64) -> (u64, u64, u64) {
     // Algorithm from http://howardhinnant.github.io/date_algorithms.html
     let z = days + 719_468;

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use graphql_ide::AnalysisHost;
 use lsp_types::Uri;
 
+#[cfg(feature = "native")]
 use crate::conversions::uri_to_file_path;
 
 /// Manages workspace state for the GraphQL Language Server.
@@ -120,17 +121,20 @@ impl WorkspaceManager {
             return self.find_host_for_virtual_file(&uri_string);
         }
 
-        let doc_path = uri_to_file_path(document_uri)?;
-        for (workspace_uri, workspace_path) in &self.workspace_roots {
-            if doc_path.starts_with(workspace_path.as_path()) {
-                if let Some(config) = self.configs.get(workspace_uri.as_str()) {
-                    if let Some(project_name) =
-                        config.find_project_for_document(&doc_path, workspace_path)
-                    {
-                        return Some((workspace_uri.clone(), project_name.to_string()));
+        #[cfg(feature = "native")]
+        {
+            let doc_path = uri_to_file_path(document_uri)?;
+            for (workspace_uri, workspace_path) in &self.workspace_roots {
+                if doc_path.starts_with(workspace_path.as_path()) {
+                    if let Some(config) = self.configs.get(workspace_uri.as_str()) {
+                        if let Some(project_name) =
+                            config.find_project_for_document(&doc_path, workspace_path)
+                        {
+                            return Some((workspace_uri.clone(), project_name.to_string()));
+                        }
                     }
+                    return None;
                 }
-                return None;
             }
         }
 
@@ -166,10 +170,19 @@ impl WorkspaceManager {
         workspace_uri: &str,
         project_name: &str,
     ) -> Option<graphql_config::FileType> {
-        let doc_path = uri_to_file_path(uri)?;
-        let workspace_path = self.workspace_roots.get(workspace_uri)?;
-        let config = self.configs.get(workspace_uri)?;
-        config.get_file_type(&doc_path, workspace_path, project_name)
+        #[cfg(not(feature = "native"))]
+        {
+            let _ = (uri, workspace_uri, project_name);
+            return None;
+        }
+
+        #[cfg(feature = "native")]
+        {
+            let doc_path = uri_to_file_path(uri)?;
+            let workspace_path = self.workspace_roots.get(workspace_uri)?;
+            let config = self.configs.get(workspace_uri)?;
+            config.get_file_type(&doc_path, workspace_path, project_name)
+        }
     }
 }
 

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -118,7 +118,19 @@ impl WorkspaceManager {
 
         // For virtual files (non-file:// scheme), search all hosts
         if !uri_string.starts_with("file://") {
-            return self.find_host_for_virtual_file(&uri_string);
+            if let Some(entry) = self.find_host_for_virtual_file(&uri_string) {
+                return Some(entry);
+            }
+
+            // In the wasm path, route unrecognised virtual files to the first
+            // installed workspace so that `didOpen` can add them to a host.
+            #[cfg(not(feature = "native"))]
+            if let Some((workspace_uri, config)) = self.configs.iter().next() {
+                let project_name = config.projects().next().map(|(n, _)| n).unwrap_or("default");
+                return Some((workspace_uri.clone(), project_name.to_string()));
+            }
+
+            return None;
         }
 
         #[cfg(feature = "native")]

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -126,7 +126,11 @@ impl WorkspaceManager {
             // installed workspace so that `didOpen` can add them to a host.
             #[cfg(not(feature = "native"))]
             if let Some((workspace_uri, config)) = self.configs.iter().next() {
-                let project_name = config.projects().next().map(|(n, _)| n).unwrap_or("default");
+                let project_name = config
+                    .projects()
+                    .next()
+                    .map(|(n, _)| n)
+                    .unwrap_or("default");
                 return Some((workspace_uri.clone(), project_name.to_string()));
             }
 

--- a/crates/lsp/src/workspace.rs
+++ b/crates/lsp/src/workspace.rs
@@ -21,6 +21,19 @@ use lsp_types::Uri;
 #[cfg(feature = "native")]
 use crate::conversions::uri_to_file_path;
 
+/// Strip the scheme/authority prefix from a URI, returning the path component
+/// for glob-pattern matching against project `schema`/`documents` patterns.
+///
+/// Used on wasm where `uri_to_file_path` is unavailable; the caller has already
+/// determined the URI belongs to a known workspace, so what remains is matching
+/// the URI's path against the project's globs as if it were a relative path.
+#[cfg(not(feature = "native"))]
+fn uri_relative_path(uri: &Uri) -> String {
+    let s = uri.as_str();
+    let after_scheme = s.split_once("://").map_or(s, |(_, rest)| rest);
+    after_scheme.trim_start_matches('/').to_string()
+}
+
 /// Manages workspace state for the GraphQL Language Server.
 pub struct WorkspaceManager {
     /// Workspace folders from initialization (drained during initialized handler)
@@ -188,8 +201,9 @@ impl WorkspaceManager {
     ) -> Option<graphql_config::FileType> {
         #[cfg(not(feature = "native"))]
         {
-            let _ = (uri, workspace_uri, project_name);
-            return None;
+            let config = self.configs.get(workspace_uri)?;
+            let rel_path = uri_relative_path(uri);
+            return config.get_file_type_by_rel_path(&rel_path, project_name);
         }
 
         #[cfg(feature = "native")]

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -9,9 +9,13 @@ description = "GraphQL parsing layer with TypeScript/JavaScript support"
 keywords = ["graphql", "parser", "syntax"]
 categories = ["parser-implementations", "development-tools"]
 
+[features]
+default = ["extract"]
+extract = ["dep:graphql-extract"]
+
 [dependencies]
 graphql-base-db = { path = "../base-db" }
-graphql-extract = { path = "../extract" }
+graphql-extract = { path = "../extract", optional = true }
 graphql-types = { path = "../types" }
 salsa = { workspace = true }
 apollo-parser = { workspace = true }

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["graphql", "parser", "syntax"]
 categories = ["parser-implementations", "development-tools"]
 
 [features]
-default = ["extract"]
+default = ["native", "extract"]
+native = []
 extract = ["dep:graphql-extract"]
 
 [dependencies]

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -178,11 +178,11 @@ pub fn parse(
 ) -> Parse {
     let uri = metadata.uri(db);
 
-    // Dispatch based on language: GraphQL parses directly, others need extraction
     #[cfg(feature = "extract")]
     if metadata.language(db).requires_extraction() {
         return extract_and_parse(db, &content.text(db), uri.as_str());
     }
+    // When the extract feature is off (wasm), all files parse as raw GraphQL.
     parse_graphql(&content.text(db), uri.as_str())
 }
 

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -177,14 +177,13 @@ pub fn parse(
     metadata: FileMetadata,
 ) -> Parse {
     let uri = metadata.uri(db);
-    let language = metadata.language(db);
 
     // Dispatch based on language: GraphQL parses directly, others need extraction
-    if language.requires_extraction() {
-        extract_and_parse(db, &content.text(db), uri.as_str())
-    } else {
-        parse_graphql(&content.text(db), uri.as_str())
+    #[cfg(feature = "extract")]
+    if metadata.language(db).requires_extraction() {
+        return extract_and_parse(db, &content.text(db), uri.as_str());
     }
+    parse_graphql(&content.text(db), uri.as_str())
 }
 
 /// Parse pure GraphQL content into a single block at offset 0
@@ -225,6 +224,7 @@ fn parse_graphql(content: &str, uri: &str) -> Parse {
 }
 
 /// Extract GraphQL from TypeScript/JavaScript and parse each block
+#[cfg(feature = "extract")]
 fn extract_and_parse(db: &dyn GraphQLSyntaxDatabase, content: &str, uri: &str) -> Parse {
     use graphql_extract::{extract_from_source, ExtractConfig, Language};
 
@@ -709,6 +709,7 @@ pub trait GraphQLSyntaxDatabase: salsa::Database {
     /// Get the extract configuration for TypeScript/JavaScript extraction
     /// Returns None by default, which means use `ExtractConfig::default()`
     /// Implementations can override to provide custom configuration
+    #[cfg(feature = "extract")]
     fn extract_config(&self) -> Option<Arc<graphql_extract::ExtractConfig>> {
         None
     }

--- a/docs/superpowers/plans/2026-04-25-wasm-lsp.md
+++ b/docs/superpowers/plans/2026-04-25-wasm-lsp.md
@@ -1,0 +1,1955 @@
+# Wasm LSP + Monaco Web IDE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compile the existing GraphQL language server to `wasm32-unknown-unknown`, host it inside a Web Worker, and stand up a Monaco-based browser playground (`packages/web-ide`) that drives it over `postMessage`-framed JSON-RPC.
+
+**Architecture:** The current synchronous `lsp-server`-based main loop is refactored into a tickable `Server` type that owns a `Connection` and exposes `handle_message(Message)` for non-blocking, JS-driven dispatch. Native paths (stdio transport, threadpool, on-disk config loading, `swc_core`-based TS/JS extraction, `reqwest` with rustls) are gated behind a default-on `native` feature on the relevant crates; a new `wasm` feature swaps in single-threaded dispatch, target-conditional `reqwest` (browser fetch backend), and an in-memory workspace declared via LSP `initializationOptions`. A new `crates/lsp-wasm` crate exposes a `wasm-bindgen` API; a new `packages/web-ide` package wires Monaco to a Web Worker that loads the wasm, using a hand-rolled minimal `LanguageClient` over `vscode-languageserver-protocol/browser`.
+
+**Tech Stack:**
+
+- Rust crates: `lsp-server` 0.7 (sync, channel-based), `salsa` 0.26 (no rayon on wasm), `reqwest` 0.13 (target-cfg'd), `wasm-bindgen` (latest), `js-sys`, `wasm-bindgen-futures`, `tracing-wasm`.
+- JS/TS: `monaco-editor` (latest), `vscode-languageserver-protocol`/`vscode-jsonrpc` (browser entry points), `vite` for dev/build, `playwright` for e2e validation.
+- Build: `wasm-pack build --target web` → static assets consumed by Vite. `cargo xtask web build|dev` orchestrates.
+
+**Out of scope (v1):** code-action UI plumbing beyond what trivial registration buys us, semantic tokens beyond the basics, file-watching analogue, multi-project workspaces. The demo uses one schema + a fixed set of sample documents.
+
+---
+
+## File Structure
+
+### New crate: `crates/lsp-wasm`
+
+- `crates/lsp-wasm/Cargo.toml` — wasm-only crate, depends on `graphql-lsp` with `default-features = false, features = ["wasm"]`.
+- `crates/lsp-wasm/src/lib.rs` — `#[wasm_bindgen]` `Server` struct, `handle_message`, panic hook, tracing-wasm setup.
+
+### New JS package: `packages/web-ide`
+
+- `packages/web-ide/package.json` — Vite + Monaco + vscode-jsonrpc/browser deps.
+- `packages/web-ide/vite.config.ts` — module worker support, wasm asset copy.
+- `packages/web-ide/tsconfig.json`
+- `packages/web-ide/index.html` — host page with Monaco mount points (schema editor + query editor side-by-side).
+- `packages/web-ide/src/main.ts` — Monaco bootstrap, registers `graphql` language, instantiates worker + minimal client.
+- `packages/web-ide/src/lsp/worker.ts` — Web Worker entry; loads wasm; bridges `BrowserMessageReader/Writer` ↔ `Server::handle_message`.
+- `packages/web-ide/src/lsp/client.ts` — hand-rolled minimal `LanguageClient` (initialize handshake, request multiplexing, notification dispatch).
+- `packages/web-ide/src/lsp/providers.ts` — Monaco `CompletionItemProvider`, `HoverProvider`, diagnostic publishing via `monaco.editor.setModelMarkers`.
+- `packages/web-ide/src/demo/schema.graphql` — sample schema (Star Wars-ish, small).
+- `packages/web-ide/src/demo/queries/example.graphql` — sample executable doc.
+- `packages/web-ide/playwright.config.ts`
+- `packages/web-ide/tests/web-ide.spec.ts` — Playwright e2e: typing, completion, hover, diagnostics, all asserted programmatically.
+
+### Modified crates
+
+- `crates/lsp/Cargo.toml` — drop unused `tempfile` dep; add `[features] default = ["native"]; native = [...]; wasm = [...]`; gate `tokio`, `threadpool`, `tracing-chrome`, `tracing-opentelemetry`, `opentelemetry*`, `vergen-git2` build-dep, `url`, `glob`, and `graphql-extract`/`graphql-introspect` deps.
+- `crates/lsp/src/lib.rs` — extract `Server` struct and `run_with_connection`; gate `tokio` runtime block; allow `initializationOptions`-based workspace bootstrap.
+- `crates/lsp/src/global_state.rs` — replace `pub threadpool: threadpool::ThreadPool` field with `pub dispatcher: Box<dyn TaskDispatcher>`; provide `ThreadPoolDispatcher` (native) and `InlineDispatcher` (wasm); wrap the three `self.threadpool.execute(...)` call sites.
+- `crates/lsp/src/main_loop.rs` — split blocking `select!` loop into a non-blocking `tick(state)` that drains `connection.receiver`, `state.task_receiver`, and `state.introspection_result_receiver` via `try_recv`; keep a `run(state, connection)` wrapper for native that loops on `select!` (unchanged behavior).
+- `crates/lsp/src/loading.rs` — gate `find_config`/`load_config` and disk-backed `load_all_project_files` behind `cfg(feature = "native")`; add `fn install_workspace_from_init_options(state, value)` that deserializes `graphql_config::Config` directly.
+- `crates/lsp/src/handlers/document_sync.rs` — confirm extraction branches are reachable only with `extract` feature on (most likely already routed via `Language::requires_extraction()`; gate any direct `graphql_extract::` call).
+- `crates/lsp/src/global_state.rs` — gate `IntrospectionRequest`/`IntrospectionResult` channels and the `tokio` thread spawn behind `cfg(feature = "introspect")` (transitively wasm builds get a no-op).
+- `crates/syntax/Cargo.toml` — add `[features] default = ["extract"]; extract = ["dep:graphql-extract"]`; mark `graphql-extract` as `optional = true`.
+- `crates/syntax/src/lib.rs` — gate `use graphql_extract::*` and `extract_config` accessor behind `cfg(feature = "extract")`; provide a stub for the trait method when feature is off.
+- `crates/ide-db/Cargo.toml` — same pattern: `extract` feature gates the `graphql-extract` dep.
+- `crates/ide-db/src/lib.rs` (or wherever `ExtractConfig` is referenced) — gate.
+- `crates/ide/Cargo.toml` — `extract` feature; mark `graphql-extract` optional.
+- `crates/ide/src/host.rs` — gate the two TS/JS extraction blocks (around `host.rs:290` and `host.rs:649`) and the `Language::from_path`/`requires_extraction` branches behind `cfg(feature = "extract")`. The native default keeps current behavior.
+- `crates/ide/src/discovery.rs` — gate the extraction branch around `discovery.rs:114-125`; tests behind `#[cfg(test)]` are unaffected (test-only `tempfile`).
+- `crates/ide/src/database.rs` — gate `pub config: Arc<graphql_extract::ExtractConfig>` field; provide a unit alternative when feature is off.
+- `crates/introspect/Cargo.toml` — split `reqwest` into native (with `rustls`, `json`) and wasm (`default-features = false`, `features = ["json"]`) via `[target.'cfg(...)'.dependencies]`.
+- `crates/introspect/src/client.rs` and `crates/introspect/src/query.rs` — verify timeouts/retries compile under wasm32 (drop `Duration`-based connector setting if unsupported); minimal cfg gating.
+- `Cargo.toml` (workspace root) — add `crates/lsp-wasm` to members.
+- `package.json` (root) — add `packages/web-ide` to npm workspaces (already covered by `packages/*` glob).
+- `xtask/src/main.rs` — add `Web { dev: bool }` subcommand: runs `wasm-pack build crates/lsp-wasm --target web --out-dir ../../packages/web-ide/src/wasm` followed by either `npm --workspace=packages/web-ide run dev` or `npm --workspace=packages/web-ide run build`.
+
+---
+
+## Phase 0: Workspace prep & validation infra
+
+Goal: ensure the engineer can build/test wasm and run Playwright before touching application code.
+
+### Task 0.1: Confirm baseline native build is clean
+
+**Files:** none.
+
+- [ ] **Step 1: Run the workspace check.**
+
+```bash
+cargo check --workspace --all-targets
+```
+
+Expected: clean exit. If not, stop and fix before continuing.
+
+- [ ] **Step 2: Run the test suite.**
+
+```bash
+cargo nextest run --workspace
+```
+
+Expected: all green. This is the "do no harm" reference suite that every subsequent task must keep passing.
+
+- [ ] **Step 3: No commit.** Baseline only.
+
+### Task 0.2: Install wasm32 target and wasm-pack
+
+**Files:** none (developer environment).
+
+- [ ] **Step 1: Add the wasm target.**
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+- [ ] **Step 2: Install wasm-pack.**
+
+```bash
+cargo install wasm-pack
+# or: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+```
+
+- [ ] **Step 3: Verify.**
+
+```bash
+wasm-pack --version
+```
+
+Expected: prints version. If missing, stop.
+
+- [ ] **Step 4: No commit.**
+
+### Task 0.3: Drop the unused `tempfile` dep from `graphql-lsp`
+
+**Files:**
+
+- Modify: `crates/lsp/Cargo.toml`
+
+- [ ] **Step 1: Remove `tempfile` from `[dependencies]`.**
+
+The grep `grep -rn "tempfile\|TempDir\|NamedTempFile" crates/lsp/src/` returns no hits — the dep is dead weight.
+
+```toml
+# Delete the line:
+tempfile = "3.0"
+# Also delete the comment "# Temp files for TypeScript extraction" if it stands alone above the deleted line.
+```
+
+- [ ] **Step 2: Verify build is unaffected.**
+
+```bash
+cargo check -p graphql-lsp
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/lsp/Cargo.toml
+git commit -m "drop unused \`tempfile\` dep from \`graphql-lsp\`"
+```
+
+---
+
+## Phase 1: `extract` feature gate in syntax / ide-db / ide
+
+Goal: make `graphql-extract` (and its `swc_core` payload) an optional dep so wasm builds can drop it cleanly. Native default remains unchanged.
+
+### Task 1.1: Make `graphql-extract` optional in `graphql-syntax`
+
+**Files:**
+
+- Modify: `crates/syntax/Cargo.toml`
+- Modify: `crates/syntax/src/lib.rs`
+
+- [ ] **Step 1: Make the dep optional in Cargo.toml.**
+
+```toml
+[dependencies]
+# ...
+graphql-extract = { path = "../extract", optional = true }
+
+[features]
+default = ["extract"]
+extract = ["dep:graphql-extract"]
+```
+
+- [ ] **Step 2: Gate the source references.**
+
+In `crates/syntax/src/lib.rs`, find all references to `graphql_extract` (the earlier grep showed two: line 229 in a `#[cfg(test)]` block, and line 712 in `extract_config`). The test usage is behind `#[cfg(test)]` so it inherits the feature flag for tests but not for default lib builds — but if the feature is off in any build (including tests), tests must also drop. Add `#[cfg(feature = "extract")]` above the test module that uses it, and:
+
+```rust
+#[cfg(feature = "extract")]
+fn extract_config(&self) -> Option<Arc<graphql_extract::ExtractConfig>> { /* existing body */ }
+
+#[cfg(not(feature = "extract"))]
+fn extract_config(&self) -> Option<()> { None }
+```
+
+If the trait is consumed externally (it is — by `ide-db` and `ide`), the return type difference will cascade. Better: keep the trait method but type-erase via a feature-gated alias.
+
+```rust
+#[cfg(feature = "extract")]
+pub type ExtractConfigArc = Arc<graphql_extract::ExtractConfig>;
+#[cfg(not(feature = "extract"))]
+pub type ExtractConfigArc = ();
+
+// trait method:
+fn extract_config(&self) -> Option<ExtractConfigArc>;
+```
+
+This keeps the trait shape feature-stable.
+
+- [ ] **Step 3: Build native and confirm green.**
+
+```bash
+cargo check -p graphql-syntax
+cargo check -p graphql-syntax --no-default-features
+```
+
+Expected: both clean. The `--no-default-features` build is the wasm-shaped build for this crate.
+
+- [ ] **Step 4: Run the syntax crate tests.**
+
+```bash
+cargo nextest run -p graphql-syntax
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/syntax/Cargo.toml crates/syntax/src/lib.rs
+git commit -m "make \`graphql-extract\` optional in \`graphql-syntax\`"
+```
+
+### Task 1.2: Make `graphql-extract` optional in `graphql-ide-db`
+
+**Files:**
+
+- Modify: `crates/ide-db/Cargo.toml`
+- Modify: any `crates/ide-db/src/*.rs` referencing `graphql_extract`.
+
+- [ ] **Step 1: Cargo.toml.**
+
+```toml
+[dependencies]
+graphql-extract = { path = "../extract", optional = true }
+
+[features]
+default = ["extract"]
+extract = ["dep:graphql-extract", "graphql-syntax/extract"]
+```
+
+- [ ] **Step 2: Source.** Mirror the `cfg(feature = "extract")` pattern from Task 1.1 wherever `graphql_extract` is referenced. Use `grep -rn graphql_extract crates/ide-db/src` to enumerate.
+
+- [ ] **Step 3: Verify both feature configurations build.**
+
+```bash
+cargo check -p graphql-ide-db
+cargo check -p graphql-ide-db --no-default-features
+cargo nextest run -p graphql-ide-db
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/ide-db
+git commit -m "make \`graphql-extract\` optional in \`graphql-ide-db\`"
+```
+
+### Task 1.3: Make `graphql-extract` optional in `graphql-ide` (the big one)
+
+**Files:**
+
+- Modify: `crates/ide/Cargo.toml`
+- Modify: `crates/ide/src/host.rs` (two extraction branches around lines 290 and 649)
+- Modify: `crates/ide/src/discovery.rs` (extraction branch around lines 114–125)
+- Modify: `crates/ide/src/database.rs` (`config: Arc<graphql_extract::ExtractConfig>` field)
+- Modify: `crates/ide/src/lib.rs` if any non-test references exist (test references stay behind `#[cfg(test)]`).
+
+- [ ] **Step 1: Cargo.toml.**
+
+```toml
+[dependencies]
+graphql-extract = { path = "../extract", optional = true }
+graphql-introspect = { path = "../introspect", optional = true }
+
+[features]
+default = ["extract", "introspect"]
+extract = ["dep:graphql-extract", "graphql-syntax/extract", "graphql-ide-db/extract"]
+introspect = ["dep:graphql-introspect"]
+```
+
+(Introspect is also gated here so the wasm path doesn't drag it in by default; it will be re-enabled separately for wasm via the `lsp-wasm` crate's feature selection — see Phase 5.)
+
+- [ ] **Step 2: Gate `database.rs` field.**
+
+```rust
+#[cfg(feature = "extract")]
+pub config: Arc<graphql_extract::ExtractConfig>,
+#[cfg(not(feature = "extract"))]
+pub config: (),
+```
+
+Audit the `Default` impl and any constructors; provide an analogous default for the `cfg(not)` arm.
+
+- [ ] **Step 3: Gate `discovery.rs:77-125`.**
+
+The signature `fn discover_files(extract_config: &graphql_extract::ExtractConfig, ...)` becomes feature-gated. Provide a no-op or a parallel signature without the param when `extract` is off. Recommended pattern: split the extraction-aware branch into a helper:
+
+```rust
+#[cfg(feature = "extract")]
+fn extract_blocks_from_path(...) -> Result<Vec<ExtractedGraphQL>, ...> { /* existing body */ }
+#[cfg(not(feature = "extract"))]
+fn extract_blocks_from_path(...) -> Result<Vec<()>, ...> { Ok(vec![]) }
+```
+
+Then the call site checks `if cfg!(feature = "extract") && lang.requires_extraction()` etc. Cleaner: gate the entire TS/JS extraction branch with `#[cfg(feature = "extract")]`, and let the `else { /* treat as .graphql */ }` branch handle non-extracted paths uniformly. Wasm will only ever hit the `else` branch.
+
+- [ ] **Step 4: Gate `host.rs:290` and `host.rs:649` extraction branches.**
+
+Wrap each `if let Some(lang) = language { if lang.requires_extraction() { ... extract_from_source ... } }` with `#[cfg(feature = "extract")]`.
+
+- [ ] **Step 5: Gate `set_extract_config`/`get_extract_config` methods (`host.rs:570-580`).**
+
+```rust
+#[cfg(feature = "extract")]
+pub fn set_extract_config(&mut self, config: graphql_extract::ExtractConfig) { /* ... */ }
+#[cfg(feature = "extract")]
+pub fn get_extract_config(&self) -> graphql_extract::ExtractConfig { /* ... */ }
+```
+
+- [ ] **Step 6: Verify both feature configurations build.**
+
+```bash
+cargo check -p graphql-ide
+cargo check -p graphql-ide --no-default-features
+cargo nextest run -p graphql-ide
+```
+
+Expected: clean. Test failures here probably mean a `cfg`-gate is too narrow or too broad — re-read the failure and adjust.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/ide
+git commit -m "make \`graphql-extract\` and \`graphql-introspect\` optional in \`graphql-ide\`"
+```
+
+---
+
+## Phase 2: `TaskDispatcher` trait
+
+Goal: replace direct `threadpool::ThreadPool` ownership in `GlobalState` with a `Box<dyn TaskDispatcher>` trait object so wasm can swap in inline execution. TDD because this is a real refactor with a behavior contract.
+
+### Task 2.1: Define the `TaskDispatcher` trait + tests
+
+**Files:**
+
+- Modify: `crates/lsp/src/global_state.rs`
+- Test: `crates/lsp/src/global_state.rs` (inline `#[cfg(test)] mod tests { ... }`)
+
+- [ ] **Step 1: Write the failing tests.**
+
+Add at the bottom of `global_state.rs`:
+
+```rust
+#[cfg(test)]
+mod dispatcher_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn inline_dispatcher_runs_work_synchronously() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let dispatcher = InlineDispatcher;
+        let c = Arc::clone(&counter);
+        dispatcher.execute(Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn threadpool_dispatcher_runs_work_eventually() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let pool = threadpool::ThreadPool::with_name("test".into(), 2);
+        let dispatcher = ThreadPoolDispatcher(pool);
+        let c = Arc::clone(&counter);
+        dispatcher.execute(Box::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        }));
+        // Drain the pool by joining; trait doesn't expose join so we sleep+poll.
+        for _ in 0..100 {
+            if counter.load(Ordering::SeqCst) == 1 {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!("threadpool dispatcher never ran the task");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests; confirm they fail (compile error: types don't exist).**
+
+```bash
+cargo test -p graphql-lsp dispatcher_tests
+```
+
+Expected: FAIL — `cannot find type 'InlineDispatcher'`.
+
+- [ ] **Step 3: Implement the trait + impls.**
+
+Add to `global_state.rs` above the `GlobalState` struct:
+
+```rust
+pub trait TaskDispatcher: Send + Sync {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>);
+}
+
+#[cfg(feature = "native")]
+pub struct ThreadPoolDispatcher(pub threadpool::ThreadPool);
+
+#[cfg(feature = "native")]
+impl TaskDispatcher for ThreadPoolDispatcher {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
+        self.0.execute(work);
+    }
+}
+
+pub struct InlineDispatcher;
+
+impl TaskDispatcher for InlineDispatcher {
+    fn execute(&self, work: Box<dyn FnOnce() + Send + 'static>) {
+        work();
+    }
+}
+```
+
+(Note: `feature = "native"` doesn't exist yet — added in Phase 4. For now, leave both impls unconditional; we'll add the `cfg` attribute in Task 4.x.)
+
+- [ ] **Step 4: Run tests; confirm pass.**
+
+```bash
+cargo test -p graphql-lsp dispatcher_tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/lsp/src/global_state.rs
+git commit -m "introduce \`TaskDispatcher\` trait with inline + threadpool impls"
+```
+
+### Task 2.2: Migrate `GlobalState` to use `Box<dyn TaskDispatcher>`
+
+**Files:**
+
+- Modify: `crates/lsp/src/global_state.rs`
+- Modify: `crates/lsp/src/lib.rs` (constructor call site at `lib.rs:259-`)
+
+- [ ] **Step 1: Replace the field.**
+
+```rust
+pub struct GlobalState {
+    pub sender: Sender<Message>,
+    pub dispatcher: Box<dyn TaskDispatcher>,
+    // ...
+}
+```
+
+(was: `pub threadpool: threadpool::ThreadPool`.)
+
+- [ ] **Step 2: Update the three call sites.**
+
+`global_state.rs` lines ~154, ~186, ~207 currently read `self.threadpool.execute(move || { ... })`. Change to:
+
+```rust
+self.dispatcher.execute(Box::new(move || { /* same body */ }));
+```
+
+- [ ] **Step 3: Update `GlobalState::new`.**
+
+Change the signature to take a dispatcher:
+
+```rust
+impl GlobalState {
+    pub fn new(
+        sender: Sender<Message>,
+        dispatcher: Box<dyn TaskDispatcher>,
+        introspection_request_sender: Sender<IntrospectionRequest>,
+        introspection_result_receiver: crossbeam_channel::Receiver<IntrospectionResult>,
+    ) -> Self {
+        let (task_sender, task_receiver) = crossbeam_channel::unbounded();
+        Self { sender, dispatcher, /* ... */ }
+    }
+}
+```
+
+- [ ] **Step 4: Update `run_server` to construct the threadpool dispatcher.**
+
+In `lib.rs:418` (`run_server`):
+
+```rust
+let dispatcher: Box<dyn TaskDispatcher> = Box::new(ThreadPoolDispatcher(
+    threadpool::ThreadPool::with_name("salsa-worker".into(), num_cpus()),
+));
+let mut state = GlobalState::new(connection.sender.clone(), dispatcher, ...);
+```
+
+(Find the exact construction site near lib.rs:469 and rewire.)
+
+- [ ] **Step 5: Build + tests.**
+
+```bash
+cargo check -p graphql-lsp
+cargo nextest run -p graphql-lsp
+```
+
+Expected: clean. Watch for any tests that constructed `GlobalState` directly — update them to pass `Box::new(InlineDispatcher)`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/lsp
+git commit -m "migrate \`GlobalState\` to \`Box<dyn TaskDispatcher>\`"
+```
+
+---
+
+## Phase 3: Tickable main loop
+
+Goal: split the blocking `select!` loop into a non-blocking `tick(state, connection)` so the wasm crate can drive the server one message at a time. Native `run` stays a `loop { tick }` driven by `select!` with blocking semantics.
+
+### Task 3.1: Extract a non-blocking `tick`
+
+**Files:**
+
+- Modify: `crates/lsp/src/main_loop.rs`
+
+- [ ] **Step 1: Replace `main_loop` with `run` and add a `tick` companion.**
+
+```rust
+/// Process *all currently buffered* messages on `connection.receiver`,
+/// `state.task_receiver`, and `state.introspection_result_receiver` without
+/// blocking. Returns `false` when the connection has closed (shutdown).
+pub fn tick(connection: &Connection, state: &mut GlobalState) -> ControlFlow {
+    use crossbeam_channel::TryRecvError;
+
+    loop {
+        match connection.receiver.try_recv() {
+            Ok(Message::Request(req)) => {
+                if connection.handle_shutdown(&req).expect("shutdown") {
+                    return ControlFlow::Shutdown;
+                }
+                handle_request(state, req);
+            }
+            Ok(Message::Notification(not)) => handle_notification(state, not),
+            Ok(Message::Response(resp)) => tracing::debug!(id = ?resp.id, "client response"),
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => return ControlFlow::Shutdown,
+        }
+    }
+
+    while let Ok(task) = state.task_receiver.try_recv() {
+        handle_task(state, task.response);
+    }
+
+    while let Ok(result) = state.introspection_result_receiver.try_recv() {
+        handle_introspection_result(state, result);
+    }
+
+    ControlFlow::Continue
+}
+
+pub enum ControlFlow {
+    Continue,
+    Shutdown,
+}
+
+#[cfg(feature = "native")]
+pub fn run(connection: &Connection, state: &mut GlobalState) {
+    use crossbeam_channel::select;
+    loop {
+        select! {
+            recv(connection.receiver) -> _ => {}
+            recv(state.task_receiver) -> _ => {}
+            recv(state.introspection_result_receiver) -> _ => {}
+        }
+        if matches!(tick(connection, state), ControlFlow::Shutdown) {
+            return;
+        }
+    }
+}
+```
+
+The `select!` arms become wakers; `tick` does the actual work. This is straightforward and preserves correctness — the only difference vs. the original is that `tick` runs after each select wake, which can drain a small batch of pending messages instead of one at a time. Behavior-wise this is equivalent or better.
+
+- [ ] **Step 2: Update the existing `run_server` call.**
+
+In `lib.rs:473`, change `main_loop::main_loop(...)` to `main_loop::run(...)`.
+
+- [ ] **Step 3: Build + tests.**
+
+```bash
+cargo check -p graphql-lsp
+cargo nextest run -p graphql-lsp
+```
+
+Expected: clean. The native server should behave identically.
+
+- [ ] **Step 4: Smoke-test the native LSP manually.**
+
+Build the native binary and connect from VS Code (per `DEVELOPMENT.md`), open `test-workspace/starwars/`, confirm completions, hovers, and diagnostics still work as before. This is the "do no harm" check; the refactor is on a hot path.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/lsp
+git commit -m "split blocking main loop into non-blocking \`tick\` + native \`run\` wrapper"
+```
+
+---
+
+## Phase 4: `wasm` and `native` features on `graphql-lsp`
+
+Goal: the lsp crate compiles to `wasm32-unknown-unknown` with `--no-default-features --features wasm`. All native-only deps and code paths are gated.
+
+### Task 4.1: Carve out `native` and `wasm` feature flags
+
+**Files:**
+
+- Modify: `crates/lsp/Cargo.toml`
+
+- [ ] **Step 1: Mark deps optional and define features.**
+
+```toml
+[dependencies]
+# Internal deps (unconditional)
+graphql-linter = { path = "../linter" }
+graphql-config = { path = "../config" }
+graphql-ide = { path = "../ide", default-features = false }
+graphql-syntax = { path = "../syntax", default-features = false }
+
+# Optional based on feature
+graphql-extract = { path = "../extract", optional = true }
+graphql-introspect = { path = "../introspect", optional = true }
+
+# GraphQL (unconditional, both targets need parsing)
+apollo-compiler = { workspace = true }
+apollo-parser = { workspace = true }
+
+# LSP transport
+lsp-server = { workspace = true }
+lsp-types = { workspace = true }
+crossbeam-channel = { workspace = true }
+threadpool = { workspace = true, optional = true }
+
+# Async (introspection only)
+tokio = { workspace = true, features = ["rt"], optional = true }
+
+# Utilities
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Tracing (subset on wasm)
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-chrome = { version = "0.7", optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"], optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+
+# Native-only fs-related
+url = { version = "2", optional = true }
+glob = { workspace = true, optional = true }
+
+[build-dependencies]
+vergen-git2 = { version = "9.1", features = ["build", "cargo"], optional = true }
+
+[features]
+default = ["native"]
+native = [
+    "dep:threadpool",
+    "dep:tokio",
+    "dep:tracing-chrome",
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:url",
+    "dep:glob",
+    "dep:vergen-git2",
+    "extract",
+    "introspect",
+    "graphql-ide/native",
+    "graphql-syntax/native",
+]
+wasm = []
+extract = ["dep:graphql-extract", "graphql-ide/extract", "graphql-syntax/extract"]
+introspect = ["dep:graphql-introspect", "graphql-ide/introspect"]
+```
+
+(`graphql-ide` and `graphql-syntax` may not yet have a `native` feature — add a no-op `native = []` feature to each in their Cargo.toml that re-exports what they need. Or omit the propagation if not needed; just confirm they build with `--no-default-features`.)
+
+- [ ] **Step 2: Build native (default).**
+
+```bash
+cargo check -p graphql-lsp
+```
+
+Expected: clean. The bin target may break if `vergen-git2` is now optional and required by `build.rs` — wrap `build.rs` reads in a `cfg(feature = "native")` or keep `vergen-git2` unconditional under `[build-dependencies]` for simplicity. Pragmatic choice: keep `build.rs` deps unconditional since they don't ship to wasm anyway (build scripts run on host).
+
+Revert `vergen-git2` to unconditional if it simplifies things:
+
+```toml
+[build-dependencies]
+vergen-git2 = { version = "9.1", features = ["build", "cargo"] }
+```
+
+- [ ] **Step 3: Build wasm-only feature shape.**
+
+```bash
+cargo check -p graphql-lsp --no-default-features --features wasm
+```
+
+Expected: numerous compile errors — references to `tokio`, `threadpool`, `graphql_extract`, etc. that aren't yet `cfg`-gated. We address those in Tasks 4.2 and 4.3.
+
+- [ ] **Step 4: Don't commit yet** — leave the broken wasm build in this commit boundary; next task fixes it. Actually, do commit the Cargo.toml changes since native still works:
+
+```bash
+git add crates/lsp/Cargo.toml crates/lsp/build.rs
+git commit -m "carve \`native\`/\`wasm\` feature flags on \`graphql-lsp\` (deps only)"
+```
+
+### Task 4.2: Gate native-only code in `lsp/src/lib.rs`
+
+**Files:**
+
+- Modify: `crates/lsp/src/lib.rs`
+- Modify: `crates/lsp/src/global_state.rs`
+
+- [ ] **Step 1: Gate tokio/introspection runtime block.**
+
+Around `lib.rs:259` is a `tokio::runtime::Builder::new_current_thread()` block that drives `IntrospectionClient`. Wrap the entire setup behind `#[cfg(feature = "introspect")]` (which transitively pulls `tokio`).
+
+```rust
+#[cfg(feature = "introspect")]
+let (introspection_request_sender, introspection_request_receiver) = crossbeam_channel::unbounded::<IntrospectionRequest>();
+#[cfg(feature = "introspect")]
+let (introspection_result_sender, introspection_result_receiver) = crossbeam_channel::unbounded::<IntrospectionResult>();
+
+#[cfg(feature = "introspect")]
+std::thread::spawn(move || { /* tokio runtime + receive loop */ });
+
+#[cfg(not(feature = "introspect"))]
+let (introspection_request_sender, _introspection_request_receiver) = crossbeam_channel::unbounded::<IntrospectionRequest>();
+#[cfg(not(feature = "introspect"))]
+let (_introspection_result_sender, introspection_result_receiver) = crossbeam_channel::unbounded::<IntrospectionResult>();
+```
+
+The off-branch creates no-op channels so `GlobalState`'s shape is preserved.
+
+- [ ] **Step 2: Gate `IntrospectionRequest` / `IntrospectionResult` types.**
+
+In `global_state.rs`, leave the types as-is (they're cheap structs) but make the `IntrospectionRequest` body's `pending: graphql_ide::PendingIntrospection` field gated if `PendingIntrospection` is feature-gated upstream. If it's always available, no change needed.
+
+- [ ] **Step 3: Gate `tracing-chrome` / OpenTelemetry layers in `init_tracing()` (around `lib.rs:136`).**
+
+Wrap each layer's `with` call in `cfg(feature = "native")` (or feature-by-feature). The basic `tracing-subscriber` env filter stays unconditional.
+
+- [ ] **Step 4: Gate `ThreadPoolDispatcher` impl.**
+
+In `global_state.rs`, wrap the `ThreadPoolDispatcher` struct + impl in `#[cfg(feature = "native")]` (feature gate added in Task 2.1 prep — verify it was applied or add now).
+
+- [ ] **Step 5: Gate `std::thread::spawn` calls under `cfg(feature = "native")`** — wasm32 panics on `std::thread::spawn`. Confirm via `grep -n "std::thread::spawn\|thread::spawn" crates/lsp/src/`.
+
+- [ ] **Step 6: Build and confirm wasm-feature build progresses.**
+
+```bash
+cargo check -p graphql-lsp --no-default-features --features wasm
+```
+
+Expected: errors decrease. Iterate until clean.
+
+- [ ] **Step 7: Build native to confirm no regression.**
+
+```bash
+cargo check -p graphql-lsp
+cargo nextest run -p graphql-lsp
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add crates/lsp
+git commit -m "gate native-only code paths in \`graphql-lsp\` behind feature flags"
+```
+
+### Task 4.3: Gate config-from-disk loading
+
+**Files:**
+
+- Modify: `crates/lsp/src/loading.rs`
+- Modify: `crates/lsp/src/lib.rs` (initialize-handshake call site)
+
+- [ ] **Step 1: Gate `load_workspace_config` and `load_all_project_files`.**
+
+These read the filesystem (`std::fs::read_to_string` and `find_config`). Add `#[cfg(feature = "native")]` to the entire `loading` module's public items that touch the filesystem, OR keep the module compilable by feature-gating only the `std::fs::read_to_string` calls and stub them out. Recommend: gate the public `load_workspace_config` and `load_all_project_files` functions with `cfg(feature = "native")`, and add a wasm equivalent next.
+
+- [ ] **Step 2: Add `install_workspace_from_init_options`.**
+
+```rust
+/// Wasm-side entry: install a single in-memory project declared via LSP
+/// `initializationOptions`. The JSON shape is the same as a `graphql_config::Config`.
+pub fn install_workspace_from_init_options(
+    state: &mut GlobalState,
+    workspace_uri: &str,
+    workspace_path: &Path,
+    init_options: serde_json::Value,
+) -> anyhow::Result<()> {
+    let config: graphql_config::Config = serde_json::from_value(init_options)
+        .context("`initializationOptions` does not deserialize as graphql_config::Config")?;
+    state.workspace.workspace_roots.insert(workspace_uri.to_string(), workspace_path.to_path_buf());
+    state.workspace.configs.insert(workspace_uri.to_string(), config);
+    // No on-disk file loading — clients drive `didOpen` instead.
+    Ok(())
+}
+```
+
+- [ ] **Step 3: In `lib.rs`, route the post-`initialize` setup conditionally.**
+
+Where `run_server` (or its successor `run_with_connection`) currently calls `load_workspace_config` after the handshake, add:
+
+```rust
+#[cfg(feature = "native")]
+loading::load_workspace_config(state, &workspace_uri, &workspace_path);
+
+#[cfg(not(feature = "native"))]
+{
+    if let Some(opts) = init_params.initialization_options {
+        loading::install_workspace_from_init_options(state, &workspace_uri, &workspace_path, opts)?;
+    }
+}
+```
+
+- [ ] **Step 4: Build wasm and native.**
+
+```bash
+cargo check -p graphql-lsp --no-default-features --features wasm
+cargo check -p graphql-lsp
+cargo nextest run -p graphql-lsp
+```
+
+Expected: both clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/lsp
+git commit -m "add \`installWorkspaceFromInitOptions\` for wasm; gate disk-backed config loading"
+```
+
+### Task 4.4: Add a `native` feature stub to `graphql-syntax` and `graphql-ide`
+
+**Files:**
+
+- Modify: `crates/syntax/Cargo.toml`
+- Modify: `crates/ide/Cargo.toml`
+
+- [ ] **Step 1: Add `native = []` to each.**
+
+Both crates need a `native` feature so `graphql-lsp/native = ["graphql-ide/native", ...]` resolves. If neither crate has any native-only code, the feature is a no-op declared for downstream consumers.
+
+```toml
+# In each Cargo.toml:
+[features]
+default = ["native", "extract"]
+native = []
+extract = ["..."]
+```
+
+- [ ] **Step 2: Re-run wasm + native builds; commit.**
+
+```bash
+cargo check -p graphql-lsp --no-default-features --features wasm
+cargo check --workspace
+git add crates/syntax/Cargo.toml crates/ide/Cargo.toml
+git commit -m "add no-op \`native\` feature to syntax/ide for downstream feature unification"
+```
+
+---
+
+## Phase 5: Wasm-compatible `graphql-introspect`
+
+Goal: `graphql-introspect` compiles for both targets. Native uses `reqwest` with `rustls`; wasm uses `reqwest` with browser fetch backend (no rustls).
+
+### Task 5.1: Target-conditional `reqwest` config
+
+**Files:**
+
+- Modify: `crates/introspect/Cargo.toml`
+- Modify (if needed): `crates/introspect/src/client.rs`, `crates/introspect/src/query.rs`
+
+- [ ] **Step 1: Cargo.toml — split reqwest by target.**
+
+```toml
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = "0.1"
+tokio = { workspace = true, features = ["time"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
+```
+
+(Workspace-level `reqwest` setting becomes unused for this crate — that's fine.)
+
+- [ ] **Step 2: Build wasm.**
+
+```bash
+cargo check -p graphql-introspect --target wasm32-unknown-unknown
+```
+
+Expected: build succeeds, OR errors specific to `Duration` / connector setup. If `connect_timeout(...)` is unsupported on wasm, `cfg`-gate those calls:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+let builder = builder.connect_timeout(self.connect_timeout);
+```
+
+Apply similar gates around any reqwest builder method that reqwest's wasm path doesn't implement (the compiler will tell you which).
+
+- [ ] **Step 3: Build native.**
+
+```bash
+cargo check -p graphql-introspect
+cargo nextest run -p graphql-introspect
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/introspect
+git commit -m "make \`graphql-introspect\` build on wasm32 via reqwest's fetch backend"
+```
+
+---
+
+## Phase 6: New crate `graphql-lsp-wasm`
+
+Goal: a `wasm-bindgen` crate that exposes a `Server` JS class with `handle_message(json) -> string[]` (returns an array of outbound messages to write back).
+
+### Task 6.1: Skeleton crate
+
+**Files:**
+
+- Create: `crates/lsp-wasm/Cargo.toml`
+- Create: `crates/lsp-wasm/src/lib.rs`
+- Modify: `Cargo.toml` (workspace members)
+
+- [ ] **Step 1: Add workspace member.**
+
+In root `Cargo.toml`:
+
+```toml
+members = [
+  # existing entries
+  "crates/lsp-wasm",
+]
+```
+
+- [ ] **Step 2: Cargo.toml.**
+
+```toml
+[package]
+name = "graphql-lsp-wasm"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Wasm bindings for the GraphQL language server"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+graphql-lsp = { path = "../lsp", default-features = false, features = ["wasm", "extract", "introspect"] }
+lsp-server = { workspace = true }
+lsp-types = { workspace = true }
+crossbeam-channel = { workspace = true }
+serde_json = { workspace = true }
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+console_error_panic_hook = "0.1"
+tracing = { workspace = true }
+tracing-wasm = "0.2"
+
+[lints]
+workspace = true
+```
+
+(Note: enabling `extract` here is a deliberate choice if we want `swc_core` in the wasm binary. Per the user's earlier note we don't — drop `extract` from features here. Final feature list: `["wasm", "introspect"]`.)
+
+- [ ] **Step 3: Skeleton `lib.rs`.**
+
+```rust
+use lsp_server::{Connection, Message};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+    tracing_wasm::set_as_global_default();
+}
+
+#[wasm_bindgen]
+pub struct Server {
+    connection: Connection,
+    state: graphql_lsp::GlobalState,
+    inbound: crossbeam_channel::Sender<Message>,
+    outbound: crossbeam_channel::Receiver<Message>,
+}
+
+#[wasm_bindgen]
+impl Server {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        let (inbound_tx, inbound_rx) = crossbeam_channel::unbounded::<Message>();
+        let (outbound_tx, outbound_rx) = crossbeam_channel::unbounded::<Message>();
+        let connection = Connection { sender: outbound_tx, receiver: inbound_rx };
+        let dispatcher: Box<dyn graphql_lsp::TaskDispatcher> = Box::new(graphql_lsp::InlineDispatcher);
+        // Introspection channels: required by GlobalState; on wasm the introspect path
+        // is feature-gated so the receiver stays empty.
+        let (intro_req_tx, _) = crossbeam_channel::unbounded();
+        let (_, intro_res_rx) = crossbeam_channel::unbounded();
+        let state = graphql_lsp::GlobalState::new(connection.sender.clone(), dispatcher, intro_req_tx, intro_res_rx);
+        Server { connection, state, inbound: inbound_tx, outbound: outbound_rx }
+    }
+
+    /// Feed an inbound LSP JSON-RPC message (already unframed). Returns an array
+    /// of outbound JSON strings that the worker should write back to the client.
+    #[wasm_bindgen(js_name = handleMessage)]
+    pub fn handle_message(&mut self, json: &str) -> Result<js_sys::Array, JsValue> {
+        let msg: Message = serde_json::from_str(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        self.inbound.send(msg).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        // Run one tick.
+        let _ = graphql_lsp::tick(&self.connection, &mut self.state);
+        // Drain outbound.
+        let arr = js_sys::Array::new();
+        while let Ok(out) = self.outbound.try_recv() {
+            let s = serde_json::to_string(&out).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            arr.push(&JsValue::from_str(&s));
+        }
+        Ok(arr)
+    }
+}
+
+impl Default for Server {
+    fn default() -> Self { Self::new() }
+}
+```
+
+For this to compile, `graphql-lsp` must re-export the symbols `GlobalState`, `TaskDispatcher`, `InlineDispatcher`, `tick`. Add these `pub use` lines to `crates/lsp/src/lib.rs`:
+
+```rust
+pub use crate::global_state::{GlobalState, InlineDispatcher, TaskDispatcher};
+pub use crate::main_loop::{tick, ControlFlow};
+pub use crate::loading::install_workspace_from_init_options;
+```
+
+- [ ] **Step 4: Build the wasm crate.**
+
+```bash
+cargo check -p graphql-lsp-wasm --target wasm32-unknown-unknown
+```
+
+Expected: clean. Iterate on missing re-exports / feature flags.
+
+- [ ] **Step 5: Build with wasm-pack.**
+
+```bash
+wasm-pack build crates/lsp-wasm --target web --out-dir pkg --dev
+```
+
+Expected: `crates/lsp-wasm/pkg/` populated with `graphql_lsp_wasm.js`, `graphql_lsp_wasm_bg.wasm`, `graphql_lsp_wasm.d.ts`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/lsp-wasm Cargo.toml crates/lsp/src/lib.rs
+git commit -m "add \`graphql-lsp-wasm\` crate with wasm-bindgen Server surface"
+```
+
+### Task 6.2: Sanity test — round-trip an `initialize` request
+
+**Files:**
+
+- Modify: `crates/lsp-wasm/src/lib.rs` (test only) OR
+- Create: `crates/lsp-wasm/tests/initialize.rs` (wasm-bindgen-test)
+
+- [ ] **Step 1: Set up wasm-bindgen-test.**
+
+Add dev-dep:
+
+```toml
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+```
+
+- [ ] **Step 2: Write the round-trip test.**
+
+`crates/lsp-wasm/tests/initialize.rs`:
+
+```rust
+use wasm_bindgen_test::*;
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn initialize_roundtrip() {
+    let mut server = graphql_lsp_wasm::Server::new();
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "capabilities": {},
+            "processId": null,
+            "rootUri": null,
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "schema": "schema.graphql",
+                "documents": ["**/*.graphql"]
+            }
+        }
+    }).to_string();
+    let outbound = server.handle_message(&init).unwrap();
+    assert_eq!(outbound.length(), 1, "expected one response");
+    let resp_str: String = outbound.get(0).as_string().unwrap();
+    assert!(resp_str.contains("\"capabilities\""));
+}
+```
+
+- [ ] **Step 3: Run the wasm test.**
+
+```bash
+wasm-pack test crates/lsp-wasm --headless --chrome
+```
+
+Expected: PASS. If headless Chrome is not available on the dev machine, fall back to `--firefox` or skip and rely on Phase 9 Playwright validation.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/lsp-wasm
+git commit -m "add wasm-bindgen-test for \`initialize\` round-trip"
+```
+
+---
+
+## Phase 7: `packages/web-ide` — Vite + Monaco scaffolding
+
+### Task 7.1: Bootstrap the package
+
+**Files:**
+
+- Create: `packages/web-ide/package.json`
+- Create: `packages/web-ide/tsconfig.json`
+- Create: `packages/web-ide/vite.config.ts`
+- Create: `packages/web-ide/index.html`
+- Create: `packages/web-ide/src/main.ts`
+
+- [ ] **Step 1: `package.json`.**
+
+```json
+{
+  "name": "@graphql-analyzer/web-ide",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "monaco-editor": "^0.46.0",
+    "vscode-jsonrpc": "^8.2.0",
+    "vscode-languageserver-protocol": "^3.17.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}
+```
+
+- [ ] **Step 2: `tsconfig.json`.**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}
+```
+
+- [ ] **Step 3: `vite.config.ts`.**
+
+```ts
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  worker: { format: "es" },
+  optimizeDeps: { exclude: ["monaco-editor"] },
+  server: { fs: { allow: [".."] } },
+});
+```
+
+- [ ] **Step 4: `index.html`.**
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>graphql-analyzer playground</title>
+    <style>
+      html, body, #app { height: 100%; margin: 0; }
+      .editors { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
+      .editor { border-right: 1px solid #ccc; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div class="editors">
+        <div id="schema" class="editor"></div>
+        <div id="doc" class="editor"></div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: `src/main.ts` skeleton.**
+
+```ts
+import * as monaco from "monaco-editor";
+
+monaco.languages.register({ id: "graphql", extensions: [".graphql", ".gql"] });
+
+const schema = monaco.editor.create(document.getElementById("schema")!, {
+  language: "graphql",
+  value: "# schema goes here\n",
+  automaticLayout: true,
+});
+const doc = monaco.editor.create(document.getElementById("doc")!, {
+  language: "graphql",
+  value: "# query goes here\n",
+  automaticLayout: true,
+});
+
+console.log("editors mounted", schema.getModel(), doc.getModel());
+```
+
+- [ ] **Step 6: Install + smoke-test.**
+
+```bash
+cd packages/web-ide
+npm install
+npm run dev
+```
+
+Expected: Vite serves at `http://localhost:5173`; opening it shows two empty Monaco editors. Confirm in browser before continuing.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add packages/web-ide package-lock.json package.json
+git commit -m "scaffold \`packages/web-ide\` with Vite + Monaco editors"
+```
+
+### Task 7.2: Hand-rolled minimal LanguageClient
+
+**Files:**
+
+- Create: `packages/web-ide/src/lsp/client.ts`
+
+- [ ] **Step 1: Implement the client.**
+
+```ts
+import {
+  BrowserMessageReader,
+  BrowserMessageWriter,
+} from "vscode-jsonrpc/browser";
+import { createMessageConnection } from "vscode-jsonrpc/browser";
+import type { MessageConnection } from "vscode-jsonrpc/browser";
+import type {
+  InitializeParams,
+  InitializeResult,
+  PublishDiagnosticsParams,
+  CompletionParams,
+  CompletionList,
+  CompletionItem,
+  HoverParams,
+  Hover,
+  DidOpenTextDocumentParams,
+  DidChangeTextDocumentParams,
+} from "vscode-languageserver-protocol";
+
+export type DiagnosticsListener = (params: PublishDiagnosticsParams) => void;
+
+export class MinimalClient {
+  private conn!: MessageConnection;
+  private diagnosticsListeners: DiagnosticsListener[] = [];
+
+  constructor(private worker: Worker) {}
+
+  async start(initOptions: unknown): Promise<InitializeResult> {
+    const reader = new BrowserMessageReader(this.worker);
+    const writer = new BrowserMessageWriter(this.worker);
+    this.conn = createMessageConnection(reader, writer);
+
+    this.conn.onNotification("textDocument/publishDiagnostics", (params: PublishDiagnosticsParams) => {
+      for (const l of this.diagnosticsListeners) l(params);
+    });
+
+    this.conn.listen();
+
+    const params: InitializeParams = {
+      processId: null,
+      rootUri: null,
+      capabilities: {
+        textDocument: {
+          synchronization: { dynamicRegistration: false },
+          completion: { completionItem: { snippetSupport: false } },
+          hover: { contentFormat: ["plaintext", "markdown"] },
+          publishDiagnostics: {},
+        },
+      },
+      initializationOptions: initOptions,
+      workspaceFolders: null,
+    };
+    const result: InitializeResult = await this.conn.sendRequest("initialize", params);
+    await this.conn.sendNotification("initialized", {});
+    return result;
+  }
+
+  onDiagnostics(l: DiagnosticsListener): void { this.diagnosticsListeners.push(l); }
+
+  didOpen(params: DidOpenTextDocumentParams): void {
+    this.conn.sendNotification("textDocument/didOpen", params);
+  }
+
+  didChange(params: DidChangeTextDocumentParams): void {
+    this.conn.sendNotification("textDocument/didChange", params);
+  }
+
+  completion(params: CompletionParams): Promise<CompletionList | CompletionItem[] | null> {
+    return this.conn.sendRequest("textDocument/completion", params);
+  }
+
+  hover(params: HoverParams): Promise<Hover | null> {
+    return this.conn.sendRequest("textDocument/hover", params);
+  }
+}
+```
+
+- [ ] **Step 2: TypeScript check.**
+
+```bash
+cd packages/web-ide && npx tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/web-ide/src/lsp/client.ts
+git commit -m "minimal hand-rolled \`LanguageClient\` over \`vscode-jsonrpc/browser\`"
+```
+
+### Task 7.3: Monaco provider adapters
+
+**Files:**
+
+- Create: `packages/web-ide/src/lsp/providers.ts`
+
+- [ ] **Step 1: Implement the adapters.**
+
+```ts
+import * as monaco from "monaco-editor";
+import type { MinimalClient } from "./client";
+import type {
+  PublishDiagnosticsParams,
+  Diagnostic,
+  CompletionItem as LspCompletionItem,
+  Hover as LspHover,
+} from "vscode-languageserver-protocol";
+
+const lspSeverityToMarker: Record<number, monaco.MarkerSeverity> = {
+  1: monaco.MarkerSeverity.Error,
+  2: monaco.MarkerSeverity.Warning,
+  3: monaco.MarkerSeverity.Info,
+  4: monaco.MarkerSeverity.Hint,
+};
+
+export function wireProviders(client: MinimalClient): void {
+  monaco.languages.registerCompletionItemProvider("graphql", {
+    triggerCharacters: [".", "$", "@", " ", "{", "(", ":"],
+    provideCompletionItems: async (model, position) => {
+      const params = {
+        textDocument: { uri: model.uri.toString() },
+        position: { line: position.lineNumber - 1, character: position.column - 1 },
+      };
+      const result = await client.completion(params);
+      const items: LspCompletionItem[] = Array.isArray(result) ? result : (result?.items ?? []);
+      return {
+        suggestions: items.map((it) => ({
+          label: it.label,
+          kind: monaco.languages.CompletionItemKind.Text,
+          insertText: typeof it.insertText === "string" ? it.insertText : it.label,
+          detail: it.detail,
+          documentation: typeof it.documentation === "string" ? it.documentation : it.documentation?.value,
+          range: undefined as unknown as monaco.IRange, // Monaco fills from current word.
+        })),
+      };
+    },
+  });
+
+  monaco.languages.registerHoverProvider("graphql", {
+    provideHover: async (model, position) => {
+      const params = {
+        textDocument: { uri: model.uri.toString() },
+        position: { line: position.lineNumber - 1, character: position.column - 1 },
+      };
+      const hover: LspHover | null = await client.hover(params);
+      if (!hover) return null;
+      const contents = Array.isArray(hover.contents) ? hover.contents : [hover.contents];
+      return {
+        contents: contents.map((c) =>
+          typeof c === "string" ? { value: c } : { value: c.value },
+        ),
+      };
+    },
+  });
+
+  client.onDiagnostics((params: PublishDiagnosticsParams) => {
+    const model = monaco.editor.getModels().find((m) => m.uri.toString() === params.uri);
+    if (!model) return;
+    const markers = params.diagnostics.map((d: Diagnostic) => ({
+      severity: lspSeverityToMarker[d.severity ?? 1] ?? monaco.MarkerSeverity.Error,
+      startLineNumber: d.range.start.line + 1,
+      startColumn: d.range.start.character + 1,
+      endLineNumber: d.range.end.line + 1,
+      endColumn: d.range.end.character + 1,
+      message: d.message,
+      source: d.source ?? "graphql",
+    }));
+    monaco.editor.setModelMarkers(model, "graphql", markers);
+  });
+}
+```
+
+- [ ] **Step 2: TypeScript check.**
+
+```bash
+cd packages/web-ide && npx tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/web-ide/src/lsp/providers.ts
+git commit -m "Monaco completion/hover/diagnostics adapters"
+```
+
+### Task 7.4: Worker bridge
+
+**Files:**
+
+- Create: `packages/web-ide/src/lsp/worker.ts`
+
+- [ ] **Step 1: Worker entry.**
+
+```ts
+/// <reference lib="webworker" />
+import init, { Server } from "../wasm/graphql_lsp_wasm";
+import { BrowserMessageReader, BrowserMessageWriter } from "vscode-jsonrpc/browser";
+import { createMessageConnection } from "vscode-jsonrpc/browser";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+async function main() {
+  await init();
+  const server = new Server();
+
+  // Read framed messages from the main thread, hand each to wasm, write outbound.
+  const reader = new BrowserMessageReader(self);
+  const writer = new BrowserMessageWriter(self);
+  const conn = createMessageConnection(reader, writer);
+
+  // We don't actually `listen` — instead, hijack reader to forward raw messages.
+  // BrowserMessageReader emits `Message` objects (already parsed). Easier: bypass
+  // createMessageConnection and use reader.listen directly.
+  conn.dispose(); // not used
+
+  reader.listen((msg) => {
+    const json = JSON.stringify(msg);
+    const outbound: string[] = server.handleMessage(json);
+    for (const out of outbound) {
+      writer.write(JSON.parse(out));
+    }
+  });
+}
+
+main().catch((e) => console.error("worker init failed", e));
+```
+
+- [ ] **Step 2: TypeScript check.**
+
+```bash
+cd packages/web-ide && npx tsc --noEmit
+```
+
+Expected: errors about `../wasm/graphql_lsp_wasm` not existing yet — that's fine, the wasm output gets generated at build time. To unblock typecheck, create a stub: `packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts`:
+
+```ts
+export default function init(): Promise<void>;
+export class Server {
+  handleMessage(json: string): string[];
+}
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/web-ide/src/lsp
+git commit -m "Web Worker bridge for the wasm LSP"
+```
+
+### Task 7.5: Wire main.ts to the worker
+
+**Files:**
+
+- Modify: `packages/web-ide/src/main.ts`
+- Create: `packages/web-ide/src/demo/schema.graphql`
+- Create: `packages/web-ide/src/demo/queries/example.graphql`
+
+- [ ] **Step 1: Demo content.**
+
+`schema.graphql`:
+
+```graphql
+type Query {
+  greeting: String
+  user(id: ID!): User
+}
+type User {
+  id: ID!
+  name: String!
+  email: String
+}
+```
+
+`queries/example.graphql`:
+
+```graphql
+query GetUser {
+  user(id: "1") {
+    id
+    name
+  }
+}
+```
+
+Use Vite raw imports.
+
+- [ ] **Step 2: Update `main.ts`.**
+
+```ts
+import * as monaco from "monaco-editor";
+import { MinimalClient } from "./lsp/client";
+import { wireProviders } from "./lsp/providers";
+import schemaText from "./demo/schema.graphql?raw";
+import docText from "./demo/queries/example.graphql?raw";
+
+monaco.languages.register({ id: "graphql", extensions: [".graphql", ".gql"] });
+
+const schemaUri = monaco.Uri.parse("inmemory://schema.graphql");
+const docUri = monaco.Uri.parse("inmemory://queries/example.graphql");
+
+const schemaModel = monaco.editor.createModel(schemaText, "graphql", schemaUri);
+const docModel = monaco.editor.createModel(docText, "graphql", docUri);
+
+monaco.editor.create(document.getElementById("schema")!, { model: schemaModel, automaticLayout: true });
+monaco.editor.create(document.getElementById("doc")!, { model: docModel, automaticLayout: true });
+
+const worker = new Worker(new URL("./lsp/worker.ts", import.meta.url), { type: "module" });
+const client = new MinimalClient(worker);
+const initOptions = {
+  // graphql_config::Config-shaped JSON. Single virtual project.
+  projects: {
+    default: {
+      schema: ["inmemory://schema.graphql"],
+      documents: ["inmemory://queries/**/*.graphql"],
+    },
+  },
+};
+await client.start(initOptions);
+
+wireProviders(client);
+
+// Sync Monaco models to the LSP via didOpen/didChange.
+function pushOpen(model: monaco.editor.ITextModel) {
+  client.didOpen({
+    textDocument: {
+      uri: model.uri.toString(),
+      languageId: "graphql",
+      version: model.getVersionId(),
+      text: model.getValue(),
+    },
+  });
+  model.onDidChangeContent((e) => {
+    client.didChange({
+      textDocument: { uri: model.uri.toString(), version: model.getVersionId() },
+      contentChanges: e.changes.map((c) => ({
+        range: {
+          start: { line: c.range.startLineNumber - 1, character: c.range.startColumn - 1 },
+          end: { line: c.range.endLineNumber - 1, character: c.range.endColumn - 1 },
+        },
+        rangeLength: c.rangeLength,
+        text: c.text,
+      })),
+    });
+  });
+}
+pushOpen(schemaModel);
+pushOpen(docModel);
+```
+
+(The `initOptions.projects` shape must match `graphql_config::Config`'s deserialized form — verify by looking at the existing yaml fixture in `test-workspace/.graphqlrc.yaml` and translating to JSON. Adjust the shape if needed.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/web-ide/src
+git commit -m "wire Monaco models to the wasm LSP via \`didOpen\`/\`didChange\`"
+```
+
+---
+
+## Phase 8: `xtask web` orchestration
+
+### Task 8.1: Add `xtask web` subcommand
+
+**Files:**
+
+- Modify: `xtask/src/main.rs`
+
+- [ ] **Step 1: Add a subcommand variant.**
+
+```rust
+#[derive(Subcommand)]
+enum Commands {
+    // ...existing...
+    /// Build the wasm LSP and run/build the web playground.
+    Web {
+        /// Run the Vite dev server (default: build only)
+        #[arg(long)]
+        dev: bool,
+    },
+}
+```
+
+- [ ] **Step 2: Implement the handler.**
+
+```rust
+fn cmd_web(dev: bool) -> Result<()> {
+    let workspace = workspace_root()?;
+    let pkg_dir = workspace.join("packages/web-ide/src/wasm");
+    let status = Command::new("wasm-pack")
+        .args(["build", "crates/lsp-wasm", "--target", "web", "--out-dir"])
+        .arg(&pkg_dir)
+        .arg("--dev")
+        .current_dir(&workspace)
+        .status()
+        .context("running wasm-pack")?;
+    if !status.success() { bail!("wasm-pack failed"); }
+
+    let script = if dev { "dev" } else { "build" };
+    let status = Command::new("npm")
+        .args(["--workspace=packages/web-ide", "run", script])
+        .current_dir(&workspace)
+        .status()
+        .context("running npm script")?;
+    if !status.success() { bail!("npm {} failed", script); }
+    Ok(())
+}
+```
+
+Wire it into the match arm in `main`.
+
+- [ ] **Step 3: Build + run.**
+
+```bash
+cargo run -p xtask -- web
+# then:
+cargo run -p xtask -- web --dev
+```
+
+Expected: first invocation produces a static build under `packages/web-ide/dist/`; second serves dev mode at `http://localhost:5173`. Open the dev URL and confirm both editors mount and the worker logs an `initialize` round-trip in DevTools.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add xtask
+git commit -m "add \`xtask web\` to build wasm + run/build the playground"
+```
+
+---
+
+## Phase 9: Playwright validation
+
+### Task 9.1: Playwright config + smoke test
+
+**Files:**
+
+- Create: `packages/web-ide/playwright.config.ts`
+- Create: `packages/web-ide/tests/web-ide.spec.ts`
+
+- [ ] **Step 1: `playwright.config.ts`.**
+
+```ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+  use: { baseURL: "http://localhost:5173" },
+  testDir: "./tests",
+});
+```
+
+- [ ] **Step 2: Smoke test — `tests/web-ide.spec.ts`.**
+
+```ts
+import { test, expect } from "@playwright/test";
+
+test("editors mount and worker initializes", async ({ page }) => {
+  const messages: string[] = [];
+  page.on("console", (m) => messages.push(m.text()));
+
+  await page.goto("/");
+  // Monaco mounts as a contenteditable region; we can detect by class.
+  await expect(page.locator(".monaco-editor").first()).toBeVisible();
+  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+
+  // Wait for any post-init log; assertion is loose because the exact text varies.
+  await page.waitForTimeout(2000);
+  expect(messages.find((m) => /initialize|capabilities|GraphQL/i.test(m))).toBeTruthy();
+});
+
+test("typing an unknown field produces a diagnostic", async ({ page }) => {
+  await page.goto("/");
+  // Focus the second (document) editor and type a bad field.
+  const docEditor = page.locator(".monaco-editor").nth(1);
+  await docEditor.click();
+  await page.keyboard.press("Control+End");
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("query Bad { user(id: \"1\") { notARealField } }");
+
+  // A red squiggle in Monaco is rendered as an .squiggly-error span.
+  await expect(page.locator(".squiggly-error").first()).toBeVisible({ timeout: 10_000 });
+});
+```
+
+- [ ] **Step 3: Run.**
+
+```bash
+cd packages/web-ide
+npx playwright install --with-deps chromium
+npm run test:e2e
+```
+
+Expected: both tests pass. If the diagnostic test is flaky, increase the timeout or assert on a specific marker via `page.evaluate(() => monaco.editor.getModelMarkers({}))` (you can expose `monaco` to `window` for testing).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/web-ide
+git commit -m "Playwright smoke + diagnostics e2e for the web playground"
+```
+
+---
+
+## Phase 10: Polish & ship
+
+### Task 10.1: Top-level documentation
+
+**Files:**
+
+- Modify: `DEVELOPMENT.md` (add a "Web playground" section with `cargo xtask web --dev` instructions and a note about `wasm-pack`/`rustup target add wasm32-unknown-unknown` prereqs).
+
+- [ ] **Step 1: Add a short section.**
+
+(This is the one place where adding documentation is justified — it's onboarding for the new build target, not gratuitous markdown.)
+
+```md
+## Web playground
+
+The `packages/web-ide` package hosts a Monaco editor wired to a wasm build of the LSP.
+
+Prereqs:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+```
+
+Build & run:
+
+```sh
+cargo xtask web --dev   # opens http://localhost:5173
+cargo xtask web         # static build under packages/web-ide/dist/
+```
+
+The wasm bundle is regenerated on each `xtask web` invocation; Vite picks up changes via its file watcher.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add DEVELOPMENT.md
+git commit -m "document \`xtask web\` workflow"
+```
+
+### Task 10.2: Changeset
+
+**Files:**
+
+- Create: `.changeset/<auto>.md` via `knope document-change`.
+
+- [ ] **Step 1: Run knope.**
+
+```bash
+knope document-change
+```
+
+Add a changeset noting:
+
+```md
+---
+graphql-lsp: minor
+graphql-lsp-wasm: minor
+"@graphql-analyzer/web-ide": minor
+---
+
+Add browser playground (`@graphql-analyzer/web-ide`) backed by a wasm build of the language server. The LSP can now compile to `wasm32-unknown-unknown` via the new `graphql-lsp-wasm` crate ([#TBD](https://github.com/trevor-scheer/graphql-analyzer/pull/TBD)).
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .changeset
+git commit -m "changeset: web playground"
+```
+
+### Task 10.3: Final verification
+
+- [ ] **Step 1: Native LSP regression check.**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Wasm LSP build.**
+
+```bash
+cargo build -p graphql-lsp-wasm --target wasm32-unknown-unknown --release
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Web playground build.**
+
+```bash
+cargo run -p xtask -- web
+```
+
+Expected: `packages/web-ide/dist/index.html` exists.
+
+- [ ] **Step 4: Web playground e2e.**
+
+```bash
+cd packages/web-ide && npm run test:e2e
+```
+
+Expected: pass.
+
+- [ ] **Step 5: VS Code extension still works (manual).**
+
+Per `DEVELOPMENT.md`, install the extension and verify nothing regressed in the existing IDE flow.
+
+---
+
+## Open risks / things to watch during execution
+
+- **`graphql_config::Config` JSON shape**: the `initializationOptions` payload in `main.ts` Task 7.5 must exactly match what `graphql_config::Config` deserializes from. Easiest verification: take an existing `.graphqlrc.yaml` from `test-workspace/`, run it through `serde_yaml::from_str::<Config>(...)` then `serde_json::to_string_pretty(&config)`, and pin that as the source of truth. If the shape doesn't fit cleanly into JSON (e.g., uses YAML-only features), expose a thin builder helper from `graphql-config` that JS can populate directly.
+- **`reqwest` wasm builder method gaps**: `connect_timeout`, custom `tls_built_in_root_certs`, and similar may not exist on the wasm path. Be ready to `#[cfg(not(target_arch = "wasm32"))]` individual builder calls.
+- **Monaco completion `range` field**: passing `undefined` works in older Monaco; current versions sometimes warn. If completions misbehave, compute the current word range from the model.
+- **Single-threaded analysis blocking the worker**: the worker's `handleMessage` returns synchronously after running `tick()`. For a small demo schema this is fine; for larger workspaces consider yielding via `setTimeout(..., 0)` between requests.
+- **`@codingame/monaco-vscode-api`**: explicitly *not* used. If we later need `monaco.editor.registerCommand` for code actions, evaluate whether to bring it in or hand-roll.
+- **Salsa rayon feature**: confirm `salsa = { default-features = false }` builds for wasm32 in Phase 4. If extra features are needed (`macros`, `inventory`, `accumulator`), enable them explicitly.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** all 6 user decisions covered — (1) `didOpen`-driven via `initializationOptions` (Task 4.3, 7.5); (2) parity introspection via target-cfg `reqwest` (Phase 5); (3) crate name `graphql-lsp-wasm` (Phase 6); (4) `packages/web-ide` location (Phase 7); (5) single-threaded `InlineDispatcher` (Task 2.x); (6) hand-rolled minimal client over `vscode-languageserver-protocol/browser` (Task 7.2).
+- **Placeholder scan:** every step has either a complete code block, a complete diff/instruction, or a verification command. No "TBD" / "implement later" wording.
+- **Type consistency:** `TaskDispatcher::execute(Box<dyn FnOnce() + Send + 'static>)` is the signature in Task 2.1 and 2.2; `tick(&Connection, &mut GlobalState) -> ControlFlow` is consistent across Task 3.1 and Task 6.1; the Server's `handleMessage(json: string) -> string[]` is consistent across the Rust impl (Task 6.1) and the TS shim (Task 7.4).
+- **Validation mechanism:** Phase 0 establishes the native baseline; each phase ends with a `cargo check` / `cargo nextest` step; Phase 9 establishes Playwright as the e2e validation. The engineer can iterate without needing the user to manually click around.

--- a/docs/superpowers/plans/2026-04-25-wasm-lsp.md
+++ b/docs/superpowers/plans/2026-04-25-wasm-lsp.md
@@ -1247,9 +1247,20 @@ export default defineConfig({
     <meta charset="utf-8" />
     <title>graphql-analyzer playground</title>
     <style>
-      html, body, #app { height: 100%; margin: 0; }
-      .editors { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
-      .editor { border-right: 1px solid #ccc; }
+      html,
+      body,
+      #app {
+        height: 100%;
+        margin: 0;
+      }
+      .editors {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        height: 100%;
+      }
+      .editor {
+        border-right: 1px solid #ccc;
+      }
     </style>
   </head>
   <body>
@@ -1311,10 +1322,7 @@ git commit -m "scaffold \`packages/web-ide\` with Vite + Monaco editors"
 - [ ] **Step 1: Implement the client.**
 
 ```ts
-import {
-  BrowserMessageReader,
-  BrowserMessageWriter,
-} from "vscode-jsonrpc/browser";
+import { BrowserMessageReader, BrowserMessageWriter } from "vscode-jsonrpc/browser";
 import { createMessageConnection } from "vscode-jsonrpc/browser";
 import type { MessageConnection } from "vscode-jsonrpc/browser";
 import type {
@@ -1343,9 +1351,12 @@ export class MinimalClient {
     const writer = new BrowserMessageWriter(this.worker);
     this.conn = createMessageConnection(reader, writer);
 
-    this.conn.onNotification("textDocument/publishDiagnostics", (params: PublishDiagnosticsParams) => {
-      for (const l of this.diagnosticsListeners) l(params);
-    });
+    this.conn.onNotification(
+      "textDocument/publishDiagnostics",
+      (params: PublishDiagnosticsParams) => {
+        for (const l of this.diagnosticsListeners) l(params);
+      },
+    );
 
     this.conn.listen();
 
@@ -1368,7 +1379,9 @@ export class MinimalClient {
     return result;
   }
 
-  onDiagnostics(l: DiagnosticsListener): void { this.diagnosticsListeners.push(l); }
+  onDiagnostics(l: DiagnosticsListener): void {
+    this.diagnosticsListeners.push(l);
+  }
 
   didOpen(params: DidOpenTextDocumentParams): void {
     this.conn.sendNotification("textDocument/didOpen", params);
@@ -1444,7 +1457,8 @@ export function wireProviders(client: MinimalClient): void {
           kind: monaco.languages.CompletionItemKind.Text,
           insertText: typeof it.insertText === "string" ? it.insertText : it.label,
           detail: it.detail,
-          documentation: typeof it.documentation === "string" ? it.documentation : it.documentation?.value,
+          documentation:
+            typeof it.documentation === "string" ? it.documentation : it.documentation?.value,
           range: undefined as unknown as monaco.IRange, // Monaco fills from current word.
         })),
       };
@@ -1461,9 +1475,7 @@ export function wireProviders(client: MinimalClient): void {
       if (!hover) return null;
       const contents = Array.isArray(hover.contents) ? hover.contents : [hover.contents];
       return {
-        contents: contents.map((c) =>
-          typeof c === "string" ? { value: c } : { value: c.value },
-        ),
+        contents: contents.map((c) => (typeof c === "string" ? { value: c } : { value: c.value })),
       };
     },
   });
@@ -1618,7 +1630,10 @@ const docUri = monaco.Uri.parse("inmemory://queries/example.graphql");
 const schemaModel = monaco.editor.createModel(schemaText, "graphql", schemaUri);
 const docModel = monaco.editor.createModel(docText, "graphql", docUri);
 
-monaco.editor.create(document.getElementById("schema")!, { model: schemaModel, automaticLayout: true });
+monaco.editor.create(document.getElementById("schema")!, {
+  model: schemaModel,
+  automaticLayout: true,
+});
 monaco.editor.create(document.getElementById("doc")!, { model: docModel, automaticLayout: true });
 
 const worker = new Worker(new URL("./lsp/worker.ts", import.meta.url), { type: "module" });
@@ -1797,7 +1812,7 @@ test("typing an unknown field produces a diagnostic", async ({ page }) => {
   await docEditor.click();
   await page.keyboard.press("Control+End");
   await page.keyboard.press("Enter");
-  await page.keyboard.type("query Bad { user(id: \"1\") { notARealField } }");
+  await page.keyboard.type('query Bad { user(id: "1") { notARealField } }');
 
   // A red squiggle in Monaco is rendered as an .squiggly-error span.
   await expect(page.locator(".squiggly-error").first()).toBeVisible({ timeout: 10_000 });
@@ -1835,7 +1850,7 @@ git commit -m "Playwright smoke + diagnostics e2e for the web playground"
 
 (This is the one place where adding documentation is justified — it's onboarding for the new build target, not gratuitous markdown.)
 
-```md
+````md
 ## Web playground
 
 The `packages/web-ide` package hosts a Monaco editor wired to a wasm build of the LSP.
@@ -1846,6 +1861,7 @@ Prereqs:
 rustup target add wasm32-unknown-unknown
 cargo install wasm-pack
 ```
+````
 
 Build & run:
 
@@ -1942,7 +1958,7 @@ Per `DEVELOPMENT.md`, install the extension and verify nothing regressed in the 
 - **`reqwest` wasm builder method gaps**: `connect_timeout`, custom `tls_built_in_root_certs`, and similar may not exist on the wasm path. Be ready to `#[cfg(not(target_arch = "wasm32"))]` individual builder calls.
 - **Monaco completion `range` field**: passing `undefined` works in older Monaco; current versions sometimes warn. If completions misbehave, compute the current word range from the model.
 - **Single-threaded analysis blocking the worker**: the worker's `handleMessage` returns synchronously after running `tick()`. For a small demo schema this is fine; for larger workspaces consider yielding via `setTimeout(..., 0)` between requests.
-- **`@codingame/monaco-vscode-api`**: explicitly *not* used. If we later need `monaco.editor.registerCommand` for code actions, evaluate whether to bring it in or hand-roll.
+- **`@codingame/monaco-vscode-api`**: explicitly _not_ used. If we later need `monaco.editor.registerCommand` for code actions, evaluate whether to bring it in or hand-roll.
 - **Salsa rayon feature**: confirm `salsa = { default-features = false }` builds for wasm32 in Phase 4. If extra features are needed (`macros`, `inventory`, `accumulator`), enable them explicitly.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9470,16 +9470,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1800,6 +1800,10 @@
       "resolved": "packages/eslint-plugin",
       "link": true
     },
+    "node_modules/@graphql-analyzer/web-ide": {
+      "resolved": "packages/web-ide",
+      "link": true
+    },
     "node_modules/@graphql-eslint/eslint-plugin": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
@@ -8270,6 +8274,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/monaco-editor": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.46.0.tgz",
+      "integrity": "sha512-ADwtLIIww+9FKybWscd7OCfm9odsFYHImBRI1v9AviGce55QY8raT+9ihH8jX/E/e6QVSGM+pKj4jSUSRmALNQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11089,6 +11099,525 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/web-ide": {
+      "name": "@graphql-analyzer/web-ide",
+      "version": "0.0.1",
+      "dependencies": {
+        "monaco-editor": "^0.46.0",
+        "vscode-jsonrpc": "^8.2.0",
+        "vscode-languageserver-protocol": "^3.17.5"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.43.0",
+        "typescript": "^5.4.0",
+        "vite": "^5.2.0"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/web-ide/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "packages/web-ide/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "packages/web-ide/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
     },
     "test-workspace/apollo-app": {
       "name": "graphql-lsp-test-workspace-apollo-app",

--- a/packages/web-ide/.gitignore
+++ b/packages/web-ide/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/web-ide/.gitignore
+++ b/packages/web-ide/.gitignore
@@ -1,2 +1,7 @@
 dist/
 node_modules/
+# wasm-pack output — the .d.ts stub is committed; the real artifacts are not
+src/wasm/*.js
+src/wasm/*.wasm
+src/wasm/*.ts.map
+!src/wasm/graphql_lsp_wasm.d.ts

--- a/packages/web-ide/.gitignore
+++ b/packages/web-ide/.gitignore
@@ -1,5 +1,7 @@
 dist/
 node_modules/
+test-results/
+playwright-report/
 # wasm-pack output — the .d.ts stub is committed; the real artifacts are not
 src/wasm/*.js
 src/wasm/*.wasm

--- a/packages/web-ide/index.html
+++ b/packages/web-ide/index.html
@@ -4,9 +4,20 @@
     <meta charset="utf-8" />
     <title>graphql-analyzer playground</title>
     <style>
-      html, body, #app { height: 100%; margin: 0; }
-      .editors { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
-      .editor { border-right: 1px solid #ccc; }
+      html,
+      body,
+      #app {
+        height: 100%;
+        margin: 0;
+      }
+      .editors {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        height: 100%;
+      }
+      .editor {
+        border-right: 1px solid #ccc;
+      }
     </style>
   </head>
   <body>

--- a/packages/web-ide/index.html
+++ b/packages/web-ide/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>graphql-analyzer playground</title>
+    <style>
+      html, body, #app { height: 100%; margin: 0; }
+      .editors { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
+      .editor { border-right: 1px solid #ccc; }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div class="editors">
+        <div id="schema" class="editor"></div>
+        <div id="doc" class="editor"></div>
+      </div>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/web-ide/package.json
+++ b/packages/web-ide/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@graphql-analyzer/web-ide",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "monaco-editor": "^0.46.0",
+    "vscode-jsonrpc": "^8.2.0",
+    "vscode-languageserver-protocol": "^3.17.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/packages/web-ide/playwright.config.ts
+++ b/packages/web-ide/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  // The debug wasm bundle is large (~22MB), so allow enough time for loading.
+  timeout: 90_000,
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: true,
+    timeout: 60_000,
+  },
+  use: { baseURL: "http://localhost:5173" },
+  testDir: "./tests",
+});

--- a/packages/web-ide/src/demo/queries/example.graphql
+++ b/packages/web-ide/src/demo/queries/example.graphql
@@ -1,0 +1,6 @@
+query GetUser {
+  user(id: "1") {
+    id
+    name
+  }
+}

--- a/packages/web-ide/src/demo/schema.graphql
+++ b/packages/web-ide/src/demo/schema.graphql
@@ -1,0 +1,9 @@
+type Query {
+  greeting: String
+  user(id: ID!): User
+}
+type User {
+  id: ID!
+  name: String!
+  email: String
+}

--- a/packages/web-ide/src/lsp/client.ts
+++ b/packages/web-ide/src/lsp/client.ts
@@ -53,10 +53,7 @@ export class MinimalClient {
       initializationOptions: initOptions,
       workspaceFolders: null,
     };
-    const result: InitializeResult = await this.conn.sendRequest(
-      "initialize",
-      params,
-    );
+    const result: InitializeResult = await this.conn.sendRequest("initialize", params);
     await this.conn.sendNotification("initialized", {});
     return result;
   }
@@ -73,9 +70,7 @@ export class MinimalClient {
     this.conn.sendNotification("textDocument/didChange", params);
   }
 
-  completion(
-    params: CompletionParams,
-  ): Promise<CompletionList | CompletionItem[] | null> {
+  completion(params: CompletionParams): Promise<CompletionList | CompletionItem[] | null> {
     return this.conn.sendRequest("textDocument/completion", params);
   }
 

--- a/packages/web-ide/src/lsp/client.ts
+++ b/packages/web-ide/src/lsp/client.ts
@@ -1,0 +1,85 @@
+import {
+  BrowserMessageReader,
+  BrowserMessageWriter,
+  createMessageConnection,
+} from "vscode-jsonrpc/browser";
+import type { MessageConnection } from "vscode-jsonrpc/browser";
+import type {
+  InitializeParams,
+  InitializeResult,
+  PublishDiagnosticsParams,
+  CompletionParams,
+  CompletionList,
+  CompletionItem,
+  HoverParams,
+  Hover,
+  DidOpenTextDocumentParams,
+  DidChangeTextDocumentParams,
+} from "vscode-languageserver-protocol";
+
+export type DiagnosticsListener = (params: PublishDiagnosticsParams) => void;
+
+export class MinimalClient {
+  private conn!: MessageConnection;
+  private diagnosticsListeners: DiagnosticsListener[] = [];
+
+  constructor(private worker: Worker) {}
+
+  async start(initOptions: unknown): Promise<InitializeResult> {
+    const reader = new BrowserMessageReader(this.worker);
+    const writer = new BrowserMessageWriter(this.worker);
+    this.conn = createMessageConnection(reader, writer);
+
+    this.conn.onNotification(
+      "textDocument/publishDiagnostics",
+      (params: PublishDiagnosticsParams) => {
+        for (const l of this.diagnosticsListeners) l(params);
+      },
+    );
+
+    this.conn.listen();
+
+    const params: InitializeParams = {
+      processId: null,
+      rootUri: null,
+      capabilities: {
+        textDocument: {
+          synchronization: { dynamicRegistration: false },
+          completion: { completionItem: { snippetSupport: false } },
+          hover: { contentFormat: ["plaintext", "markdown"] },
+          publishDiagnostics: {},
+        },
+      },
+      initializationOptions: initOptions,
+      workspaceFolders: null,
+    };
+    const result: InitializeResult = await this.conn.sendRequest(
+      "initialize",
+      params,
+    );
+    await this.conn.sendNotification("initialized", {});
+    return result;
+  }
+
+  onDiagnostics(l: DiagnosticsListener): void {
+    this.diagnosticsListeners.push(l);
+  }
+
+  didOpen(params: DidOpenTextDocumentParams): void {
+    this.conn.sendNotification("textDocument/didOpen", params);
+  }
+
+  didChange(params: DidChangeTextDocumentParams): void {
+    this.conn.sendNotification("textDocument/didChange", params);
+  }
+
+  completion(
+    params: CompletionParams,
+  ): Promise<CompletionList | CompletionItem[] | null> {
+    return this.conn.sendRequest("textDocument/completion", params);
+  }
+
+  hover(params: HoverParams): Promise<Hover | null> {
+    return this.conn.sendRequest("textDocument/hover", params);
+  }
+}

--- a/packages/web-ide/src/lsp/providers.ts
+++ b/packages/web-ide/src/lsp/providers.ts
@@ -26,9 +26,7 @@ export function wireProviders(client: MinimalClient): void {
         },
       };
       const result = await client.completion(params);
-      const items: LspCompletionItem[] = Array.isArray(result)
-        ? result
-        : (result?.items ?? []);
+      const items: LspCompletionItem[] = Array.isArray(result) ? result : (result?.items ?? []);
       const word = model.getWordUntilPosition(position);
       const range: monaco.IRange = {
         startLineNumber: position.lineNumber,
@@ -43,9 +41,7 @@ export function wireProviders(client: MinimalClient): void {
           insertText: typeof it.insertText === "string" ? it.insertText : it.label,
           detail: it.detail,
           documentation:
-            typeof it.documentation === "string"
-              ? it.documentation
-              : it.documentation?.value,
+            typeof it.documentation === "string" ? it.documentation : it.documentation?.value,
           range,
         })),
       };
@@ -63,26 +59,18 @@ export function wireProviders(client: MinimalClient): void {
       };
       const hover: LspHover | null = await client.hover(params);
       if (!hover) return null;
-      const contents = Array.isArray(hover.contents)
-        ? hover.contents
-        : [hover.contents];
+      const contents = Array.isArray(hover.contents) ? hover.contents : [hover.contents];
       return {
-        contents: contents.map((c) =>
-          typeof c === "string" ? { value: c } : { value: c.value },
-        ),
+        contents: contents.map((c) => (typeof c === "string" ? { value: c } : { value: c.value })),
       };
     },
   });
 
   client.onDiagnostics((params: PublishDiagnosticsParams) => {
-    const model = monaco
-      .editor
-      .getModels()
-      .find((m) => m.uri.toString() === params.uri);
+    const model = monaco.editor.getModels().find((m) => m.uri.toString() === params.uri);
     if (!model) return;
     const markers = params.diagnostics.map((d: Diagnostic) => ({
-      severity:
-        lspSeverityToMarker[d.severity ?? 1] ?? monaco.MarkerSeverity.Error,
+      severity: lspSeverityToMarker[d.severity ?? 1] ?? monaco.MarkerSeverity.Error,
       startLineNumber: d.range.start.line + 1,
       startColumn: d.range.start.character + 1,
       endLineNumber: d.range.end.line + 1,

--- a/packages/web-ide/src/lsp/providers.ts
+++ b/packages/web-ide/src/lsp/providers.ts
@@ -1,0 +1,95 @@
+import * as monaco from "monaco-editor";
+import type { MinimalClient } from "./client";
+import type {
+  PublishDiagnosticsParams,
+  Diagnostic,
+  CompletionItem as LspCompletionItem,
+  Hover as LspHover,
+} from "vscode-languageserver-protocol";
+
+const lspSeverityToMarker: Record<number, monaco.MarkerSeverity> = {
+  1: monaco.MarkerSeverity.Error,
+  2: monaco.MarkerSeverity.Warning,
+  3: monaco.MarkerSeverity.Info,
+  4: monaco.MarkerSeverity.Hint,
+};
+
+export function wireProviders(client: MinimalClient): void {
+  monaco.languages.registerCompletionItemProvider("graphql", {
+    triggerCharacters: [".", "$", "@", " ", "{", "(", ":"],
+    provideCompletionItems: async (model, position) => {
+      const params = {
+        textDocument: { uri: model.uri.toString() },
+        position: {
+          line: position.lineNumber - 1,
+          character: position.column - 1,
+        },
+      };
+      const result = await client.completion(params);
+      const items: LspCompletionItem[] = Array.isArray(result)
+        ? result
+        : (result?.items ?? []);
+      const word = model.getWordUntilPosition(position);
+      const range: monaco.IRange = {
+        startLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endLineNumber: position.lineNumber,
+        endColumn: word.endColumn,
+      };
+      return {
+        suggestions: items.map((it) => ({
+          label: it.label,
+          kind: monaco.languages.CompletionItemKind.Text,
+          insertText: typeof it.insertText === "string" ? it.insertText : it.label,
+          detail: it.detail,
+          documentation:
+            typeof it.documentation === "string"
+              ? it.documentation
+              : it.documentation?.value,
+          range,
+        })),
+      };
+    },
+  });
+
+  monaco.languages.registerHoverProvider("graphql", {
+    provideHover: async (model, position) => {
+      const params = {
+        textDocument: { uri: model.uri.toString() },
+        position: {
+          line: position.lineNumber - 1,
+          character: position.column - 1,
+        },
+      };
+      const hover: LspHover | null = await client.hover(params);
+      if (!hover) return null;
+      const contents = Array.isArray(hover.contents)
+        ? hover.contents
+        : [hover.contents];
+      return {
+        contents: contents.map((c) =>
+          typeof c === "string" ? { value: c } : { value: c.value },
+        ),
+      };
+    },
+  });
+
+  client.onDiagnostics((params: PublishDiagnosticsParams) => {
+    const model = monaco
+      .editor
+      .getModels()
+      .find((m) => m.uri.toString() === params.uri);
+    if (!model) return;
+    const markers = params.diagnostics.map((d: Diagnostic) => ({
+      severity:
+        lspSeverityToMarker[d.severity ?? 1] ?? monaco.MarkerSeverity.Error,
+      startLineNumber: d.range.start.line + 1,
+      startColumn: d.range.start.character + 1,
+      endLineNumber: d.range.end.line + 1,
+      endColumn: d.range.end.character + 1,
+      message: d.message,
+      source: d.source ?? "graphql",
+    }));
+    monaco.editor.setModelMarkers(model, "graphql", markers);
+  });
+}

--- a/packages/web-ide/src/lsp/worker.ts
+++ b/packages/web-ide/src/lsp/worker.ts
@@ -8,9 +8,23 @@ import {
 
 declare const self: DedicatedWorkerGlobalScope;
 
+// Buffer messages that arrive before the wasm module finishes loading.
+// BrowserMessageReader sets self.onmessage in its constructor, which fires any
+// already-queued messages synchronously — before reader.listen() has registered
+// a callback. We capture those messages here and replay them afterwards.
+const pendingMessages: MessageEvent[] = [];
+function bufferMessage(e: MessageEvent) {
+  pendingMessages.push(e);
+}
+self.addEventListener("message", bufferMessage);
+
 async function main() {
   await init();
   const server = new Server();
+
+  // Stop buffering before BrowserMessageReader installs its own self.onmessage,
+  // then replay any messages that arrived during wasm init.
+  self.removeEventListener("message", bufferMessage);
 
   const reader = new BrowserMessageReader(self);
   const writer = new BrowserMessageWriter(self);
@@ -22,6 +36,11 @@ async function main() {
       writer.write(JSON.parse(out));
     }
   });
+
+  // Replay buffered messages through the now-live reader path.
+  for (const e of pendingMessages) {
+    self.dispatchEvent(new MessageEvent("message", { data: e.data }));
+  }
 }
 
 main().catch((e) => console.error("worker init failed", e));

--- a/packages/web-ide/src/lsp/worker.ts
+++ b/packages/web-ide/src/lsp/worker.ts
@@ -1,0 +1,27 @@
+/// <reference lib="webworker" />
+// Needed for DedicatedWorkerGlobalScope to be in scope for BrowserMessageReader/Writer.
+import init, { Server } from "../wasm/graphql_lsp_wasm";
+import {
+  BrowserMessageReader,
+  BrowserMessageWriter,
+} from "vscode-jsonrpc/browser";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+async function main() {
+  await init();
+  const server = new Server();
+
+  const reader = new BrowserMessageReader(self);
+  const writer = new BrowserMessageWriter(self);
+
+  reader.listen((msg) => {
+    const json = JSON.stringify(msg);
+    const outbound: string[] = server.handleMessage(json);
+    for (const out of outbound) {
+      writer.write(JSON.parse(out));
+    }
+  });
+}
+
+main().catch((e) => console.error("worker init failed", e));

--- a/packages/web-ide/src/lsp/worker.ts
+++ b/packages/web-ide/src/lsp/worker.ts
@@ -1,10 +1,7 @@
 /// <reference lib="webworker" />
 // Needed for DedicatedWorkerGlobalScope to be in scope for BrowserMessageReader/Writer.
 import init, { Server } from "../wasm/graphql_lsp_wasm";
-import {
-  BrowserMessageReader,
-  BrowserMessageWriter,
-} from "vscode-jsonrpc/browser";
+import { BrowserMessageReader, BrowserMessageWriter } from "vscode-jsonrpc/browser";
 
 declare const self: DedicatedWorkerGlobalScope;
 

--- a/packages/web-ide/src/main.ts
+++ b/packages/web-ide/src/main.ts
@@ -1,6 +1,9 @@
 import * as monaco from "monaco-editor";
 import { MinimalClient } from "./lsp/client";
 import { wireProviders } from "./lsp/providers";
+
+// Expose monaco globally so Playwright tests can call getModelMarkers.
+(window as unknown as Record<string, unknown>).__monaco = monaco;
 import schemaText from "./demo/schema.graphql?raw";
 import docText from "./demo/queries/example.graphql?raw";
 
@@ -21,15 +24,32 @@ monaco.editor.create(document.getElementById("doc")!, {
   automaticLayout: true,
 });
 
+console.log("Creating LSP worker...");
 const worker = new Worker(new URL("./lsp/worker.ts", import.meta.url), {
   type: "module",
 });
+worker.addEventListener("error", (e) => {
+  console.error("LSP worker error:", e.message, e.filename, e.lineno);
+});
+worker.addEventListener("messageerror", (e) => {
+  console.error("LSP worker messageerror:", e);
+});
+console.log("LSP worker created");
 const client = new MinimalClient(worker);
 const initOptions = {
   schema: "schema.graphql",
   documents: "**/*.graphql",
 };
-await client.start(initOptions);
+let initResult;
+try {
+  initResult = await client.start(initOptions);
+  console.log("LSP initialized", initResult.capabilities);
+  // Signal to e2e tests that the LSP is ready.
+  (window as unknown as Record<string, unknown>).__lspReady = true;
+} catch (e) {
+  console.error("LSP initialize failed", e);
+  throw e;
+}
 
 wireProviders(client);
 

--- a/packages/web-ide/src/main.ts
+++ b/packages/web-ide/src/main.ts
@@ -1,16 +1,69 @@
 import * as monaco from "monaco-editor";
+import { MinimalClient } from "./lsp/client";
+import { wireProviders } from "./lsp/providers";
+import schemaText from "./demo/schema.graphql?raw";
+import docText from "./demo/queries/example.graphql?raw";
 
 monaco.languages.register({ id: "graphql", extensions: [".graphql", ".gql"] });
 
-const schema = monaco.editor.create(document.getElementById("schema")!, {
-  language: "graphql",
-  value: "# schema goes here\n",
+const schemaUri = monaco.Uri.parse("inmemory://schema.graphql");
+const docUri = monaco.Uri.parse("inmemory://queries/example.graphql");
+
+const schemaModel = monaco.editor.createModel(schemaText, "graphql", schemaUri);
+const docModel = monaco.editor.createModel(docText, "graphql", docUri);
+
+monaco.editor.create(document.getElementById("schema")!, {
+  model: schemaModel,
   automaticLayout: true,
 });
-const doc = monaco.editor.create(document.getElementById("doc")!, {
-  language: "graphql",
-  value: "# query goes here\n",
+monaco.editor.create(document.getElementById("doc")!, {
+  model: docModel,
   automaticLayout: true,
 });
 
-console.log("editors mounted", schema.getModel(), doc.getModel());
+const worker = new Worker(new URL("./lsp/worker.ts", import.meta.url), {
+  type: "module",
+});
+const client = new MinimalClient(worker);
+const initOptions = {
+  schema: "schema.graphql",
+  documents: "**/*.graphql",
+};
+await client.start(initOptions);
+
+wireProviders(client);
+
+function pushOpen(model: monaco.editor.ITextModel) {
+  client.didOpen({
+    textDocument: {
+      uri: model.uri.toString(),
+      languageId: "graphql",
+      version: model.getVersionId(),
+      text: model.getValue(),
+    },
+  });
+  model.onDidChangeContent((e) => {
+    client.didChange({
+      textDocument: {
+        uri: model.uri.toString(),
+        version: model.getVersionId(),
+      },
+      contentChanges: e.changes.map((c) => ({
+        range: {
+          start: {
+            line: c.range.startLineNumber - 1,
+            character: c.range.startColumn - 1,
+          },
+          end: {
+            line: c.range.endLineNumber - 1,
+            character: c.range.endColumn - 1,
+          },
+        },
+        rangeLength: c.rangeLength,
+        text: c.text,
+      })),
+    });
+  });
+}
+pushOpen(schemaModel);
+pushOpen(docModel);

--- a/packages/web-ide/src/main.ts
+++ b/packages/web-ide/src/main.ts
@@ -1,0 +1,16 @@
+import * as monaco from "monaco-editor";
+
+monaco.languages.register({ id: "graphql", extensions: [".graphql", ".gql"] });
+
+const schema = monaco.editor.create(document.getElementById("schema")!, {
+  language: "graphql",
+  value: "# schema goes here\n",
+  automaticLayout: true,
+});
+const doc = monaco.editor.create(document.getElementById("doc")!, {
+  language: "graphql",
+  value: "# query goes here\n",
+  automaticLayout: true,
+});
+
+console.log("editors mounted", schema.getModel(), doc.getModel());

--- a/packages/web-ide/src/vite-env.d.ts
+++ b/packages/web-ide/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
+++ b/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
@@ -1,0 +1,7 @@
+// Stub for the wasm-pack generated module. wasm-pack overwrites this when
+// `xtask web` runs; until then, this unblocks `tsc --noEmit`.
+export default function init(): Promise<void>;
+export class Server {
+  constructor();
+  handleMessage(json: string): string[];
+}

--- a/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
+++ b/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
@@ -19,9 +19,9 @@ export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembl
 export interface InitOutput {
     readonly memory: WebAssembly.Memory;
     readonly __wbg_server_free: (a: number, b: number) => void;
-    readonly init: () => void;
     readonly server_handleMessage: (a: number, b: number, c: number) => [number, number, number];
     readonly server_new: () => number;
+    readonly init: () => void;
     readonly __wbindgen_free_command_export: (a: number, b: number, c: number) => void;
     readonly __wbindgen_exn_store_command_export: (a: number) => void;
     readonly __externref_table_alloc_command_export: () => number;

--- a/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
+++ b/packages/web-ide/src/wasm/graphql_lsp_wasm.d.ts
@@ -1,7 +1,55 @@
-// Stub for the wasm-pack generated module. wasm-pack overwrites this when
-// `xtask web` runs; until then, this unblocks `tsc --noEmit`.
-export default function init(): Promise<void>;
+/* tslint:disable */
+/* eslint-disable */
+
 export class Server {
-  constructor();
-  handleMessage(json: string): string[];
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * Feed an inbound LSP JSON-RPC message (already unframed). Returns an array
+     * of outbound JSON strings the worker should write back to the client.
+     */
+    handleMessage(json: string): Array<any>;
+    constructor();
 }
+
+export function init(): void;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly __wbg_server_free: (a: number, b: number) => void;
+    readonly init: () => void;
+    readonly server_handleMessage: (a: number, b: number, c: number) => [number, number, number];
+    readonly server_new: () => number;
+    readonly __wbindgen_free_command_export: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_exn_store_command_export: (a: number) => void;
+    readonly __externref_table_alloc_command_export: () => number;
+    readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_malloc_command_export: (a: number, b: number) => number;
+    readonly __wbindgen_realloc_command_export: (a: number, b: number, c: number, d: number) => number;
+    readonly __externref_table_dealloc_command_export: (a: number) => void;
+    readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/packages/web-ide/tests/web-ide.spec.ts
+++ b/packages/web-ide/tests/web-ide.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 // The wasm bundle is large (~22MB in debug builds), so loading can take a while.
 // We poll for readiness signals rather than using fixed sleeps.
 const WASM_INIT_TIMEOUT = 60_000;
 
-async function waitForLspReady(page: Parameters<typeof test>[1]["page"]) {
+async function waitForLspReady(page: Page) {
   // Poll until window.__monaco is available and __lspReady is set.
   await expect
     .poll(

--- a/packages/web-ide/tests/web-ide.spec.ts
+++ b/packages/web-ide/tests/web-ide.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+
+// The wasm bundle is large (~22MB in debug builds), so loading can take a while.
+// We poll for readiness signals rather than using fixed sleeps.
+const WASM_INIT_TIMEOUT = 60_000;
+
+async function waitForLspReady(page: Parameters<typeof test>[1]["page"]) {
+  // Poll until window.__monaco is available and __lspReady is set.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          return (window as unknown as Record<string, unknown>).__lspReady === true;
+        }),
+      { timeout: WASM_INIT_TIMEOUT, message: "timed out waiting for LSP to initialize" },
+    )
+    .toBe(true);
+}
+
+test("editors mount and worker initializes", async ({ page }) => {
+  const messages: string[] = [];
+  page.on("console", (m) => messages.push(m.text()));
+
+  await page.goto("/");
+  await expect(page.locator(".monaco-editor").first()).toBeVisible();
+  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+
+  await waitForLspReady(page);
+
+  // At this point the LSP has responded to the initialize request.
+  expect(messages.find((m) => /initialize|capabilities|GraphQL|LSP/i.test(m))).toBeTruthy();
+});
+
+test("typing a syntax error produces a diagnostic marker", async ({ page }) => {
+  await page.goto("/");
+
+  // Wait for both editors to mount.
+  await expect(page.locator(".monaco-editor").first()).toBeVisible();
+  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+
+  // Wait for the LSP worker to fully initialize (wasm loading can be slow).
+  await waitForLspReady(page);
+
+  // Click the document editor (second Monaco instance) and append a syntax error.
+  const docEditor = page.locator(".monaco-editor").nth(1);
+  await docEditor.click();
+  await page.keyboard.press("Control+End");
+  await page.keyboard.press("Enter");
+  // Intentionally unclosed brace — guaranteed parser-level syntax error.
+  // Schema-aware field validation may not work under wasm yet (Task 19 limitation)
+  // but syntax errors are always surfaced.
+  await page.keyboard.type('query Bad { user(id: "1") {');
+
+  // Poll for Monaco markers via the exposed window.__monaco global.
+  await expect
+    .poll(
+      async () => {
+        const markers = await page.evaluate(() => {
+          const m = (window as unknown as Record<string, unknown>).__monaco;
+          if (!m) return 0;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (m as any).editor.getModelMarkers({}).length;
+        });
+        return markers;
+      },
+      { timeout: 10_000, message: "expected at least one LSP diagnostic marker" },
+    )
+    .toBeGreaterThan(0);
+});

--- a/packages/web-ide/tests/web-ide.spec.ts
+++ b/packages/web-ide/tests/web-ide.spec.ts
@@ -47,8 +47,6 @@ test("typing a syntax error produces a diagnostic marker", async ({ page }) => {
   await page.keyboard.press("Control+End");
   await page.keyboard.press("Enter");
   // Intentionally unclosed brace — guaranteed parser-level syntax error.
-  // Schema-aware field validation may not work under wasm yet (Task 19 limitation)
-  // but syntax errors are always surfaced.
   await page.keyboard.type('query Bad { user(id: "1") {');
 
   // Poll for Monaco markers via the exposed window.__monaco global.
@@ -66,4 +64,50 @@ test("typing a syntax error produces a diagnostic marker", async ({ page }) => {
       { timeout: 10_000, message: "expected at least one LSP diagnostic marker" },
     )
     .toBeGreaterThan(0);
+});
+
+test("schema-aware validation flags an unknown field", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.locator(".monaco-editor").first()).toBeVisible();
+  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+  await waitForLspReady(page);
+
+  // Replace the document editor's content with a query referencing a field
+  // that doesn't exist on `User`. This exercises type-aware validation, which
+  // requires the schema editor's contents to be paired correctly with the
+  // document file (i.e. wasm-side workspace routing).
+  await page.evaluate(() => {
+    const m = (window as unknown as Record<string, unknown>).__monaco;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const monaco = m as any;
+    const docModel = monaco.editor
+      .getModels()
+      .find((mod: { uri: { toString(): string } }) =>
+        mod.uri.toString().includes("queries/example.graphql"),
+      );
+    docModel?.setValue("query Bad { user(id: \"1\") { notARealField } }\n");
+  });
+
+  // The schema-aware diagnostic should arrive within a couple seconds. We
+  // specifically look for a marker whose message mentions the field name to
+  // distinguish it from any unrelated syntax error.
+  await expect
+    .poll(
+      async () => {
+        const messages = await page.evaluate(() => {
+          const m = (window as unknown as Record<string, unknown>).__monaco;
+          if (!m) return [] as string[];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const markers = (m as any).editor.getModelMarkers({}) as Array<{ message: string }>;
+          return markers.map((mk) => mk.message);
+        });
+        return messages.some((msg) => /notARealField/i.test(msg));
+      },
+      {
+        timeout: 10_000,
+        message: "expected a schema-aware diagnostic mentioning `notARealField`",
+      },
+    )
+    .toBe(true);
 });

--- a/packages/web-ide/tests/web-ide.spec.ts
+++ b/packages/web-ide/tests/web-ide.spec.ts
@@ -4,6 +4,26 @@ import { test, expect, type Page } from "@playwright/test";
 // We poll for readiness signals rather than using fixed sleeps.
 const WASM_INIT_TIMEOUT = 60_000;
 
+// Attach diagnostic listeners early so a worker-init failure (network, MIME,
+// runtime) is visible in the CI log instead of a bare `waitForLspReady` timeout.
+function attachDiagnostics(page: Page, label: string): { dump: () => void } {
+  const consoleMessages: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (m) => consoleMessages.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => pageErrors.push(`[pageerror] ${e.message}`));
+  page.on("requestfailed", (req) => {
+    pageErrors.push(`[requestfailed] ${req.url()} — ${req.failure()?.errorText ?? "?"}`);
+  });
+  return {
+    dump: () => {
+      console.error(`--- ${label}: console (${consoleMessages.length}) ---`);
+      for (const m of consoleMessages) console.error(m);
+      console.error(`--- ${label}: errors (${pageErrors.length}) ---`);
+      for (const e of pageErrors) console.error(e);
+    },
+  };
+}
+
 async function waitForLspReady(page: Page) {
   // Poll until window.__monaco is available and __lspReady is set.
   await expect
@@ -20,94 +40,112 @@ async function waitForLspReady(page: Page) {
 test("editors mount and worker initializes", async ({ page }) => {
   const messages: string[] = [];
   page.on("console", (m) => messages.push(m.text()));
+  const diag = attachDiagnostics(page, "editors mount");
 
-  await page.goto("/");
-  await expect(page.locator(".monaco-editor").first()).toBeVisible();
-  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+  try {
+    await page.goto("/");
+    await expect(page.locator(".monaco-editor").first()).toBeVisible();
+    await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
 
-  await waitForLspReady(page);
+    await waitForLspReady(page);
 
-  // At this point the LSP has responded to the initialize request.
-  expect(messages.find((m) => /initialize|capabilities|GraphQL|LSP/i.test(m))).toBeTruthy();
+    // At this point the LSP has responded to the initialize request.
+    expect(messages.find((m) => /initialize|capabilities|GraphQL|LSP/i.test(m))).toBeTruthy();
+  } catch (e) {
+    diag.dump();
+    throw e;
+  }
 });
 
 test("typing a syntax error produces a diagnostic marker", async ({ page }) => {
-  await page.goto("/");
+  const diag = attachDiagnostics(page, "syntax error");
+  try {
+    await page.goto("/");
 
-  // Wait for both editors to mount.
-  await expect(page.locator(".monaco-editor").first()).toBeVisible();
-  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+    // Wait for both editors to mount.
+    await expect(page.locator(".monaco-editor").first()).toBeVisible();
+    await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
 
-  // Wait for the LSP worker to fully initialize (wasm loading can be slow).
-  await waitForLspReady(page);
+    // Wait for the LSP worker to fully initialize (wasm loading can be slow).
+    await waitForLspReady(page);
 
-  // Click the document editor (second Monaco instance) and append a syntax error.
-  const docEditor = page.locator(".monaco-editor").nth(1);
-  await docEditor.click();
-  await page.keyboard.press("Control+End");
-  await page.keyboard.press("Enter");
-  // Intentionally unclosed brace — guaranteed parser-level syntax error.
-  await page.keyboard.type('query Bad { user(id: "1") {');
+    // Click the document editor (second Monaco instance) and append a syntax error.
+    const docEditor = page.locator(".monaco-editor").nth(1);
+    await docEditor.click();
+    await page.keyboard.press("Control+End");
+    await page.keyboard.press("Enter");
+    // Intentionally unclosed brace — guaranteed parser-level syntax error.
+    await page.keyboard.type('query Bad { user(id: "1") {');
 
-  // Poll for Monaco markers via the exposed window.__monaco global.
-  await expect
-    .poll(
-      async () => {
-        const markers = await page.evaluate(() => {
-          const m = (window as unknown as Record<string, unknown>).__monaco;
-          if (!m) return 0;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (m as any).editor.getModelMarkers({}).length;
-        });
-        return markers;
-      },
-      { timeout: 10_000, message: "expected at least one LSP diagnostic marker" },
-    )
-    .toBeGreaterThan(0);
+    // Poll for Monaco markers via the exposed window.__monaco global.
+    await expect
+      .poll(
+        async () => {
+          const markers = await page.evaluate(() => {
+            const m = (window as unknown as Record<string, unknown>).__monaco;
+            if (!m) return 0;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (m as any).editor.getModelMarkers({}).length;
+          });
+          return markers;
+        },
+        { timeout: 10_000, message: "expected at least one LSP diagnostic marker" },
+      )
+      .toBeGreaterThan(0);
+  } catch (e) {
+    diag.dump();
+    throw e;
+  }
 });
 
 test("schema-aware validation flags an unknown field", async ({ page }) => {
-  await page.goto("/");
+  const diag = attachDiagnostics(page, "schema-aware");
+  try {
+    await page.goto("/");
 
-  await expect(page.locator(".monaco-editor").first()).toBeVisible();
-  await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
-  await waitForLspReady(page);
+    await expect(page.locator(".monaco-editor").first()).toBeVisible();
+    await expect(page.locator(".monaco-editor").nth(1)).toBeVisible();
+    await waitForLspReady(page);
 
-  // Replace the document editor's content with a query referencing a field
-  // that doesn't exist on `User`. This exercises type-aware validation, which
-  // requires the schema editor's contents to be paired correctly with the
-  // document file (i.e. wasm-side workspace routing).
-  await page.evaluate(() => {
-    const m = (window as unknown as Record<string, unknown>).__monaco;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const monaco = m as any;
-    const docModel = monaco.editor
-      .getModels()
-      .find((mod: { uri: { toString(): string } }) =>
-        mod.uri.toString().includes("queries/example.graphql"),
-      );
-    docModel?.setValue('query Bad { user(id: "1") { notARealField } }\n');
-  });
+    // Replace the document editor's content with a query referencing a field
+    // that doesn't exist on `User`. This exercises type-aware validation, which
+    // requires the schema editor's contents to be paired correctly with the
+    // document file (i.e. wasm-side workspace routing).
+    await page.evaluate(() => {
+      const m = (window as unknown as Record<string, unknown>).__monaco;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const monaco = m as any;
+      const docModel = monaco.editor
+        .getModels()
+        .find((mod: { uri: { toString(): string } }) =>
+          mod.uri.toString().includes("queries/example.graphql"),
+        );
+      docModel?.setValue('query Bad { user(id: "1") { notARealField } }\n');
+    });
 
-  // The schema-aware diagnostic should arrive within a couple seconds. We
-  // specifically look for a marker whose message mentions the field name to
-  // distinguish it from any unrelated syntax error.
-  await expect
-    .poll(
-      async () => {
-        const messages = await page.evaluate(() => {
-          const m = (window as unknown as Record<string, unknown>).__monaco;
-          if (!m) return [] as string[];
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const markers = (m as any).editor.getModelMarkers({}) as Array<{ message: string }>;
-          return markers.map((mk) => mk.message);
-        });
-        return messages.some((msg) => /notARealField/i.test(msg));
-      },
-      {
-        timeout: 10_000,
-        message: "expected a schema-aware diagnostic mentioning `notARealField`",
-      },
-    )
-    .toBe(true);
+    // The schema-aware diagnostic should arrive within a couple seconds. We
+    // specifically look for a marker whose message mentions the field name to
+    // distinguish it from any unrelated syntax error.
+    await expect
+      .poll(
+        async () => {
+          const messages = await page.evaluate(() => {
+            const m = (window as unknown as Record<string, unknown>).__monaco;
+            if (!m) return [] as string[];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const markers = (m as any).editor.getModelMarkers({}) as Array<{ message: string }>;
+            return markers.map((mk) => mk.message);
+          });
+          return messages.some((msg) => /notARealField/i.test(msg));
+        },
+        {
+          timeout: 10_000,
+          message: "expected a schema-aware diagnostic mentioning `notARealField`",
+        },
+      )
+      .toBe(true);
+  } catch (e) {
+    diag.dump();
+    throw e;
+  }
 });

--- a/packages/web-ide/tests/web-ide.spec.ts
+++ b/packages/web-ide/tests/web-ide.spec.ts
@@ -86,7 +86,7 @@ test("schema-aware validation flags an unknown field", async ({ page }) => {
       .find((mod: { uri: { toString(): string } }) =>
         mod.uri.toString().includes("queries/example.graphql"),
       );
-    docModel?.setValue("query Bad { user(id: \"1\") { notARealField } }\n");
+    docModel?.setValue('query Bad { user(id: "1") { notARealField } }\n');
   });
 
   // The schema-aware diagnostic should arrive within a couple seconds. We

--- a/packages/web-ide/tsconfig.json
+++ b/packages/web-ide/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "types": [],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/web-ide/vite.config.ts
+++ b/packages/web-ide/vite.config.ts
@@ -36,6 +36,6 @@ export default defineConfig({
   build: { target: "esnext" },
   worker: { format: "es", plugins: () => [wasmStubPlugin()] },
   optimizeDeps: { exclude: ["monaco-editor"] },
-  server: { fs: { allow: [".."] } },
+  server: { fs: { allow: [resolve(__dirname, "../..")] } },
   plugins: [wasmStubPlugin()],
 });

--- a/packages/web-ide/vite.config.ts
+++ b/packages/web-ide/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  worker: { format: "es" },
+  optimizeDeps: { exclude: ["monaco-editor"] },
+  server: { fs: { allow: [".."] } },
+});

--- a/packages/web-ide/vite.config.ts
+++ b/packages/web-ide/vite.config.ts
@@ -1,7 +1,41 @@
-import { defineConfig } from "vite";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig, type Plugin } from "vite";
+
+// When wasm-pack hasn't run yet (no .js alongside the .d.ts stub), provide a
+// placeholder module so `tsc --noEmit` and `vite build` succeed without the
+// real wasm artifact. `xtask web` generates the real file before building.
+const WASM_MODULE_ID = resolve(__dirname, "src/wasm/graphql_lsp_wasm.js");
+const WASM_STUB_ID = "\0virtual:graphql-lsp-wasm-stub";
+
+function wasmStubPlugin(): Plugin {
+  return {
+    name: "wasm-stub",
+    resolveId(id, _importer, _options) {
+      if (id.includes("graphql_lsp_wasm") && !existsSync(WASM_MODULE_ID)) {
+        return WASM_STUB_ID;
+      }
+    },
+    load(id) {
+      if (id === WASM_STUB_ID) {
+        return [
+          "export default function init() {",
+          "  return Promise.reject(new Error('wasm not built — run xtask web'));",
+          "}",
+          "export class Server {",
+          "  constructor() { throw new Error('wasm not built — run xtask web'); }",
+          "  handleMessage(_json) { throw new Error('wasm not built — run xtask web'); }",
+          "}",
+        ].join("\n");
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  worker: { format: "es" },
+  build: { target: "esnext" },
+  worker: { format: "es", plugins: () => [wasmStubPlugin()] },
   optimizeDeps: { exclude: ["monaco-editor"] },
   server: { fs: { allow: [".."] } },
+  plugins: [wasmStubPlugin()],
 });

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,12 @@ enum Commands {
         #[arg(long)]
         release: bool,
     },
+    /// Build the wasm LSP and run/build the web playground.
+    Web {
+        /// Run the Vite dev server (default: build only)
+        #[arg(long)]
+        dev: bool,
+    },
     /// Build release artifacts locally (cargo-dist + `VSCode` extension)
     Release {
         /// Specific target triple to build for (defaults to host target)
@@ -58,6 +64,7 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Install { release } => install(release),
+        Commands::Web { dev } => cmd_web(dev),
         Commands::Release {
             target,
             all_targets,
@@ -82,6 +89,32 @@ fn project_root() -> PathBuf {
         .parent()
         .expect("xtask should be in project root")
         .to_path_buf()
+}
+
+fn cmd_web(dev: bool) -> Result<()> {
+    let workspace = project_root();
+    let pkg_dir = workspace.join("packages/web-ide/src/wasm");
+    let status = Command::new("wasm-pack")
+        .args(["build", "crates/lsp-wasm", "--target", "web", "--out-dir"])
+        .arg(&pkg_dir)
+        .arg("--dev")
+        .current_dir(&workspace)
+        .status()
+        .context("running wasm-pack")?;
+    if !status.success() {
+        bail!("wasm-pack failed");
+    }
+
+    let script = if dev { "dev" } else { "build" };
+    let status = Command::new("npm")
+        .args(["--workspace=packages/web-ide", "run", script])
+        .current_dir(&workspace)
+        .status()
+        .context("running npm script")?;
+    if !status.success() {
+        bail!("npm {} failed", script);
+    }
+    Ok(())
 }
 
 fn install(release: bool) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -94,10 +94,13 @@ fn project_root() -> PathBuf {
 fn cmd_web(dev: bool) -> Result<()> {
     let workspace = project_root();
     let pkg_dir = workspace.join("packages/web-ide/src/wasm");
-    let status = Command::new("wasm-pack")
-        .args(["build", "crates/lsp-wasm", "--target", "web", "--out-dir"])
-        .arg(&pkg_dir)
-        .arg("--dev")
+    let mut cmd = Command::new("wasm-pack");
+    cmd.args(["build", "crates/lsp-wasm", "--target", "web", "--out-dir"]);
+    cmd.arg(&pkg_dir);
+    if dev {
+        cmd.arg("--dev");
+    }
+    let status = cmd
         .current_dir(&workspace)
         .status()
         .context("running wasm-pack")?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,7 +112,7 @@ fn cmd_web(dev: bool) -> Result<()> {
         .status()
         .context("running npm script")?;
     if !status.success() {
-        bail!("npm {} failed", script);
+        bail!("npm {script} failed");
     }
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -94,6 +94,18 @@ fn project_root() -> PathBuf {
 fn cmd_web(dev: bool) -> Result<()> {
     let workspace = project_root();
     let pkg_dir = workspace.join("packages/web-ide/src/wasm");
+
+    if !workspace.join("node_modules").exists() {
+        let status = Command::new("npm")
+            .arg("install")
+            .current_dir(&workspace)
+            .status()
+            .context("running npm install")?;
+        if !status.success() {
+            bail!("npm install failed");
+        }
+    }
+
     let mut cmd = Command::new("wasm-pack");
     cmd.args(["build", "crates/lsp-wasm", "--target", "web", "--out-dir"]);
     cmd.arg(&pkg_dir);


### PR DESCRIPTION
## Summary

Compile the GraphQL language server to `wasm32-unknown-unknown` and ship a Monaco-based browser playground (`@graphql-analyzer/web-ide`) that drives it via a Web Worker. The LSP runs entirely in the browser — no backend — providing parse-level and schema-aware diagnostics, hover, and completion against an in-memory schema/document pair.

The Rust side splits the existing native LSP into a tickable, transport-agnostic core (a non-blocking `tick(&Connection, &mut GlobalState)` plus a thin native `run` wrapper) so the same machinery works under both the existing stdio server and a new `crates/lsp-wasm` `wasm-bindgen` surface. Heavy native-only deps (`tokio`, `threadpool`, `swc_core` via `graphql-extract`, `tracing-chrome`, OpenTelemetry stack) are made optional behind `native`/`wasm`/`extract`/`introspect` feature flags so the wasm build drops them entirely.

The web frontend is hand-rolled around `vscode-jsonrpc/browser` (no `monaco-languageclient`, no `@codingame/monaco-vscode-api` payload) — a minimal `LanguageClient` plus thin Monaco provider adapters for completion, hover, and diagnostics.

Closes #425
Closes #418

## Changes

- `crates/lsp-wasm` (new): `wasm-bindgen` crate exposing `Server { handleMessage(json: string) -> string[] }`. Drives `graphql-lsp` via in-memory crossbeam channels, intercepts `initialize` for the wasm bootstrap, then pumps every message through the existing `tick`/dispatch pipeline.
- `crates/lsp`: introduce `TaskDispatcher` trait (`InlineDispatcher` for wasm, `ThreadPoolDispatcher` for native) replacing the bare `threadpool::ThreadPool` field on `GlobalState`. Split the blocking `main_loop::main_loop` into a non-blocking `tick` + a native `run` waker. Add `install_workspace_from_init_options` so the wasm side can declare project shape via LSP `initializationOptions` instead of disk-scanning. Carve `native`/`wasm`/`extract`/`introspect` feature flags and gate every native-only call site explicitly.
- `crates/syntax`, `crates/ide`, `crates/ide-db`, `crates/hir`, `crates/linter`, `crates/analysis`: make `graphql-extract` (and `graphql-introspect` where reachable) optional via feature chains so the wasm bundle doesn't pull `swc_core`. Final wasm release size: 6.4 MB (down from a naive 7.7 MB).
- `crates/config`: add `WorkspaceConfig::get_file_type_by_rel_path(rel_path: &str, project_name: &str)` for URI-pattern routing where filesystem path conversion isn't available.
- `crates/introspect`: target-conditional `reqwest` config — native uses rustls + json; wasm uses default-features = false + json (browser fetch backend). Tokio split similarly to drop `rt-multi-thread` from the wasm path.
- `packages/web-ide` (new): Vite + Monaco scaffold; `MinimalClient` over `BrowserMessageReader/Writer`; Monaco `CompletionItemProvider`/`HoverProvider` adapters and a diagnostic-publishing handler that translates LSP `Diagnostic` to `monaco.editor.IMarkerData`. Web Worker hosts the wasm `Server` and bridges JSON-RPC to/from the main thread; a Vite plugin stubs the wasm import when artifacts aren't built yet.
- `xtask`: new `web [--dev]` subcommand orchestrating `wasm-pack build` + `npm run build|dev`. Auto-runs `npm install` if `node_modules` is missing.
- `.github/workflows/ci.yml`: new `web` job — wasm-feature host build, `wasm32-unknown-unknown` check, `wasm-pack build`, TypeScript check, Vite production build, Playwright e2e (chromium).
- `DEVELOPMENT.md`: Web Playground section with prereqs and `xtask web` commands.
- Changeset: minor bump on `graphql-analyzer-lsp`.

## Consulted SME Agents

- **rust-analyzer.md** / **salsa.md**: design of the snapshot-safe sync architecture predates this PR; the dispatcher abstraction and tickable loop preserve those invariants.
- **lsp.md**: protocol semantics for `initialize`, `initializationOptions`, and `publishDiagnostics`.
- **graphiql.md** / **graphql-cli.md**: shape of the in-memory project (`schema` + `documents`) declared via `initializationOptions`.

## Manual Testing Plan

1. From the repo root: `cargo xtask web --dev`. Open <http://localhost:5173>.
2. Verify both Monaco editors mount (left = schema, right = query) with the demo content.
3. In the right pane, type a clearly invalid field, e.g. `query Bad { user(id: \"1\") { notARealField } }`. A red squiggle and hover message mentioning `notARealField` should appear (schema-aware validation).
4. In either pane, type a syntax error like `query Foo {` and stop. A parser-level diagnostic should appear within ~1s.
5. Trigger completion in the document pane (e.g. inside a selection set) — expect `User` field suggestions backed by the schema.
6. Hover over an identifier — expect a popover with type info.

## Known Follow-Ups (not blocking)

- Diagnostic markers are placed one Monaco line below the offending source line (off-by-one between the LSP's `LineIndex` and Monaco's coords); needs investigation.
- `spawn_introspection_thread` is still native-only because it uses `std::thread`; the wasm fetch backend compiles but isn't wired. Browser-side introspection requires a `wasm-bindgen-futures` consumer.
- The `crates/lsp-wasm` `initialize_roundtrip` test is `#[ignore]`'d — needs `wasm-pack test --headless --chrome` infra in CI to run; Playwright covers the equivalent flow today.

> **Note:** This PR is best reviewed commit-by-commit. The branch begins with the implementation plan in `docs/superpowers/plans/2026-04-25-wasm-lsp.md`, then advances phase-by-phase: feature-gating in the lower crates → trait abstraction → main-loop split → wasm bridge → web playground → CI/docs.