### PR TITLE
Wire up npm publishing for first `@graphql-analyzer/eslint-plugin` release

### DIFF
--- a/.changeset/require-selections-fragment-routing-suffix.md
+++ b/.changeset/require-selections-fragment-routing-suffix.md
@@ -1,5 +1,9 @@
 ---
-graphql-analyzer-linter: patch
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+graphql-analyzer-mcp: patch
+graphql-analyzer-core: patch
+graphql-analyzer-eslint-plugin: patch
 ---
 
 `require-selections`: append `` or add to used fragment(s) `X` `` suffix when the missing field is reachable through fragments that don't contain it (closes part of [#1004](https://github.com/trevor-scheer/graphql-analyzer/issues/1004))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,91 @@ jobs:
           name: vscode-extension-${{ matrix.vscode_target }}
           path: editors/vscode/*.vsix
 
+  # Build the @graphql-analyzer/core native addon for each platform.
+  # The matrix mirrors build-binaries (5 targets); only linux-arm64-gnu cross
+  # compiles, and it uses an apt-installed gcc cross toolchain rather than
+  # `cross` (Docker) because napi-rs invokes cargo directly.
+  build-core:
+    needs: check-release
+    if: needs.check-release.outputs.should_release == 'true'
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            npm_dir: darwin-arm64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            npm_dir: darwin-x64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            npm_dir: linux-arm64-gnu
+            linux_cross: true
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            npm_dir: linux-x64-gnu
+            # Picked arbitrarily as the runner that also uploads the
+            # platform-independent dispatcher entry points (index.js, index.d.ts)
+            # so publish-npm gets exactly one copy.
+            dispatcher: true
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            npm_dir: win32-x64-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        run: rustup show
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "release-core-${{ matrix.target }}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Install Linux ARM cross toolchain
+        if: matrix.linux_cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+          echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - name: Build native addon
+        working-directory: packages/core
+        run: npx napi build --cargo-cwd ../../crates/napi --platform --release --target ${{ matrix.target }}
+
+      - name: Upload .node binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: core-bindings-${{ matrix.npm_dir }}
+          path: packages/core/graphql-analyzer.*.node
+          if-no-files-found: error
+
+      # index.js and index.d.ts are platform-independent — every runner produces
+      # identical bytes. Upload from a single runner so publish-npm gets one copy.
+      - name: Upload dispatcher entry points
+        if: matrix.dispatcher
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: core-dispatcher
+          path: |
+            packages/core/index.js
+            packages/core/index.d.ts
+          if-no-files-found: error
+
   # Create GitHub releases and upload all assets
   release:
     needs: [check-release, build-binaries, build-vscode]
@@ -315,6 +400,103 @@ jobs:
             echo "Publishing $vsix"
             npx ovsx publish "$vsix" --pat "$OVSX_PAT"
           done
+
+  # Publish @graphql-analyzer/* packages to npm.
+  #
+  # Order matters: platform stubs must publish first because the dispatcher pins
+  # them via exact-version optionalDependencies; @graphql-analyzer/eslint-plugin
+  # publishes last because it depends on @graphql-analyzer/core. Each step is
+  # idempotent (`npm view` short-circuits already-published versions) so a
+  # partial failure can be recovered by re-running the workflow.
+  #
+  # OIDC trusted publishing: no NPM_TOKEN required. Each of the 7 published
+  # package names must have npmjs.com → trusted publisher → this repo +
+  # release.yml + publish-npm job bound on the registry.
+  publish-npm:
+    needs: [check-release, build-core, release]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Download .node bindings (all platforms)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: core-bindings-*
+          path: napi-artifacts
+          merge-multiple: true
+
+      - name: Download dispatcher entry points
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: core-dispatcher
+          path: packages/core
+
+      # `napi artifacts` reads the flat dir of `<name>.<platform-suffix>.node`
+      # files and copies each into packages/core/npm/<dir>/ based on the suffix.
+      - name: Distribute .node bindings into platform stub dirs
+        working-directory: packages/core
+        run: npx napi artifacts --dir ../../napi-artifacts
+
+      - name: Confirm publish layout
+        run: find packages/core packages/eslint-plugin -type f \( -name "*.node" -o -name "index.js" -o -name "index.d.ts" -o -name "package.json" \) -not -path "*/node_modules/*" | sort
+
+      # eslint-plugin's TS imports the dispatcher's index.d.ts, so the dispatcher
+      # files (downloaded above) must be in place before tsc runs.
+      - name: Build @graphql-analyzer/eslint-plugin
+        run: npm run build --workspace=@graphql-analyzer/eslint-plugin
+
+      - name: Publish @graphql-analyzer/core platform stubs
+        run: |
+          set -euo pipefail
+          for dir in packages/core/npm/*/; do
+            name=$(node -p "require('./${dir}package.json').name")
+            version=$(node -p "require('./${dir}package.json').version")
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "${name}@${version} already published — skipping"
+              continue
+            fi
+            echo "::group::Publishing ${name}@${version}"
+            (cd "$dir" && npm publish --tag alpha --provenance --access public)
+            echo "::endgroup::"
+          done
+
+      - name: Publish @graphql-analyzer/core
+        working-directory: packages/core
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} already published — skipping"
+            exit 0
+          fi
+          npm publish --tag alpha --provenance --access public
+
+      - name: Publish @graphql-analyzer/eslint-plugin
+        working-directory: packages/eslint-plugin
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} already published — skipping"
+            exit 0
+          fi
+          npm publish --tag alpha --provenance --access public
 
   # Update the Homebrew tap formula with the new CLI version
   update-homebrew-formula:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -123,13 +123,30 @@ component(s) the change reaches users through.
 ## npm publishing auth
 
 The workflow uses npm [Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
-(OIDC) exclusively — no `NPM_TOKEN` secret lives in CI. All seven
-`@graphql-analyzer/*` package names are bound to this repo + `release.yml` on
-npmjs.com.
+(OIDC) exclusively — no `NPM_TOKEN` secret lives in CI. Each of the seven
+`@graphql-analyzer/*` package names must be bound on npmjs.com to:
 
-In `release.yml`, the publish job sets `permissions: id-token: write` and uses
-`npm publish --provenance`. npm verifies the OIDC token against the registered
-binding before accepting the publish.
+- Repository: `trevor-scheer/graphql-analyzer`
+- Workflow: `.github/workflows/release.yml`
+- Environment: _none_
+- Job: `publish-npm`
+
+The `publish-npm` job sets `permissions: id-token: write` and runs
+`npm publish --provenance --access public --tag alpha` for every package. npm
+verifies the OIDC token against the registered binding before accepting the
+publish.
+
+### Publish ordering and idempotency
+
+The `publish-npm` job runs publishes in a fixed order: 5 platform stubs →
+`@graphql-analyzer/core` dispatcher → `@graphql-analyzer/eslint-plugin`. The
+order is mandatory — the dispatcher pins each platform stub via exact-version
+`optionalDependencies`, and the eslint-plugin pins the dispatcher via a normal
+exact-version dependency.
+
+Each step short-circuits via `npm view <name>@<version>` if that version is
+already on the registry, so a re-run of a partially-completed job picks up where
+the failure left off.
 
 ## Testing a release locally
 
@@ -199,16 +216,21 @@ All files listed under a single `versioned_files` must already share a
 version before the next release. If they drift, hand-align them in a
 preparatory commit.
 
-### npm publish fails with "version already exists"
+### npm publish fails partway through
 
-Knope wrote the version but a previous publish partially completed. Either
-bump to the next patch and re-run, or delete the offending versions from
-npm (within the 72-hour unpublish window).
+Re-run the failed `publish-npm` job from the GitHub Actions UI. Each publish
+step checks `npm view <name>@<version>` first and skips packages already on the
+registry, so a re-run finishes whatever didn't complete the first time.
+
+If a stub fails mid-stream and the dispatcher publishes anyway (it shouldn't —
+each step is sequential and `set -euo pipefail`), users on the affected
+platform will see `Cannot find module @graphql-analyzer/core-<triple>` at
+install time. Recover by re-running the workflow once the underlying issue is
+fixed.
 
 ### optionalDependencies resolve incorrectly
 
-All six `@graphql-analyzer/core*` packages must share an exact version, and
-the platform stubs must be published _before_ the dispatcher. The
-`publish-npm` job enforces this ordering — if a stub publish fails, the
-dispatcher publish must be skipped or users on that platform will see
-`Cannot find module @graphql-analyzer/core-<triple>` at install time.
+All six `@graphql-analyzer/core*` packages must share an exact version, and the
+platform stubs must be published _before_ the dispatcher. The `publish-npm` job
+enforces this ordering, and `scripts/sync-workspace-deps.mjs` (run by knope
+during prepare-release) keeps the version pins in lockstep.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -126,10 +126,13 @@ The workflow uses npm [Trusted Publishing](https://docs.npmjs.com/trusted-publis
 (OIDC) exclusively — no `NPM_TOKEN` secret lives in CI. Each of the seven
 `@graphql-analyzer/*` package names must be bound on npmjs.com to:
 
-- Repository: `trevor-scheer/graphql-analyzer`
-- Workflow: `.github/workflows/release.yml`
-- Environment: _none_
-- Job: `publish-npm`
+- Organization / user: `trevor-scheer`
+- Repository: `graphql-analyzer`
+- Workflow filename: `release.yml`
+- Environment: _(leave empty)_
+
+The binding is scoped to the workflow file, not to individual jobs — so the
+same binding authorizes `publish-vscode`, `publish-openvsx`, and `publish-npm`.
 
 The `publish-npm` job sets `permissions: id-token: write` and runs
 `npm publish --provenance --access public --tag alpha` for every package. npm

--- a/knope.toml
+++ b/knope.toml
@@ -8,6 +8,13 @@
 #   graphql-analyzer-lsp: minor
 #   ---
 
+# We drive every release from changesets exclusively. Conventional-commit
+# parsing would otherwise also bump versions based on commit message prefixes
+# (`feat:`, `fix:`), and our commit style intentionally doesn't follow that
+# convention.
+[changes]
+ignore_conventional_commits = true
+
 [packages.graphql-analyzer-cli]
 versioned_files = ["crates/cli/Cargo.toml"]
 changelog = "crates/cli/CHANGELOG.md"
@@ -64,7 +71,6 @@ name = "prepare-release"
 [[workflows.steps]]
 type = "PrepareRelease"
 prerelease_label = "alpha"
-ignore_conventional_commits = true
 
 # Knope only bumps `version` fields. Re-pin intra-workspace npm deps to the
 # new core version so published packages list the exact version they were

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,19 @@
+# @graphql-analyzer/core
+
+Low-level [napi-rs][napi] binding that exposes the [graphql-analyzer] Rust core
+to Node.js. This package is **not intended for direct consumption** — it's the
+substrate for higher-level wrappers like
+[`@graphql-analyzer/eslint-plugin`](https://www.npmjs.com/package/@graphql-analyzer/eslint-plugin).
+
+The `.node` binary is distributed via platform-specific
+`optionalDependencies` (`@graphql-analyzer/core-<triple>`); npm picks the
+right one for your machine at install time.
+
+For project documentation, see <https://trevor-scheer.github.io/graphql-analyzer/>.
+
+## License
+
+MIT OR Apache-2.0
+
+[graphql-analyzer]: https://github.com/trevor-scheer/graphql-analyzer
+[napi]: https://napi.rs

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,44 @@
+# @graphql-analyzer/eslint-plugin
+
+ESLint plugin for GraphQL, powered by [graphql-analyzer]. A drop-in replacement
+for [`@graphql-eslint/eslint-plugin`][graphql-eslint] — same plugin name, same
+rule names, same flat-config preset names. The Rust analyzer does the work via
+a native addon, so performance matches the CLI.
+
+## Install
+
+```sh
+npm install --save-dev @graphql-analyzer/eslint-plugin@alpha
+```
+
+Requires Node.js 18+ and ESLint 8.40+ or 9.x (flat config only). The native
+addon ships as platform-specific optional dependencies; npm picks the right
+one for your machine automatically.
+
+## Usage
+
+```js
+// eslint.config.mjs
+import graphql from "@graphql-analyzer/eslint-plugin";
+
+export default [
+  {
+    files: ["**/*.graphql"],
+    languageOptions: { parser: graphql.parser },
+    plugins: { "@graphql-analyzer": graphql },
+    rules: graphql.configs["flat/operations-recommended"].rules,
+  },
+];
+```
+
+For embedded GraphQL in TypeScript/JavaScript files, the migration guide, the
+full rule reference, and configuration via `.graphqlrc.yaml`, see the docs:
+
+→ <https://trevor-scheer.github.io/graphql-analyzer/linting/eslint-plugin/>
+
+## License
+
+MIT OR Apache-2.0
+
+[graphql-analyzer]: https://github.com/trevor-scheer/graphql-analyzer
+[graphql-eslint]: https://the-guild.dev/graphql/eslint/docs


### PR DESCRIPTION
## Summary

Brings the release workflow up to date for the first `@graphql-analyzer/eslint-plugin` and `@graphql-analyzer/core` (native addon) npm publishes. `RELEASES.md` and `knope.toml` already described an npm publish flow, but the matching `build-core` and `publish-npm` jobs never existed in `release.yml` — so a release-PR merge today bumps the npm package versions but doesn't publish them anywhere.

## Changes

- **`release.yml`: add `build-core` + `publish-npm` jobs**
  - `build-core` matrix-builds the napi-rs `.node` for all 5 supported targets (mirrors `build-binaries`). aarch64-unknown-linux-gnu cross uses an apt-installed gcc cross toolchain. The x86_64-unknown-linux-gnu runner additionally uploads the platform-independent dispatcher (`index.js`/`index.d.ts`) as its own artifact.
  - `publish-npm` downloads all `.node` artifacts plus the dispatcher entry points, lays them out via `napi artifacts`, builds the eslint-plugin TS, then publishes in fixed order: 5 platform stubs → `@graphql-analyzer/core` dispatcher → `@graphql-analyzer/eslint-plugin`. Each step is idempotent via `npm view <name>@<version>`.
  - Auth via npm trusted publishing (OIDC) — `permissions: id-token: write`, `npm publish --provenance --access public --tag alpha`. No `NPM_TOKEN` needed.
- **Re-target orphan changeset.** `require-selections-fragment-routing-suffix.md` referenced `graphql-analyzer-linter`, which isn't a knope package — knope was silently dropping it. Re-pointed at the five published components per `RELEASES.md` convention.
- **Migrate deprecated knope config.** Move `ignore_conventional_commits` from `PrepareRelease` to a top-level `[changes]` section so knope stops printing deprecation warnings on every run.
- **Package-level READMEs** for `@graphql-analyzer/core` and `@graphql-analyzer/eslint-plugin` (terse, link to the docs site).
- **`RELEASES.md`** updated to spell out the trusted-publisher binding requirements (repo + workflow + job name), the publish ordering invariant, and the re-run-to-recover idempotency story.

## Manual Testing Plan

- Verify each of the 7 `@graphql-analyzer/*` packages on npmjs.com → Settings → Trusted Publishers has its binding set to:
  - Repository: `trevor-scheer/graphql-analyzer`
  - Workflow: `.github/workflows/release.yml`
  - Job: `publish-npm`
  - Environment: _(none)_
- After merge, the next changeset-bearing merge to `main` should produce a release PR. Merging that PR runs the new `build-core` + `publish-npm` jobs end-to-end. The release-prep simulation (`scripts/check-release-prep.mjs`) runs on every PR and exercises the lockfile + version-bump flow ahead of time.