### PR TITLE
Normalize publishable `package.json` trailing newlines after knope bumps

### DIFF
--- a/scripts/check-release-prep.mjs
+++ b/scripts/check-release-prep.mjs
@@ -130,5 +130,9 @@ for (const p of bumped) {
 run("node", ["scripts/sync-workspace-deps.mjs"]);
 run("npm", ["install", "--package-lock-only"]);
 run("npm", ["ci"]);
+// Catch any formatting drift introduced by the bump+sync round-trip — knope's
+// JSON writer omits the trailing newline that oxfmt requires, and the sync
+// script is responsible for normalizing that.
+run("npx", ["oxfmt", "--check", "packages/", "editors/"]);
 
 console.log("\nRelease-prep simulation passed.");

--- a/scripts/sync-workspace-deps.mjs
+++ b/scripts/sync-workspace-deps.mjs
@@ -125,7 +125,6 @@ function syncPackages(packages, { write }) {
   const changes = [];
 
   for (const { path, pkg } of packages) {
-    let mutated = false;
     for (const section of DEP_SECTIONS) {
       const deps = pkg[section];
       if (!deps) continue;
@@ -135,11 +134,16 @@ function syncPackages(packages, { write }) {
         if (!EXACT_VERSION_RE.test(current)) continue; // wildcards/ranges intentional
         if (current === target) continue;
         deps[name] = target;
-        mutated = true;
         changes.push({ path, section, name, from: current, to: target });
       }
     }
-    if (mutated && write) writeJson(path, pkg);
+    // Always re-write publishable packages (even when no dep refs changed) so
+    // the on-disk formatting is canonical. Knope's serializer omits the
+    // trailing newline that the project's formatter (oxfmt) requires; this
+    // guarantees `oxfmt --check` passes on the release PR. Private packages
+    // (test fixtures, root) aren't in knope's `versioned_files`, so they're
+    // left alone.
+    if (write && !pkg.private) writeJson(path, pkg);
   }
 
   return changes;


### PR DESCRIPTION
## Summary

Follow-up to #1022. With Node pinned in `prepare-release.yml`, the `npm ci`-related failures are gone — now release PR #1005's `Format` job fails on `oxfmt --check`:

```
Format issues found in above 5 files. Run without `--check` to fix.
  packages/core/npm/darwin-arm64/package.json
  packages/core/npm/darwin-x64/package.json
  packages/core/npm/linux-arm64-gnu/package.json
  packages/core/npm/linux-x64-gnu/package.json
  packages/core/npm/win32-x64-msvc/package.json
```

## Root cause

Knope's JSON writer emits files without a trailing newline. `oxfmt --check` requires one. Files that `scripts/sync-workspace-deps.mjs` also touches got re-serialized via `JSON.stringify(...) + "\n"` and so came out formatted; the 5 platform stubs have no intra-workspace dep refs to sync, so they passed through as knope wrote them.

I confirmed this by writing `}\n}` (no trailing newline) to one of the stubs, running the sync script, and observing the file end up as `}\n}\n` — the script's normalization was the only thing keeping the other publishable files formatted.

## Changes

- **`scripts/sync-workspace-deps.mjs`**: always re-write every non-private (publishable) workspace `package.json` after the bump+sync pass, not just files where a dep ref changed. This guarantees canonical formatting (trailing newline) on every file knope might have touched. Private packages (test fixtures, root) aren't in knope's `versioned_files`, so they're left alone.
- **`scripts/check-release-prep.mjs`**: add `npx oxfmt --check packages/ editors/` at the end of the simulation. The simulation already catches dep-ref drift and lockfile drift; this closes the formatting hole so future drift fails on every PR rather than only on the auto-generated release PR.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- After merge, knope re-prepares `release/next` (changesets are still on main). Verify the `Format` job passes on the regenerated release PR.
- Locally simulate knope's exact write behavior (no trailing newline) and confirm the sync script normalizes it:
  ```bash
  node -e 'const fs=require("fs"),p="packages/core/npm/darwin-arm64/package.json",pkg=JSON.parse(fs.readFileSync(p,"utf8"));fs.writeFileSync(p,JSON.stringify(pkg,null,2));'
  tail -c 6 packages/core/npm/darwin-arm64/package.json | xxd  # ends in `}` (no \n)
  node scripts/sync-workspace-deps.mjs
  tail -c 6 packages/core/npm/darwin-arm64/package.json | xxd  # ends in `}\n`
  npx oxfmt --check packages/core/npm/darwin-arm64/package.json  # passes
  git checkout -- packages/
  ```

## Related Issues

- Follow-up to #1022 (Node-version pin). Together they should close the recurring release-PR-CI failure mode that PRs #1007 and #1010 attempted to fix.