### PR TITLE
Pin Node version in `prepare-release.yml` so the auto-generated release PR has a CI-compatible lockfile

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -45,6 +45,20 @@ jobs:
         if: steps.check.outputs.changeset_count > 0
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      # Knope runs `npm install --package-lock-only` to regenerate the lockfile.
+      # The CI jobs that consume the produced release PR (Format / VSCode /
+      # ESLint Plugin) all use `actions/setup-node` with Node 24 (npm 11). npm
+      # 10 (the runner default) and npm 11 write structurally different
+      # lockfiles for optional deps that aren't yet on the registry — so a
+      # lockfile produced here without setup-node fails `npm ci` over there
+      # with `Missing: @graphql-analyzer/core-* from lock file`. Pin Node 24
+      # to match CI.
+      - name: Setup Node.js
+        if: steps.check.outputs.changeset_count > 0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
       - name: Install knope
         if: steps.check.outputs.changeset_count > 0
         uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2

--- a/knope.toml
+++ b/knope.toml
@@ -78,6 +78,15 @@ command = "node scripts/sync-workspace-deps.mjs"
 type = "Command"
 command = "npm install --package-lock-only"
 
+# Verify the regenerated lockfile is consumable by `npm ci`. Without this, a
+# lockfile that fails downstream `npm ci` (e.g. produced by an off-version npm
+# in the prepare-release runner) would still be force-pushed to release/next
+# and only blow up on the auto-generated PR's CI. This makes the prepare-release
+# job itself fail before the push, with a clear, fail-fast signal.
+[[workflows.steps]]
+type = "Command"
+command = "npm ci --ignore-scripts --no-audit --no-fund"
+
 [[workflows.steps]]
 type = "Command"
 command = "git add packages/ package-lock.json"


### PR DESCRIPTION
## Summary

Third (and actually-root-cause) fix for release PRs failing CI on the same `Missing: @graphql-analyzer/core-* from lock file` error. The previous two attempts (#1007, #1010) fixed real but non-root-cause bugs in `scripts/sync-workspace-deps.mjs`; this PR fixes the underlying environment mismatch that's been making release PRs ship broken lockfiles.

## Why every release PR was breaking

`prepare-release.yml` had no `actions/setup-node` step, so knope's `npm install --package-lock-only` ran on the `ubuntu-24.04` runner default (Node ~22 / npm 10). Every other workflow — including the `Format`, `VSCode Extension`, `ESLint Plugin`, and `Release Prep Simulation` jobs that consume the produced release PR — pins `node-version: "24"` (npm 11).

npm 10 and npm 11 produce structurally different lockfiles for optional deps that aren't yet published to the registry. npm 11 writes placeholder `optional: true` entries for `packages/core/node_modules/@graphql-analyzer/core-*` plus `libc` selector fields; npm 10 omits both. CI's `npm ci` (npm 11) then rejects the npm-10-shaped lockfile with `Missing: @graphql-analyzer/core-darwin-arm64@ from lock file` (and the four sibling stubs).

I confirmed this by replicating knope's exact sequence locally with Node 24 — the produced lockfile contains the placeholder entries and `npm ci` succeeds. The release/next branch's lockfile is missing those entries entirely.

## Why the simulation didn't catch it

The `Release Prep Simulation` job in `ci.yml` regenerates the lockfile and runs `npm ci` in the same job — both with Node 24. Within that job, the lockfile is internally consistent. The bug only manifests across the boundary between knope's Node-less runner and CI's Node 24 runners, and the simulation has no view of that boundary.

## Changes

- **`.github/workflows/prepare-release.yml`**: add `actions/setup-node@v6` with `node-version: "24"` before knope runs. Direct root cause fix — knope's lockfile-regen step now uses the same npm CI uses.
- **`knope.toml`**: add `npm ci --ignore-scripts --no-audit --no-fund` immediately after `npm install --package-lock-only`. Defense in depth — if knope's runner ever drifts from CI again (or if npm changes lockfile semantics in a future release), the prepare-release job itself fails *before* force-pushing to `release/next` and opening the auto-PR. The `--ignore-scripts --no-audit --no-fund` flags skip the native-addon postinstall and registry round-trips that aren't relevant to lockfile validation.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- After merge, the existing release PR (#1005) needs to be regenerated for the fix to apply (knope force-pushes `release/next` on each main commit with changesets present). Easiest way: merge this and push any small change with a changeset, or re-run `Prepare Release` via `workflow_dispatch`. Verify the regenerated #1005's `Format` / `VSCode Extension` / `ESLint Plugin` jobs all pass `npm ci`.
- Locally simulate knope's exact sequence (with Node 24) to confirm the lockfile is `npm ci`-able:
  ```bash
  # bump to the next alpha versions, then:
  node scripts/sync-workspace-deps.mjs
  npm install --package-lock-only
  npm ci --ignore-scripts --no-audit --no-fund
  ```

## Related Issues

- Follow-up to #1007 and #1010, both of which addressed real but non-root-cause issues in the same release-PR-CI failure mode.