### PR TITLE
docs: currency pass across the site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -103,6 +103,7 @@ export default defineConfig({
               label: "loneExecutableDefinition",
               slug: "rules/loneExecutableDefinition",
             },
+            { label: "matchDocumentFilename", slug: "rules/matchDocumentFilename" },
             { label: "namingConvention", slug: "rules/namingConvention" },
             {
               label: "noAnonymousOperations",
@@ -115,6 +116,7 @@ export default defineConfig({
               slug: "rules/noHashtagDescription",
             },
             { label: "noOnePlaceFragments", slug: "rules/noOnePlaceFragments" },
+            { label: "noRootType", slug: "rules/noRootType" },
             {
               label: "noScalarResultTypeOnMutation",
               slug: "rules/noScalarResultTypeOnMutation",
@@ -126,6 +128,11 @@ export default defineConfig({
             { label: "noUnusedVariables", slug: "rules/noUnusedVariables" },
             { label: "operationNameSuffix", slug: "rules/operationNameSuffix" },
             { label: "redundantFields", slug: "rules/redundantFields" },
+            { label: "relayArguments", slug: "rules/relayArguments" },
+            { label: "relayConnectionTypes", slug: "rules/relayConnectionTypes" },
+            { label: "relayEdgeTypes", slug: "rules/relayEdgeTypes" },
+            { label: "relayPageInfo", slug: "rules/relayPageInfo" },
+            { label: "requireDeprecationDate", slug: "rules/requireDeprecationDate" },
             {
               label: "requireDeprecationReason",
               slug: "rules/requireDeprecationReason",
@@ -136,7 +143,11 @@ export default defineConfig({
               slug: "rules/requireFieldOfTypeQueryInMutationResult",
             },
             { label: "requireIdField", slug: "rules/requireIdField" },
+            { label: "requireImportFragment", slug: "rules/requireImportFragment" },
+            { label: "requireNullableFieldsWithOneof", slug: "rules/requireNullableFieldsWithOneof" },
+            { label: "requireNullableResultInRoot", slug: "rules/requireNullableResultInRoot" },
             { label: "requireSelections", slug: "rules/requireSelections" },
+            { label: "requireTypePatternWithOneof", slug: "rules/requireTypePatternWithOneof" },
             { label: "selectionSetDepth", slug: "rules/selectionSetDepth" },
             { label: "strictIdInTypes", slug: "rules/strictIdInTypes" },
             {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -144,7 +144,10 @@ export default defineConfig({
             },
             { label: "requireIdField", slug: "rules/requireIdField" },
             { label: "requireImportFragment", slug: "rules/requireImportFragment" },
-            { label: "requireNullableFieldsWithOneof", slug: "rules/requireNullableFieldsWithOneof" },
+            {
+              label: "requireNullableFieldsWithOneof",
+              slug: "rules/requireNullableFieldsWithOneof",
+            },
             { label: "requireNullableResultInRoot", slug: "rules/requireNullableResultInRoot" },
             { label: "requireSelections", slug: "rules/requireSelections" },
             { label: "requireTypePatternWithOneof", slug: "rules/requireTypePatternWithOneof" },

--- a/docs/src/content/docs/advanced/performance-tuning.mdx
+++ b/docs/src/content/docs/advanced/performance-tuning.mdx
@@ -54,25 +54,32 @@ This is key to keeping the IDE responsive in large codebases.
 
 ### Enable OpenTelemetry tracing
 
+In VS Code settings (`Preferences: Open User Settings (JSON)`):
+
+```json
+{
+  "graphql-analyzer.debug.otelEnabled": true,
+  "graphql-analyzer.debug.otelEndpoint": "http://localhost:4317"
+}
+```
+
+`4317` is the OTLP gRPC ingestion endpoint (the collector). View traces in Jaeger's UI at `http://localhost:16686` (requires Jaeger running locally — these are two different ports with different purposes).
+
+### Enable debug logging
+
 In VS Code settings:
 
 ```json
 {
+  "graphql-analyzer.debug.logLevel": "debug",
   "graphql-analyzer.server.env": {
-    "OTEL_TRACES_ENABLED": "1",
     "RUST_LOG": "debug"
   }
 }
 ```
 
-View traces in Jaeger at `http://localhost:16686` (requires Jaeger running locally).
-
-### Enable debug logging
+For the CLI:
 
 ```sh
-# CLI
 RUST_LOG=debug graphql validate
-
-# LSP
-RUST_LOG=debug graphql-lsp 2> lsp.log
 ```

--- a/docs/src/content/docs/advanced/remote-schemas.mdx
+++ b/docs/src/content/docs/advanced/remote-schemas.mdx
@@ -27,12 +27,12 @@ schema:
   retry: 3
 ```
 
-| Field     | Required | Description                                                  |
-| --------- | -------- | ------------------------------------------------------------ |
-| `url`     | Yes      | The GraphQL endpoint URL to introspect                       |
-| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation  |
-| `timeout` | No       | Request timeout in seconds (default: 30)                     |
-| `retry`   | No       | Number of retry attempts on failure (default: 0)             |
+| Field     | Required | Description                                                 |
+| --------- | -------- | ----------------------------------------------------------- |
+| `url`     | Yes      | The GraphQL endpoint URL to introspect                      |
+| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation |
+| `timeout` | No       | Request timeout in seconds (default: 30)                    |
+| `retry`   | No       | Number of retry attempts on failure (default: 0)            |
 
 The `${VAR}` syntax pulls values from environment variables at config load time. Use `${VAR:default}` to provide a fallback when the variable is unset. This keeps secrets out of config files that are checked into source control.
 

--- a/docs/src/content/docs/advanced/remote-schemas.mdx
+++ b/docs/src/content/docs/advanced/remote-schemas.mdx
@@ -12,7 +12,29 @@ schema: https://api.example.com/graphql
 documents: src/**/*.{graphql,tsx}
 ```
 
-The tool sends an introspection query to the endpoint and caches the result.
+The tool sends an introspection query to the endpoint. Introspection runs each time the schema is loaded; results are held in memory by the running LSP/CLI process.
+
+## Remote schema with options
+
+For authenticated endpoints or custom timeouts, use the structured form:
+
+```yaml
+schema:
+  url: https://api.example.com/graphql
+  headers:
+    Authorization: Bearer ${API_TOKEN}
+  timeout: 60
+  retry: 3
+```
+
+| Field     | Required | Description                                                  |
+| --------- | -------- | ------------------------------------------------------------ |
+| `url`     | Yes      | The GraphQL endpoint URL to introspect                       |
+| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation  |
+| `timeout` | No       | Request timeout in seconds (default: 30)                     |
+| `retry`   | No       | Number of retry attempts on failure (default: 0)             |
+
+The `${VAR}` syntax pulls values from environment variables at config load time. Use `${VAR:default}` to provide a fallback when the variable is unset. This keeps secrets out of config files that are checked into source control.
 
 ## Per-project remote schemas
 
@@ -28,9 +50,9 @@ projects:
 
 ## How it works
 
-1. On first load, the tool sends a standard introspection query to the endpoint
-2. The schema response is cached locally
-3. Both the LSP and CLI use the cached schema for validation
+1. The tool sends a standard introspection query to the endpoint each time the schema is loaded
+2. The schema response is held in memory by the running LSP/CLI process
+3. Both the LSP and CLI use the in-memory schema for validation
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/advanced/troubleshooting.mdx
+++ b/docs/src/content/docs/advanced/troubleshooting.mdx
@@ -48,9 +48,12 @@ Supported file names (in priority order):
 
 1. `.graphqlrc.yml` / `.graphqlrc.yaml`
 2. `.graphqlrc.json`
-3. `.graphqlrc`
-4. `graphql.config.yml` / `graphql.config.yaml`
-5. `graphql.config.json`
+3. `.graphqlrc.toml`
+4. `.graphqlrc` (YAML or JSON, auto-detected)
+5. `graphql.config.yml` / `graphql.config.yaml`
+6. `graphql.config.json`
+7. `graphql.config.toml`
+8. `package.json` with a `"graphql"` key (lowest priority fallback)
 
 **Not supported:** `graphql.config.js`, `graphql.config.ts`
 

--- a/docs/src/content/docs/ai-integration/mcp.mdx
+++ b/docs/src/content/docs/ai-integration/mcp.mdx
@@ -80,3 +80,128 @@ Load a specific project by name.
 ### get_project_diagnostics
 
 Get all diagnostics for all loaded projects. No parameters.
+
+### goto_definition
+
+Find the definition of a GraphQL symbol (type, field, fragment, directive, etc.) at a given file position. Returns file locations with ranges.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `line` (required) — Zero-based line number
+- `character` (required) — Zero-based character offset
+- `project` (optional) — Project name
+
+### find_references
+
+Find all references to a GraphQL symbol across the project at a given file position. Returns all file locations where the symbol is used.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `line` (required) — Zero-based line number
+- `character` (required) — Zero-based character offset
+- `include_declaration` (optional) — Whether to include the declaration itself
+- `project` (optional) — Project name
+
+### hover
+
+Get hover information (type details, documentation, deprecation) for a GraphQL symbol at a given position. Returns markdown content.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `line` (required) — Zero-based line number
+- `character` (required) — Zero-based character offset
+- `project` (optional) — Project name
+
+### document_symbols
+
+Get a hierarchical symbol outline for a GraphQL file (types, operations, fragments, fields). Useful for understanding file structure at a glance.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `project` (optional) — Project name
+
+### workspace_symbols
+
+Search for GraphQL symbols by name across all workspace files. Returns matching symbols with their locations and kinds.
+
+**Parameters:**
+
+- `query` (required) — Symbol name or prefix to search for
+- `project` (optional) — Project name
+
+### get_completions
+
+Get completion suggestions at a cursor position in a GraphQL file. Returns labeled items with kind, detail, and documentation.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `line` (required) — Zero-based line number
+- `character` (required) — Zero-based character offset
+- `project` (optional) — Project name
+
+### get_file_diagnostics
+
+Get diagnostics (errors and warnings) for a specific file. More targeted than `get_project_diagnostics` when you only need one file.
+
+**Parameters:**
+
+- `file_path` (required) — Absolute path to the file
+- `project` (optional) — Project name
+
+### get_schema_types
+
+List all types in the schema with their kind and metadata. Optionally filter by kind (`object`, `interface`, `union`, `enum`, `scalar`, `input_object`).
+
+**Parameters:**
+
+- `kind` (optional) — Filter by type kind
+- `project` (optional) — Project name
+
+### get_type_info
+
+Get full details for a named type: fields, arguments, interfaces, directives, enum values, and union members.
+
+**Parameters:**
+
+- `type_name` (required) — Name of the type to look up
+- `project` (optional) — Project name
+
+### get_schema_sdl
+
+Return the full merged schema as SDL text, with all extensions applied.
+
+**Parameters:**
+
+- `project` (optional) — Project name
+
+### get_operations
+
+Extract all operations from the loaded project with their names, types, variables, and fragment dependencies. Optionally filter by file.
+
+**Parameters:**
+
+- `file_path` (optional) — Filter to operations in a specific file
+- `project` (optional) — Project name
+
+### get_query_complexity
+
+Calculate complexity scores for operations. Returns total complexity, depth, per-field breakdown, and warnings. Optionally filter by operation name.
+
+**Parameters:**
+
+- `operation_name` (optional) — Filter to a specific operation
+- `project` (optional) — Project name
+
+### introspect_endpoint
+
+Fetch a schema from a remote GraphQL endpoint via introspection and return the SDL. Supports custom headers for authentication (e.g., `Authorization`).
+
+**Parameters:**
+
+- `url` (required) — GraphQL endpoint URL
+- `headers` (optional) — Map of HTTP headers to include in the request

--- a/docs/src/content/docs/cli/check.mdx
+++ b/docs/src/content/docs/cli/check.mdx
@@ -13,11 +13,11 @@ graphql check [OPTIONS]
 
 ## Options
 
-| Option                    | Description                                                    |
-| ------------------------- | -------------------------------------------------------------- |
-| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
-| `-w, --watch`             | Watch for file changes and re-check                            |
-| `--max-warnings <N>`      | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
+| Option                  | Description                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `-f, --format <FORMAT>` | Output format: `human` (default), `json`, `github`, `sarif`                            |
+| `-w, --watch`           | Watch for file changes and re-check                                                    |
+| `--max-warnings <N>`    | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
 
 ## Examples
 

--- a/docs/src/content/docs/cli/check.mdx
+++ b/docs/src/content/docs/cli/check.mdx
@@ -13,10 +13,11 @@ graphql check [OPTIONS]
 
 ## Options
 
-| Option              | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| `--format <FORMAT>` | Output format: `human` (default), `json`, `github` |
-| `--watch`           | Watch for file changes and re-check                |
+| Option                    | Description                                                    |
+| ------------------------- | -------------------------------------------------------------- |
+| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
+| `-w, --watch`             | Watch for file changes and re-check                            |
+| `--max-warnings <N>`      | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
 
 ## Examples
 
@@ -38,3 +39,4 @@ graphql --project backend check
 
 - `0` — No validation or lint errors
 - `1` — Errors found
+- `6` — Warning threshold exceeded (`--max-warnings`)

--- a/docs/src/content/docs/cli/ci-cd.mdx
+++ b/docs/src/content/docs/cli/ci-cd.mdx
@@ -99,8 +99,27 @@ fi
 
 ## Enabling expensive rules in CI
 
-Some lint rules (like `noUnusedFields`) are too expensive for real-time editor feedback but work well in CI. You can enable them via CLI flags:
+Some lint rules (like `noUnusedFields`) are too expensive for real-time editor feedback but work well in CI. Enable them via CLI-specific config overrides in `.graphqlrc.yaml`:
+
+```yaml
+extensions:
+  lint:
+    extends: recommended
+  cli:
+    lint:
+      rules:
+        noUnusedFields: error
+        noUnusedFragments: error
+```
+
+The `extensions.cli.lint.rules` block applies only when running the CLI, so the LSP and editor stays fast.
+
+## Enforcing zero warnings in CI
+
+Use `--max-warnings 0` to treat any warning as a failure:
 
 ```bash
-graphql check --rule noUnusedFields=error --rule noUnusedFragments=error
+graphql check --max-warnings 0
 ```
+
+This returns exit code 6 if any warnings are found, making CI strict about warnings without promoting them all to errors in the config.

--- a/docs/src/content/docs/cli/lint.mdx
+++ b/docs/src/content/docs/cli/lint.mdx
@@ -13,13 +13,13 @@ graphql lint [OPTIONS]
 
 ## Options
 
-| Option                    | Description                                                    |
-| ------------------------- | -------------------------------------------------------------- |
-| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
-| `-w, --watch`             | Watch for file changes and re-lint                             |
-| `--fix`                   | Automatically fix issues that have safe fixes                  |
-| `--fix-dry-run`           | Show what would be fixed without modifying files               |
-| `--max-warnings <N>`      | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
+| Option                  | Description                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `-f, --format <FORMAT>` | Output format: `human` (default), `json`, `github`, `sarif`                            |
+| `-w, --watch`           | Watch for file changes and re-lint                                                     |
+| `--fix`                 | Automatically fix issues that have safe fixes                                          |
+| `--fix-dry-run`         | Show what would be fixed without modifying files                                       |
+| `--max-warnings <N>`    | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
 
 ## Examples
 

--- a/docs/src/content/docs/cli/lint.mdx
+++ b/docs/src/content/docs/cli/lint.mdx
@@ -13,12 +13,13 @@ graphql lint [OPTIONS]
 
 ## Options
 
-| Option              | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| `--format <FORMAT>` | Output format: `human` (default), `json`, `github` |
-| `--watch`           | Watch for file changes and re-lint                 |
-| `--fix`             | Automatically fix issues that have safe fixes      |
-| `--fix-dry-run`     | Show what would be fixed without modifying files   |
+| Option                    | Description                                                    |
+| ------------------------- | -------------------------------------------------------------- |
+| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
+| `-w, --watch`             | Watch for file changes and re-lint                             |
+| `--fix`                   | Automatically fix issues that have safe fixes                  |
+| `--fix-dry-run`           | Show what would be fixed without modifying files               |
+| `--max-warnings <N>`      | Maximum number of warnings allowed before returning a non-zero exit code (exit code 6) |
 
 ## Examples
 
@@ -46,6 +47,7 @@ graphql --project frontend lint
 
 - `0` — No lint errors (warnings don't cause non-zero exit)
 - `1` — Lint errors found
+- `6` — Warning threshold exceeded (`--max-warnings`)
 
 ## Configuring rules
 

--- a/docs/src/content/docs/cli/output-formats.mdx
+++ b/docs/src/content/docs/cli/output-formats.mdx
@@ -27,12 +27,15 @@ Colorized, human-readable output with source context:
 Machine-readable JSON for CI/CD pipelines and custom tooling:
 
 ```sh
-graphql validate --format json
+graphql check --format json
 ```
+
+The `check` command emits an object with per-file `errors` and `warnings` arrays and a unified `stats` block:
 
 ```json
 {
   "success": false,
+  "schema_loaded": true,
   "files": [
     {
       "file": "src/queries.graphql",
@@ -40,17 +43,23 @@ graphql validate --format json
         {
           "message": "Cannot query field \"invalidField\" on type \"User\"",
           "severity": "error",
+          "source": "validation",
+          "rule": null,
           "location": {
             "start": { "line": 5, "column": 3 },
             "end": { "line": 5, "column": 15 }
           }
         }
-      ]
+      ],
+      "warnings": []
     }
   ],
   "stats": {
     "total_files": 1,
-    "total_errors": 1
+    "total_errors": 1,
+    "total_warnings": 0,
+    "validation_errors": 1,
+    "lint_errors": 0
   }
 }
 ```
@@ -64,7 +73,7 @@ graphql validate --format github
 ```
 
 ```
-::error file=src/queries.graphql,line=5,col=3::Cannot query field "invalidField" on type "User"
+::error file=src/queries.graphql,line=5,col=3,endLine=5,endColumn=15::Cannot query field "invalidField" on type "User"
 ```
 
 See [CI/CD Integration](/graphql-analyzer/cli/ci-cd/) for a full GitHub Actions workflow.

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -19,17 +19,21 @@ See [Installation](/graphql-analyzer/getting-started/installation/) for all meth
 
 ## Commands
 
-| Command        | Description                               | Recommended for      |
-| -------------- | ----------------------------------------- | -------------------- |
-| `check`        | Run validation + linting in a single pass | Most workflows       |
-| `validate`     | Run schema validation only                | Schema-only checks   |
-| `lint`         | Run lint rules only                       | Lint-only checks     |
-| `deprecations` | List deprecated field usages              | Deprecation tracking |
-| `schema`       | Schema management (download, etc.)        | Schema introspection |
-| `stats`        | Display project statistics                | Project overview     |
-| `fragments`    | Analyze fragment usage                    | Fragment cleanup     |
-| `coverage`     | Show schema field coverage by operations  | Coverage analysis    |
-| `complexity`   | Analyze query complexity                  | Complexity budgeting |
+| Command        | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| `check`        | Run validation + linting in a single pass (recommended)      |
+| `validate`     | Run schema validation only                                   |
+| `lint`         | Run lint rules only                                          |
+| `deprecations` | List all deprecated field usages across the project          |
+| `schema`       | Schema-related commands (download, etc.)                     |
+| `stats`        | Display statistics about the GraphQL project                 |
+| `fragments`    | Analyze fragment usage across the project                    |
+| `coverage`     | Show schema field coverage by operations                     |
+| `complexity`   | Analyze query complexity for GraphQL operations              |
+| `mcp`          | Start an MCP server for AI agent integration                 |
+| `list-rules`   | List all available lint rules                                |
+| `explain`      | Show details about a lint rule                               |
+| `lsp`          | Start the Language Server Protocol (LSP) server              |
 
 **`check` is the recommended command** — it's more efficient than running `validate` and `lint` separately.
 
@@ -60,15 +64,17 @@ graphql complexity --threshold 100
 
 ## Global options
 
-| Option              | Description                                      |
-| ------------------- | ------------------------------------------------ |
-| `--config <PATH>`   | Path to config file (auto-discovered by default) |
-| `--project <NAME>`  | Project name for multi-project configs           |
-| `--quiet`, `-q`     | Suppress all output except errors                |
-| `--no-progress`     | Suppress progress spinners only                  |
-| `--format <FORMAT>` | Output format: `human`, `json`, `github`         |
-| `--color`           | Force colored output even when not a TTY         |
-| `--no-color`        | Disable colored output                           |
+| Option                   | Description                                      |
+| ------------------------ | ------------------------------------------------ |
+| `-c, --config <FILE>`    | Path to config file (auto-discovered by default) |
+| `-p, --project <PROJECT>`| Project name for multi-project configs           |
+| `--color`                | Force colored output even when not a TTY         |
+| `--no-color`             | Disable colored output                           |
+| `-q, --quiet`            | Suppress all output except errors                |
+| `--no-progress`          | Suppress progress spinners only                  |
+| `-V, --version`          | Print version and exit                           |
+
+Each output-producing command supports `-f, --format` independently.
 
 **Output verbosity:**
 
@@ -88,6 +94,7 @@ graphql complexity --threshold 100
 | 3    | Schema load error (introspection failed, etc.) |
 | 4    | I/O error (file read/write failure)            |
 | 5    | Parse error (invalid GraphQL syntax)           |
+| 6    | Warning threshold exceeded (`--max-warnings` limit hit) |
 
 ```sh
 graphql validate
@@ -104,6 +111,7 @@ esac
 
 | Variable         | Description                                           |
 | ---------------- | ----------------------------------------------------- |
+| `GRAPHQL_CONFIG` | Override config file path                             |
 | `RUST_LOG`       | Log level (`error`, `warn`, `info`, `debug`, `trace`) |
 | `NO_COLOR`       | Disable colored output                                |
 | `CLICOLOR`       | `0` to disable, `1` to enable colors                  |

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -19,21 +19,21 @@ See [Installation](/graphql-analyzer/getting-started/installation/) for all meth
 
 ## Commands
 
-| Command        | Description                                                  |
-| -------------- | ------------------------------------------------------------ |
-| `check`        | Run validation + linting in a single pass (recommended)      |
-| `validate`     | Run schema validation only                                   |
-| `lint`         | Run lint rules only                                          |
-| `deprecations` | List all deprecated field usages across the project          |
-| `schema`       | Schema-related commands (download, etc.)                     |
-| `stats`        | Display statistics about the GraphQL project                 |
-| `fragments`    | Analyze fragment usage across the project                    |
-| `coverage`     | Show schema field coverage by operations                     |
-| `complexity`   | Analyze query complexity for GraphQL operations              |
-| `mcp`          | Start an MCP server for AI agent integration                 |
-| `list-rules`   | List all available lint rules                                |
-| `explain`      | Show details about a lint rule                               |
-| `lsp`          | Start the Language Server Protocol (LSP) server              |
+| Command        | Description                                             |
+| -------------- | ------------------------------------------------------- |
+| `check`        | Run validation + linting in a single pass (recommended) |
+| `validate`     | Run schema validation only                              |
+| `lint`         | Run lint rules only                                     |
+| `deprecations` | List all deprecated field usages across the project     |
+| `schema`       | Schema-related commands (download, etc.)                |
+| `stats`        | Display statistics about the GraphQL project            |
+| `fragments`    | Analyze fragment usage across the project               |
+| `coverage`     | Show schema field coverage by operations                |
+| `complexity`   | Analyze query complexity for GraphQL operations         |
+| `mcp`          | Start an MCP server for AI agent integration            |
+| `list-rules`   | List all available lint rules                           |
+| `explain`      | Show details about a lint rule                          |
+| `lsp`          | Start the Language Server Protocol (LSP) server         |
 
 **`check` is the recommended command** — it's more efficient than running `validate` and `lint` separately.
 
@@ -64,15 +64,15 @@ graphql complexity --threshold 100
 
 ## Global options
 
-| Option                   | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `-c, --config <FILE>`    | Path to config file (auto-discovered by default) |
-| `-p, --project <PROJECT>`| Project name for multi-project configs           |
-| `--color`                | Force colored output even when not a TTY         |
-| `--no-color`             | Disable colored output                           |
-| `-q, --quiet`            | Suppress all output except errors                |
-| `--no-progress`          | Suppress progress spinners only                  |
-| `-V, --version`          | Print version and exit                           |
+| Option                    | Description                                      |
+| ------------------------- | ------------------------------------------------ |
+| `-c, --config <FILE>`     | Path to config file (auto-discovered by default) |
+| `-p, --project <PROJECT>` | Project name for multi-project configs           |
+| `--color`                 | Force colored output even when not a TTY         |
+| `--no-color`              | Disable colored output                           |
+| `-q, --quiet`             | Suppress all output except errors                |
+| `--no-progress`           | Suppress progress spinners only                  |
+| `-V, --version`           | Print version and exit                           |
 
 Each output-producing command supports `-f, --format` independently.
 
@@ -86,14 +86,14 @@ Each output-producing command supports `-f, --format` independently.
 
 ## Exit codes
 
-| Code | Meaning                                        |
-| ---- | ---------------------------------------------- |
-| 0    | Success — no errors                            |
-| 1    | Validation or lint errors found                |
-| 2    | Configuration error (missing/invalid config)   |
-| 3    | Schema load error (introspection failed, etc.) |
-| 4    | I/O error (file read/write failure)            |
-| 5    | Parse error (invalid GraphQL syntax)           |
+| Code | Meaning                                                 |
+| ---- | ------------------------------------------------------- |
+| 0    | Success — no errors                                     |
+| 1    | Validation or lint errors found                         |
+| 2    | Configuration error (missing/invalid config)            |
+| 3    | Schema load error (introspection failed, etc.)          |
+| 4    | I/O error (file read/write failure)                     |
+| 5    | Parse error (invalid GraphQL syntax)                    |
 | 6    | Warning threshold exceeded (`--max-warnings` limit hit) |
 
 ```sh

--- a/docs/src/content/docs/cli/validate.mdx
+++ b/docs/src/content/docs/cli/validate.mdx
@@ -13,11 +13,11 @@ graphql validate [OPTIONS]
 
 ## Options
 
-| Option              | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| `--format <FORMAT>` | Output format: `human` (default), `json`, `github` |
-| `--watch`           | Watch for file changes and re-validate             |
-| `--syntax-only`     | Skip schema validation, only check syntax          |
+| Option                    | Description                                                    |
+| ------------------------- | -------------------------------------------------------------- |
+| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
+| `-w, --watch`             | Watch for file changes and re-validate                         |
+| `--syntax-only`           | Skip schema validation, only check syntax                      |
 
 ## Examples
 

--- a/docs/src/content/docs/cli/validate.mdx
+++ b/docs/src/content/docs/cli/validate.mdx
@@ -13,11 +13,11 @@ graphql validate [OPTIONS]
 
 ## Options
 
-| Option                    | Description                                                    |
-| ------------------------- | -------------------------------------------------------------- |
-| `-f, --format <FORMAT>`   | Output format: `human` (default), `json`, `github`, `sarif`   |
-| `-w, --watch`             | Watch for file changes and re-validate                         |
-| `--syntax-only`           | Skip schema validation, only check syntax                      |
+| Option                  | Description                                                 |
+| ----------------------- | ----------------------------------------------------------- |
+| `-f, --format <FORMAT>` | Output format: `human` (default), `json`, `github`, `sarif` |
+| `-w, --watch`           | Watch for file changes and re-validate                      |
+| `--syntax-only`         | Skip schema validation, only check syntax                   |
 
 ## Examples
 

--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -20,6 +20,7 @@ The tool searches for these files in order, walking up the directory tree from y
 5. `graphql.config.yml` / `graphql.config.yaml`
 6. `graphql.config.json`
 7. `graphql.config.toml`
+8. `package.json` (with a `"graphql"` key — lowest priority fallback)
 
 You can also specify a config file explicitly:
 
@@ -56,10 +57,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   </TabItem>
 </Tabs>
 
-| Field       | Required | Description                        |
-| ----------- | -------- | ---------------------------------- |
-| `schema`    | Yes      | Schema source (file, glob, or URL) |
-| `documents` | No       | Document file patterns             |
+| Field       | Required | Description                                                   |
+| ----------- | -------- | ------------------------------------------------------------- |
+| `schema`    | Yes      | Schema source (file, glob, or URL)                            |
+| `documents` | No       | Document file patterns                                        |
+| `include`   | No       | File patterns that scope which files belong to this project   |
+| `exclude`   | No       | File patterns to exclude from this project                    |
 
 ## Adding linting
 
@@ -141,15 +144,39 @@ module.exports = {
 
 <Tabs>
   <TabItem label="YAML">
-    ```yaml # .graphqlrc.yml (equivalent) schema: schema.graphql documents: src/**/*.graphql ```
+    ```yaml
+    # .graphqlrc.yml (equivalent)
+    schema: schema.graphql
+    documents: src/**/*.graphql
+    ```
   </TabItem>
   <TabItem label="TOML">
-    ```toml # .graphqlrc.toml (equivalent) schema = "schema.graphql" documents = "src/**/*.graphql"
+    ```toml
+    # .graphqlrc.toml (equivalent)
+    schema = "schema.graphql"
+    documents = "src/**/*.graphql"
     ```
   </TabItem>
 </Tabs>
 
 For dynamic configuration needs, generate the YAML/JSON/TOML config as a build step.
+
+## Environment variable interpolation
+
+Config values support `${VAR}` and `${VAR:default}` substitution. This is useful for keeping secrets like API tokens out of your config file:
+
+```yaml
+schema:
+  url: https://api.example.com/graphql
+  headers:
+    Authorization: Bearer ${API_TOKEN}
+    X-Tenant: ${TENANT_ID:default-tenant}
+```
+
+- `${VAR}` — replaced with the value of `VAR`; fails with an error if the variable is unset
+- `${VAR:default}` — replaced with the value of `VAR`, or `default` if the variable is unset
+
+Interpolation is applied to all string values before the config is parsed, so it works in any field — URLs, headers, file paths, etc.
 
 ## Environment variables
 

--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -57,12 +57,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   </TabItem>
 </Tabs>
 
-| Field       | Required | Description                                                   |
-| ----------- | -------- | ------------------------------------------------------------- |
-| `schema`    | Yes      | Schema source (file, glob, or URL)                            |
-| `documents` | No       | Document file patterns                                        |
-| `include`   | No       | File patterns that scope which files belong to this project   |
-| `exclude`   | No       | File patterns to exclude from this project                    |
+| Field       | Required | Description                                                 |
+| ----------- | -------- | ----------------------------------------------------------- |
+| `schema`    | Yes      | Schema source (file, glob, or URL)                          |
+| `documents` | No       | Document file patterns                                      |
+| `include`   | No       | File patterns that scope which files belong to this project |
+| `exclude`   | No       | File patterns to exclude from this project                  |
 
 ## Adding linting
 
@@ -144,17 +144,10 @@ module.exports = {
 
 <Tabs>
   <TabItem label="YAML">
-    ```yaml
-    # .graphqlrc.yml (equivalent)
-    schema: schema.graphql
-    documents: src/**/*.graphql
-    ```
+    ```yaml # .graphqlrc.yml (equivalent) schema: schema.graphql documents: src/**/*.graphql ```
   </TabItem>
   <TabItem label="TOML">
-    ```toml
-    # .graphqlrc.toml (equivalent)
-    schema = "schema.graphql"
-    documents = "src/**/*.graphql"
+    ```toml # .graphqlrc.toml (equivalent) schema = "schema.graphql" documents = "src/**/*.graphql"
     ```
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/configuration/documents.mdx
+++ b/docs/src/content/docs/configuration/documents.mdx
@@ -23,6 +23,8 @@ documents:
   - "src/**/*.gql"
   - "src/**/*.tsx"
   - "src/**/*.ts"
+  - "src/**/*.jsx"
+  - "src/**/*.js"
   - "src/**/*.vue"
   - "src/**/*.svelte"
   - "src/**/*.astro"
@@ -74,6 +76,7 @@ extensions:
 
 | Option                   | Default           | Description                      |
 | ------------------------ | ----------------- | -------------------------------- |
-| `tagIdentifiers`         | `["gql"]`         | Tag function names to recognize  |
-| `modules`                | `["graphql-tag"]` | Import sources to recognize      |
-| `allowGlobalIdentifiers` | `false`           | Allow unimported tag identifiers |
+| `tagIdentifiers`         | `["gql", "graphql"]`                                                                                   | Tag function names to recognize                                                    |
+| `modules`                | `["graphql-tag", "@apollo/client", "apollo-server", "apollo-server-express", "gatsby", "react-relay"]` | Import sources to recognize                                                        |
+| `magicComment`           | `"GraphQL"`                                                                                             | Enables extraction from string literals and untagged template literals preceded by a `/* GraphQL */` comment |
+| `allowGlobalIdentifiers` | `false`                                                                                                 | Allow unimported tag identifiers                                                   |

--- a/docs/src/content/docs/configuration/documents.mdx
+++ b/docs/src/content/docs/configuration/documents.mdx
@@ -74,9 +74,9 @@ extensions:
       allowGlobalIdentifiers: true
 ```
 
-| Option                   | Default           | Description                      |
-| ------------------------ | ----------------- | -------------------------------- |
-| `tagIdentifiers`         | `["gql", "graphql"]`                                                                                   | Tag function names to recognize                                                    |
-| `modules`                | `["graphql-tag", "@apollo/client", "apollo-server", "apollo-server-express", "gatsby", "react-relay"]` | Import sources to recognize                                                        |
-| `magicComment`           | `"GraphQL"`                                                                                             | Enables extraction from string literals and untagged template literals preceded by a `/* GraphQL */` comment |
-| `allowGlobalIdentifiers` | `false`                                                                                                 | Allow unimported tag identifiers                                                   |
+| Option                   | Default                                                                                                | Description                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `tagIdentifiers`         | `["gql", "graphql"]`                                                                                   | Tag function names to recognize                                                                              |
+| `modules`                | `["graphql-tag", "@apollo/client", "apollo-server", "apollo-server-express", "gatsby", "react-relay"]` | Import sources to recognize                                                                                  |
+| `magicComment`           | `"GraphQL"`                                                                                            | Enables extraction from string literals and untagged template literals preceded by a `/* GraphQL */` comment |
+| `allowGlobalIdentifiers` | `false`                                                                                                | Allow unimported tag identifiers                                                                             |

--- a/docs/src/content/docs/configuration/multi-project.mdx
+++ b/docs/src/content/docs/configuration/multi-project.mdx
@@ -20,6 +20,48 @@ projects:
 
 Each project is fully independent — it has its own schema, documents, and lint configuration.
 
+## Scoping files with include/exclude
+
+Use `include` and `exclude` to precisely control which files belong to each project. This is especially useful when document patterns alone would be ambiguous:
+
+```yaml
+projects:
+  web:
+    schema: packages/web/schema.graphql
+    documents: packages/web/src/**/*.{graphql,tsx}
+    include:
+      - packages/web/**
+    exclude:
+      - packages/web/**/__tests__/**
+  api:
+    schema: packages/api/schema.graphql
+    documents: packages/api/src/**/*.graphql
+    include:
+      - packages/api/**
+```
+
+`include` restricts the project to files under those paths. `exclude` removes files from the project even if they match other patterns. Both accept glob patterns.
+
+## Per-project client configuration
+
+The `client` extension field (`apollo` | `relay` | `none`) controls which client-side directives are recognized for that project. For example, setting `client: apollo` makes `@client`, `@connection`, and other Apollo-specific directives valid in operations:
+
+```yaml
+projects:
+  web:
+    schema: packages/web/schema.graphql
+    documents: packages/web/src/**/*.{graphql,tsx}
+    extensions:
+      graphql-analyzer:
+        client: apollo
+  api:
+    schema: packages/api/schema.graphql
+    documents: packages/api/src/**/*.graphql
+    extensions:
+      graphql-analyzer:
+        client: none
+```
+
 ## Per-project linting
 
 ```yaml

--- a/docs/src/content/docs/configuration/schema-sources.mdx
+++ b/docs/src/content/docs/configuration/schema-sources.mdx
@@ -33,9 +33,31 @@ schema:
 schema: https://api.example.com/graphql
 ```
 
-The tool fetches the schema via introspection query. The schema is cached automatically.
+The tool fetches the schema via introspection query. Introspection runs each time the schema is loaded; results are held in memory by the running LSP/CLI process.
 
-See [Remote Schema Introspection](/graphql-analyzer/advanced/remote-schemas/) for authentication and advanced options.
+## Remote schema with options
+
+For authenticated endpoints or custom timeouts, use the structured form:
+
+```yaml
+schema:
+  url: https://api.example.com/graphql
+  headers:
+    Authorization: Bearer ${API_TOKEN}
+  timeout: 60
+  retry: 3
+```
+
+| Field     | Required | Description                                                    |
+| --------- | -------- | -------------------------------------------------------------- |
+| `url`     | Yes      | The GraphQL endpoint URL to introspect                         |
+| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation   |
+| `timeout` | No       | Request timeout in seconds (default: 30)                       |
+| `retry`   | No       | Number of retry attempts on failure (default: 0)               |
+
+See [Environment variable interpolation](#environment-variable-interpolation) for how to keep secrets out of your config file.
+
+See [Remote Schema Introspection](/graphql-analyzer/advanced/remote-schemas/) for additional details.
 
 ## Per-project schemas
 

--- a/docs/src/content/docs/configuration/schema-sources.mdx
+++ b/docs/src/content/docs/configuration/schema-sources.mdx
@@ -48,12 +48,12 @@ schema:
   retry: 3
 ```
 
-| Field     | Required | Description                                                    |
-| --------- | -------- | -------------------------------------------------------------- |
-| `url`     | Yes      | The GraphQL endpoint URL to introspect                         |
-| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation   |
-| `timeout` | No       | Request timeout in seconds (default: 30)                       |
-| `retry`   | No       | Number of retry attempts on failure (default: 0)               |
+| Field     | Required | Description                                                 |
+| --------- | -------- | ----------------------------------------------------------- |
+| `url`     | Yes      | The GraphQL endpoint URL to introspect                      |
+| `headers` | No       | Map of header name → value; supports `${VAR}` interpolation |
+| `timeout` | No       | Request timeout in seconds (default: 30)                    |
+| `retry`   | No       | Number of retry attempts on failure (default: 0)            |
 
 See [Environment variable interpolation](#environment-variable-interpolation) for how to keep secrets out of your config file.
 

--- a/docs/src/content/docs/editors/neovim.mdx
+++ b/docs/src/content/docs/editors/neovim.mdx
@@ -15,13 +15,17 @@ Add to your `init.lua`:
 ```lua
 require('lspconfig').graphql.setup {
   cmd = { 'graphql-lsp' },
-  filetypes = { 'graphql', 'typescriptreact', 'javascriptreact' },
+  filetypes = { 'graphql', 'typescript', 'typescriptreact', 'javascript', 'javascriptreact', 'vue', 'svelte', 'astro' },
   root_dir = require('lspconfig.util').root_pattern(
     '.graphqlrc*',
     'graphql.config.*'
   ),
 }
 ```
+
+:::note
+**Note:** Nvim 0.11+ users should prefer the new-style `vim.lsp.config` API. The built-in `graphql` server in nvim-lspconfig points to a different tool — always pass an explicit `cmd = { 'graphql-lsp' }` to use this project's LSP server.
+:::
 
 ## Custom binary path
 

--- a/docs/src/content/docs/editors/other.mdx
+++ b/docs/src/content/docs/editors/other.mdx
@@ -39,6 +39,7 @@ The server supports:
 - `textDocument/rename` — Rename symbols
 - `textDocument/codeAction` — Quick fixes
 - `workspace/didChangeWatchedFiles` — React to file changes
+- `workspace/executeCommand` — Execute server-side commands
 
 ## Running the server
 
@@ -64,6 +65,10 @@ command = "graphql-lsp"
 ```
 
 ## Zed
+
+:::note
+**Note:** Zed does not currently support arbitrary custom LSP servers via settings.json. The configuration below requires a Zed extension to register the server. Track Zed's [language server documentation](https://zed.dev/docs/configuring-zed#language-servers) for status.
+:::
 
 Zed has built-in LSP support. Add to your settings:
 

--- a/docs/src/content/docs/editors/vscode.mdx
+++ b/docs/src/content/docs/editors/vscode.mdx
@@ -54,15 +54,15 @@ The extension activates automatically when a `.graphqlrc.*` or `graphql.config.*
 
 ## Commands
 
-| Command                          | Description         |
-| -------------------------------- | ------------------- |
-| `graphql-analyzer.restartServer`        | Restart LSP server               |
-| `graphql-analyzer.jumpToLogs`           | Show server logs                 |
-| `graphql-analyzer.checkStatus`          | Check server status              |
-| `graphql-analyzer.reportIssue`          | Report an issue                  |
-| `graphql-analyzer.testOtelConnection`   | Test OpenTelemetry Connection    |
-| `graphql-analyzer.startTrace`           | Start performance trace          |
-| `graphql-analyzer.stopTrace`            | Stop performance trace           |
+| Command                               | Description                   |
+| ------------------------------------- | ----------------------------- |
+| `graphql-analyzer.restartServer`      | Restart LSP server            |
+| `graphql-analyzer.jumpToLogs`         | Show server logs              |
+| `graphql-analyzer.checkStatus`        | Check server status           |
+| `graphql-analyzer.reportIssue`        | Report an issue               |
+| `graphql-analyzer.testOtelConnection` | Test OpenTelemetry Connection |
+| `graphql-analyzer.startTrace`         | Start performance trace       |
+| `graphql-analyzer.stopTrace`          | Stop performance trace        |
 
 Access via Command Palette (`Ctrl/Cmd+Shift+P`).
 

--- a/docs/src/content/docs/editors/vscode.mdx
+++ b/docs/src/content/docs/editors/vscode.mdx
@@ -7,17 +7,9 @@ The VS Code extension bundles the LSP server — no separate installation needed
 
 ## Installation
 
-**One-line installer (macOS/Linux):**
+Install **[GraphQL Analyzer](https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer)** from the VS Code Marketplace, or search "GraphQL Analyzer" in the Extensions view (`Ctrl/Cmd+Shift+X`).
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.sh | sh
-```
-
-**One-line installer (Windows PowerShell):**
-
-```powershell
-irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.ps1 | iex
-```
+For VS Codium, Cursor, Windsurf, and other VS Code-compatible editors, install from the [Open VSX Registry](https://open-vsx.org/extension/graphql-analyzer/graphql-analyzer).
 
 **Manual:** Download the `.vsix` for your platform from the [releases page](https://github.com/trevor-scheer/graphql-analyzer/releases) and install with `code --install-extension <file>.vsix`.
 
@@ -30,7 +22,7 @@ schema: "schema.graphql"
 documents: "src/**/*.{graphql,ts,tsx,vue,svelte,astro}"
 ```
 
-Open any GraphQL file to activate the extension.
+The extension activates automatically when a `.graphqlrc.*` or `graphql.config.*` file is detected in your workspace root.
 
 ## Extension settings
 
@@ -64,10 +56,13 @@ Open any GraphQL file to activate the extension.
 
 | Command                          | Description         |
 | -------------------------------- | ------------------- |
-| `graphql-analyzer.restartServer` | Restart LSP server  |
-| `graphql-analyzer.jumpToLogs`    | Show server logs    |
-| `graphql-analyzer.checkStatus`   | Check server status |
-| `graphql-analyzer.reportIssue`   | Report an issue     |
+| `graphql-analyzer.restartServer`        | Restart LSP server               |
+| `graphql-analyzer.jumpToLogs`           | Show server logs                 |
+| `graphql-analyzer.checkStatus`          | Check server status              |
+| `graphql-analyzer.reportIssue`          | Report an issue                  |
+| `graphql-analyzer.testOtelConnection`   | Test OpenTelemetry Connection    |
+| `graphql-analyzer.startTrace`           | Start performance trace          |
+| `graphql-analyzer.stopTrace`            | Stop performance trace           |
 
 Access via Command Palette (`Ctrl/Cmd+Shift+P`).
 
@@ -84,7 +79,7 @@ The extension includes a pre-compiled LSP server binary for:
 **Extension not working?**
 
 1. Open the Output panel (View → Output)
-2. Select "GraphQL Language Server" from the dropdown
+2. Select "graphql-analyzer Debug" from the dropdown (or "graphql-analyzer LSP" for raw LSP traffic)
 3. Look for errors
 
 **Common fixes:**

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -15,17 +15,11 @@ GraphQL Analyzer has three main components you can install independently:
 
 The extension bundles the LSP server — no separate installation needed.
 
-**One-line installer (macOS/Linux):**
+Install **[GraphQL Analyzer](https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer)** from the VS Code Marketplace, or search "GraphQL Analyzer" in the Extensions view (`Ctrl/Cmd+Shift+X`).
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.sh | sh
-```
+For VS Codium, Cursor, Windsurf, and other VS Code-compatible editors, install from the [Open VSX Registry](https://open-vsx.org/extension/graphql-analyzer/graphql-analyzer).
 
-**One-line installer (Windows PowerShell):**
-
-```powershell
-irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.ps1 | iex
-```
+### Other installation methods
 
 **Manual installation:**
 
@@ -87,7 +81,7 @@ For editors other than VS Code (Neovim, Helix, etc.), install the LSP server dir
 **Via Cargo:**
 
 ```sh
-cargo install graphql-lsp
+cargo install --git https://github.com/trevor-scheer/graphql-analyzer graphql-lsp
 ```
 
 **Binary downloads:**

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -5,19 +5,7 @@ description: Get up and running with GraphQL Analyzer in 3 minutes.
 
 ## 1. Install the VS Code extension
 
-**macOS / Linux:**
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.sh | sh
-```
-
-**Windows (PowerShell):**
-
-```powershell
-irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install-vscode.ps1 | iex
-```
-
-Or download the `.vsix` from the [releases page](https://github.com/trevor-scheer/graphql-analyzer/releases) and install via `code --install-extension <file>.vsix`.
+Install [GraphQL Analyzer](https://marketplace.visualstudio.com/items?itemName=graphql-analyzer.graphql-analyzer) from the VS Code Marketplace, or [Open VSX](https://open-vsx.org/extension/graphql-analyzer/graphql-analyzer) for VS Codium/Cursor.
 
 ## 2. Configure your project
 

--- a/docs/src/content/docs/ide-features/diagnostics.mdx
+++ b/docs/src/content/docs/ide-features/diagnostics.mdx
@@ -7,7 +7,7 @@ GraphQL Analyzer provides real-time diagnostics as you type, showing validation 
 
 ## What's checked
 
-- **GraphQL spec validation** — Full compliance via Apollo compiler
+- **GraphQL spec validation** — Full GraphQL spec validation via the project's analysis layer
 - **Schema type checking** — Fields, arguments, types validated against your schema
 - **Lint rules** — Configurable rules for best practices
 - **Position-accurate** — Correct line/column even for embedded GraphQL in TypeScript/JavaScript

--- a/docs/src/content/docs/ide-features/embedded-graphql.mdx
+++ b/docs/src/content/docs/ide-features/embedded-graphql.mdx
@@ -7,12 +7,12 @@ GraphQL Analyzer provides full IDE support for GraphQL embedded in TypeScript, J
 
 ## Supported file types
 
-| File type               | Extensions                   | How GraphQL is found                                    |
-| ----------------------- | ---------------------------- | ------------------------------------------------------- |
+| File type               | Extensions                                   | How GraphQL is found                                    |
+| ----------------------- | -------------------------------------------- | ------------------------------------------------------- |
 | TypeScript / JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` | Tagged template literals (`gql`, `graphql`)             |
-| Vue                     | `.vue`                       | `<script>` / `<script setup>` blocks → tagged templates |
-| Svelte                  | `.svelte`                    | `<script>` blocks → tagged templates                    |
-| Astro                   | `.astro`                     | Frontmatter (`---`) section → tagged templates          |
+| Vue                     | `.vue`                                       | `<script>` / `<script setup>` blocks → tagged templates |
+| Svelte                  | `.svelte`                                    | `<script>` blocks → tagged templates                    |
+| Astro                   | `.astro`                                     | Frontmatter (`---`) section → tagged templates          |
 
 All IDE features work inside embedded GraphQL regardless of file type:
 
@@ -121,13 +121,18 @@ In addition to tagged template literals, the analyzer extracts GraphQL from unta
 ```typescript
 const query = /* GraphQL */ `
   query GetUser($id: ID!) {
-    user(id: $id) { id name }
+    user(id: $id) {
+      id
+      name
+    }
   }
 `;
 
 const mutation = /* GraphQL */ `
   mutation UpdateUser($id: ID!, $name: String!) {
-    updateUser(id: $id, name: $name) { id }
+    updateUser(id: $id, name: $name) {
+      id
+    }
   }
 `;
 ```

--- a/docs/src/content/docs/ide-features/embedded-graphql.mdx
+++ b/docs/src/content/docs/ide-features/embedded-graphql.mdx
@@ -9,7 +9,7 @@ GraphQL Analyzer provides full IDE support for GraphQL embedded in TypeScript, J
 
 | File type               | Extensions                   | How GraphQL is found                                    |
 | ----------------------- | ---------------------------- | ------------------------------------------------------- |
-| TypeScript / JavaScript | `.ts`, `.tsx`, `.js`, `.jsx` | Tagged template literals (`gql`, `graphql`)             |
+| TypeScript / JavaScript | `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` | Tagged template literals (`gql`, `graphql`)             |
 | Vue                     | `.vue`                       | `<script>` / `<script setup>` blocks → tagged templates |
 | Svelte                  | `.svelte`                    | `<script>` blocks → tagged templates                    |
 | Astro                   | `.astro`                     | Frontmatter (`---`) section → tagged templates          |
@@ -101,7 +101,7 @@ The analyzer extracts GraphQL from tagged template literals and maps positions b
 
 ## Configuring extraction
 
-By default, the tool recognizes `gql` imported from `graphql-tag`. Customize which tags and modules are recognized:
+By default, the tool recognizes `gql` and `graphql` tags imported from any of these modules: `graphql-tag`, `@apollo/client`, `apollo-server`, `apollo-server-express`, `gatsby`, and `react-relay`. Customize which tags and modules are recognized:
 
 ```yaml
 extensions:
@@ -113,6 +113,26 @@ extensions:
 ```
 
 See [Documents configuration](/graphql-analyzer/configuration/documents/) for details.
+
+## Magic comment extraction
+
+In addition to tagged template literals, the analyzer extracts GraphQL from untagged string literals and template literals preceded by a `/* GraphQL */` comment:
+
+```typescript
+const query = /* GraphQL */ `
+  query GetUser($id: ID!) {
+    user(id: $id) { id name }
+  }
+`;
+
+const mutation = /* GraphQL */ `
+  mutation UpdateUser($id: ID!, $name: String!) {
+    updateUser(id: $id, name: $name) { id }
+  }
+`;
+```
+
+This covers patterns where the tag function is unavailable or unnecessary — the comment signals intent and triggers the same extraction pipeline as a recognized tag.
 
 ## Common issues
 

--- a/docs/src/content/docs/ide-features/find-references.mdx
+++ b/docs/src/content/docs/ide-features/find-references.mdx
@@ -7,12 +7,12 @@ Right-click → "Find All References" (or `Shift+F12`) to see everywhere a Graph
 
 ## Supported targets
 
-| Definition          | Finds                                                                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Fragment definition | All fragment spreads across the project                                                                                               |
-| Type definition     | Usages in field types, union members, implements, input fields, arguments (schema files only; inline fragment usages are not returned) |
-| Field definition    | All selections of that field across documents                                                                                         |
-| Directive definition | All usages across schema and document files                                                                                          |
+| Definition           | Finds                                                                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Fragment definition  | All fragment spreads across the project                                                                                                |
+| Type definition      | Usages in field types, union members, implements, input fields, arguments (schema files only; inline fragment usages are not returned) |
+| Field definition     | All selections of that field across documents                                                                                          |
+| Directive definition | All usages across schema and document files                                                                                            |
 
 ## Examples
 

--- a/docs/src/content/docs/ide-features/find-references.mdx
+++ b/docs/src/content/docs/ide-features/find-references.mdx
@@ -7,10 +7,12 @@ Right-click → "Find All References" (or `Shift+F12`) to see everywhere a Graph
 
 ## Supported targets
 
-| Definition          | Finds                                                                     |
-| ------------------- | ------------------------------------------------------------------------- |
-| Fragment definition | All fragment spreads across the project                                   |
-| Type definition     | Usages in field types, union members, implements, input fields, arguments |
+| Definition          | Finds                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Fragment definition | All fragment spreads across the project                                                                                               |
+| Type definition     | Usages in field types, union members, implements, input fields, arguments (schema files only; inline fragment usages are not returned) |
+| Field definition    | All selections of that field across documents                                                                                         |
+| Directive definition | All usages across schema and document files                                                                                          |
 
 ## Examples
 

--- a/docs/src/content/docs/ide-features/goto-definition.mdx
+++ b/docs/src/content/docs/ide-features/goto-definition.mdx
@@ -13,9 +13,10 @@ Press `F12` (or `Ctrl/Cmd+Click`) on any GraphQL element to jump to its definiti
 | Type reference (`on User`)  | Type definition in schema        |
 | Field (`name`)              | Field definition in schema       |
 | Variable (`$id`)            | Variable definition in operation |
-| Argument (`id:`)            | Argument definition in schema    |
-| Enum value (`ACTIVE`)       | Enum value definition in schema  |
-| Directive (`@deprecated`)   | Directive definition in schema   |
+| Argument (`id:`)                          | Argument definition in schema    |
+| Operation name                            | Operation definition             |
+| Directive argument (`@cache(maxAge: ...)`) | Argument definition in schema    |
+| Directive (`@deprecated`)                 | Directive definition in schema   |
 
 ## Examples
 

--- a/docs/src/content/docs/ide-features/goto-definition.mdx
+++ b/docs/src/content/docs/ide-features/goto-definition.mdx
@@ -7,16 +7,16 @@ Press `F12` (or `Ctrl/Cmd+Click`) on any GraphQL element to jump to its definiti
 
 ## Supported targets
 
-| Source                      | Navigates to                     |
-| --------------------------- | -------------------------------- |
-| Fragment spread (`...Frag`) | Fragment definition              |
-| Type reference (`on User`)  | Type definition in schema        |
-| Field (`name`)              | Field definition in schema       |
-| Variable (`$id`)            | Variable definition in operation |
-| Argument (`id:`)                          | Argument definition in schema    |
-| Operation name                            | Operation definition             |
+| Source                                     | Navigates to                     |
+| ------------------------------------------ | -------------------------------- |
+| Fragment spread (`...Frag`)                | Fragment definition              |
+| Type reference (`on User`)                 | Type definition in schema        |
+| Field (`name`)                             | Field definition in schema       |
+| Variable (`$id`)                           | Variable definition in operation |
+| Argument (`id:`)                           | Argument definition in schema    |
+| Operation name                             | Operation definition             |
 | Directive argument (`@cache(maxAge: ...)`) | Argument definition in schema    |
-| Directive (`@deprecated`)                 | Directive definition in schema   |
+| Directive (`@deprecated`)                  | Directive definition in schema   |
 
 ## Examples
 

--- a/docs/src/content/docs/ide-features/hover.mdx
+++ b/docs/src/content/docs/ide-features/hover.mdx
@@ -10,7 +10,9 @@ Hover over any GraphQL element to see type information, descriptions, and deprec
 - **Type information** for fields and variables
 - **Schema descriptions** from doc strings
 - **Deprecation warnings** with reasons
-- **Argument types** and default values
+- **Directives** — locations, repeatable flag, arguments, and description
+- **Fragment spreads** — type condition and description
+- **Type names** — kind (object, interface, enum, etc.) and description
 
 ## Example
 
@@ -27,7 +29,7 @@ For deprecated fields, the hover shows the deprecation reason:
 ```graphql
 query {
   user {
-    name # Hover → ⚠️ Deprecated: Use fullName instead
+    name # Hover → **Deprecated:** Use fullName instead
   }
 }
 ```

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -30,8 +30,8 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 </Card>
 
 <Card title="Configurable Linting" icon="approve-check-circle">
-  10 rules in the `recommended` preset and 38 rules total. Configure severity per-rule, enable expensive
-  rules in CI only.
+  10 rules in the `recommended` preset and 38 rules total. Configure severity per-rule, enable
+  expensive rules in CI only.
 </Card>
 
 <Card title="Embedded GraphQL" icon="seti:typescript">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 </Card>
 
 <Card title="Configurable Linting" icon="approve-check-circle">
-  9 built-in lint rules with the `recommended` preset. Configure severity per-rule, enable expensive
+  10 rules in the `recommended` preset and 38 rules total. Configure severity per-rule, enable expensive
   rules in CI only.
 </Card>
 

--- a/docs/src/content/docs/linting/eslint-plugin.mdx
+++ b/docs/src/content/docs/linting/eslint-plugin.mdx
@@ -140,6 +140,9 @@ Available presets:
 
 - `flat/schema-recommended` — sensible defaults for schema files
 - `flat/operations-recommended` — sensible defaults for operation documents
+- `flat/schema-all` — all schema rules enabled
+- `flat/schema-relay` — Relay-specific schema rules
+- `flat/operations-all` — all operation rules enabled
 
 ## Migrating from `@graphql-eslint/eslint-plugin`
 

--- a/docs/src/content/docs/linting/overview.mdx
+++ b/docs/src/content/docs/linting/overview.mdx
@@ -36,34 +36,34 @@ The `recommended` preset enables rules that are objectively beneficial without b
 
 These rules are available but not in the `recommended` preset — enable them based on your project's needs:
 
-| Rule                                      | Description                                  |
-| ----------------------------------------- | -------------------------------------------- |
-| `alphabetize`                             | Enforce alphabetical ordering                |
-| `descriptionStyle`                        | Enforce block vs inline description style    |
-| `inputName`                               | Require configurable suffix on input types   |
-| `loneExecutableDefinition`                | Require one operation or fragment per file   |
-| `namingConvention`                        | Enforce naming conventions                   |
-| `noOnePlaceFragments`                     | Detect fragments used in only one place      |
-| `noScalarResultTypeOnMutation`            | Require mutations to return object types     |
-| `noTypenamePrefix`                        | Disallow field names prefixed with type name |
-| `operationNameSuffix`                     | Enforce operation name conventions           |
-| `requireDescription`                      | Require descriptions on type definitions     |
-| `requireFieldOfTypeQueryInMutationResult` | Require Query field in mutation results      |
-| `requireIdField`                          | Require `id` field for cache normalization   |
-| `selectionSetDepth`                       | Limit selection set nesting depth            |
-| `strictIdInTypes`                         | Require ID field in object types             |
-| `uniqueNames`                             | Ensure operation/fragment names are unique   |
-| `noUnusedVariables`                       | Detect unused query variables                |
-| `matchDocumentFilename`                   | Document — Enforces that operation and fragment names match the filename |
-| `noRootType`                              | Schema — Disallows certain root type definitions in the schema |
-| `relayArguments`                          | Schema — Enforce Relay-compliant pagination arguments on connection fields |
-| `relayConnectionTypes`                    | Schema — Enforces Relay connection type conventions on types ending in 'Connection' |
-| `relayEdgeTypes`                          | Schema — Enforces Relay-compliant edge type definitions |
-| `relayPageInfo`                           | Schema — Enforces that the PageInfo type follows the Relay specification |
-| `requireDeprecationDate`                  | Schema — Requires @deprecated directives to include a deletion date |
-| `requireImportFragment`                   | Document — Requires fragment spreads to have a corresponding import comment |
-| `requireNullableFieldsWithOneof`          | Schema — Requires all fields in @oneOf input types to be nullable |
-| `requireNullableResultInRoot`             | Schema — Requires root type fields to return nullable types for error resilience |
+| Rule                                      | Description                                                                             |
+| ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `alphabetize`                             | Enforce alphabetical ordering                                                           |
+| `descriptionStyle`                        | Enforce block vs inline description style                                               |
+| `inputName`                               | Require configurable suffix on input types                                              |
+| `loneExecutableDefinition`                | Require one operation or fragment per file                                              |
+| `namingConvention`                        | Enforce naming conventions                                                              |
+| `noOnePlaceFragments`                     | Detect fragments used in only one place                                                 |
+| `noScalarResultTypeOnMutation`            | Require mutations to return object types                                                |
+| `noTypenamePrefix`                        | Disallow field names prefixed with type name                                            |
+| `operationNameSuffix`                     | Enforce operation name conventions                                                      |
+| `requireDescription`                      | Require descriptions on type definitions                                                |
+| `requireFieldOfTypeQueryInMutationResult` | Require Query field in mutation results                                                 |
+| `requireIdField`                          | Require `id` field for cache normalization                                              |
+| `selectionSetDepth`                       | Limit selection set nesting depth                                                       |
+| `strictIdInTypes`                         | Require ID field in object types                                                        |
+| `uniqueNames`                             | Ensure operation/fragment names are unique                                              |
+| `noUnusedVariables`                       | Detect unused query variables                                                           |
+| `matchDocumentFilename`                   | Document — Enforces that operation and fragment names match the filename                |
+| `noRootType`                              | Schema — Disallows certain root type definitions in the schema                          |
+| `relayArguments`                          | Schema — Enforce Relay-compliant pagination arguments on connection fields              |
+| `relayConnectionTypes`                    | Schema — Enforces Relay connection type conventions on types ending in 'Connection'     |
+| `relayEdgeTypes`                          | Schema — Enforces Relay-compliant edge type definitions                                 |
+| `relayPageInfo`                           | Schema — Enforces that the PageInfo type follows the Relay specification                |
+| `requireDeprecationDate`                  | Schema — Requires @deprecated directives to include a deletion date                     |
+| `requireImportFragment`                   | Document — Requires fragment spreads to have a corresponding import comment             |
+| `requireNullableFieldsWithOneof`          | Schema — Requires all fields in @oneOf input types to be nullable                       |
+| `requireNullableResultInRoot`             | Schema — Requires root type fields to return nullable types for error resilience        |
 | `requireTypePatternWithOneof`             | Schema — Enforces that types with @oneOf directive contain both 'ok' and 'error' fields |
 
 See the [Rules Catalog](/graphql-analyzer/rules/catalog/) for details on each rule.

--- a/docs/src/content/docs/linting/overview.mdx
+++ b/docs/src/content/docs/linting/overview.mdx
@@ -54,6 +54,17 @@ These rules are available but not in the `recommended` preset — enable them ba
 | `strictIdInTypes`                         | Require ID field in object types             |
 | `uniqueNames`                             | Ensure operation/fragment names are unique   |
 | `noUnusedVariables`                       | Detect unused query variables                |
+| `matchDocumentFilename`                   | Document — Enforces that operation and fragment names match the filename |
+| `noRootType`                              | Schema — Disallows certain root type definitions in the schema |
+| `relayArguments`                          | Schema — Enforce Relay-compliant pagination arguments on connection fields |
+| `relayConnectionTypes`                    | Schema — Enforces Relay connection type conventions on types ending in 'Connection' |
+| `relayEdgeTypes`                          | Schema — Enforces Relay-compliant edge type definitions |
+| `relayPageInfo`                           | Schema — Enforces that the PageInfo type follows the Relay specification |
+| `requireDeprecationDate`                  | Schema — Requires @deprecated directives to include a deletion date |
+| `requireImportFragment`                   | Document — Requires fragment spreads to have a corresponding import comment |
+| `requireNullableFieldsWithOneof`          | Schema — Requires all fields in @oneOf input types to be nullable |
+| `requireNullableResultInRoot`             | Schema — Requires root type fields to return nullable types for error resilience |
+| `requireTypePatternWithOneof`             | Schema — Enforces that types with @oneOf directive contain both 'ok' and 'error' fields |
 
 See the [Rules Catalog](/graphql-analyzer/rules/catalog/) for details on each rule.
 

--- a/docs/src/content/docs/rules/alphabetize.mdx
+++ b/docs/src/content/docs/rules/alphabetize.mdx
@@ -3,8 +3,8 @@ title: alphabetize
 description: Enforce alphabetical ordering of selections, arguments, and variables.
 ---
 
-| Property         | Value         |
-| ---------------- | ------------- |
+| Property         | Value             |
+| ---------------- | ----------------- |
 | Config name      | `alphabetize`     |
 | Default severity | `—`               |
 | Context          | Document + Schema |
@@ -40,15 +40,15 @@ query GetUser {
 
 ## Options
 
-| Option        | Type                   | Default | Description                                                                                                         |
-| ------------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| `selections`  | `bool \| string[]`     | `true`  | Enforce alphabetical order in selection sets. Pass `true` or a list of owner kinds (`OperationDefinition`, `FragmentDefinition`). |
-| `arguments`   | `bool \| string[]`     | `false` | Enforce alphabetical order on arguments. Pass `true` or a list of AST kinds (`FieldDefinition`, `Field`, …).        |
-| `variables`   | `bool`                 | `false` | Enforce alphabetical order on variable definitions.                                                                 |
-| `definitions` | `bool`                 | `false` | Enforce alphabetical order on top-level type definitions across the document (schema-side).                         |
-| `fields`      | `bool \| string[]`     | `false` | Enforce alphabetical order on field declarations. `true` covers all type kinds; pass an array to scope to specific kinds (e.g. `ObjectTypeDefinition`). |
-| `values`      | `bool`                 | `false` | Enforce alphabetical order on enum value declarations.                                                              |
-| `groups`      | `string[]`             | `[]`    | Explicit ordering groups (e.g. `["id", "*", "createdAt"]`). Names in earlier groups sort first; `"*"` is the catch-all bucket. |
+| Option        | Type               | Default | Description                                                                                                                                             |
+| ------------- | ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `selections`  | `bool \| string[]` | `true`  | Enforce alphabetical order in selection sets. Pass `true` or a list of owner kinds (`OperationDefinition`, `FragmentDefinition`).                       |
+| `arguments`   | `bool \| string[]` | `false` | Enforce alphabetical order on arguments. Pass `true` or a list of AST kinds (`FieldDefinition`, `Field`, …).                                            |
+| `variables`   | `bool`             | `false` | Enforce alphabetical order on variable definitions.                                                                                                     |
+| `definitions` | `bool`             | `false` | Enforce alphabetical order on top-level type definitions across the document (schema-side).                                                             |
+| `fields`      | `bool \| string[]` | `false` | Enforce alphabetical order on field declarations. `true` covers all type kinds; pass an array to scope to specific kinds (e.g. `ObjectTypeDefinition`). |
+| `values`      | `bool`             | `false` | Enforce alphabetical order on enum value declarations.                                                                                                  |
+| `groups`      | `string[]`         | `[]`    | Explicit ordering groups (e.g. `["id", "*", "createdAt"]`). Names in earlier groups sort first; `"*"` is the catch-all bucket.                          |
 
 ## Configuration
 

--- a/docs/src/content/docs/rules/alphabetize.mdx
+++ b/docs/src/content/docs/rules/alphabetize.mdx
@@ -5,10 +5,10 @@ description: Enforce alphabetical ordering of selections, arguments, and variabl
 
 | Property         | Value         |
 | ---------------- | ------------- |
-| Config name      | `alphabetize` |
-| Default severity | `—`           |
-| Context          | Document      |
-| In recommended   | No            |
+| Config name      | `alphabetize`     |
+| Default severity | `—`               |
+| Context          | Document + Schema |
+| In recommended   | No                |
 
 ## What it checks
 
@@ -38,6 +38,18 @@ query GetUser {
 }
 ```
 
+## Options
+
+| Option        | Type                   | Default | Description                                                                                                         |
+| ------------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `selections`  | `bool \| string[]`     | `true`  | Enforce alphabetical order in selection sets. Pass `true` or a list of owner kinds (`OperationDefinition`, `FragmentDefinition`). |
+| `arguments`   | `bool \| string[]`     | `false` | Enforce alphabetical order on arguments. Pass `true` or a list of AST kinds (`FieldDefinition`, `Field`, …).        |
+| `variables`   | `bool`                 | `false` | Enforce alphabetical order on variable definitions.                                                                 |
+| `definitions` | `bool`                 | `false` | Enforce alphabetical order on top-level type definitions across the document (schema-side).                         |
+| `fields`      | `bool \| string[]`     | `false` | Enforce alphabetical order on field declarations. `true` covers all type kinds; pass an array to scope to specific kinds (e.g. `ObjectTypeDefinition`). |
+| `values`      | `bool`                 | `false` | Enforce alphabetical order on enum value declarations.                                                              |
+| `groups`      | `string[]`             | `[]`    | Explicit ordering groups (e.g. `["id", "*", "createdAt"]`). Names in earlier groups sort first; `"*"` is the catch-all bucket. |
+
 ## Configuration
 
 ```yaml
@@ -46,4 +58,12 @@ extensions:
     lint:
       rules:
         alphabetize: [warn, { selections: true, arguments: true, variables: true }]
+
+# Schema-side example
+        alphabetize:
+          - warn
+          - definitions: true
+            fields: true
+            values: true
+            groups: ["id", "*", "createdAt", "updatedAt"]
 ```

--- a/docs/src/content/docs/rules/catalog.mdx
+++ b/docs/src/content/docs/rules/catalog.mdx
@@ -17,34 +17,34 @@ description: All available lint rules.
 | [uniqueEnumValueNames](/graphql-analyzer/rules/uniqueEnumValueNames/)                                       | warn             | Schema          | Yes               |
 | [noUnusedFragments](/graphql-analyzer/rules/noUnusedFragments/)                                             | warn             | Project         | Yes               |
 | [noUnusedFields](/graphql-analyzer/rules/noUnusedFields/)                                                   | warn             | Project         | Yes               |
-| [alphabetize](/graphql-analyzer/rules/alphabetize/)                                                         | —                | Document        | No                |
-| [descriptionStyle](/graphql-analyzer/rules/descriptionStyle/)                                               | —                | Schema          | No                |
-| [inputName](/graphql-analyzer/rules/inputName/)                                                             | —                | Schema          | No                |
-| [loneExecutableDefinition](/graphql-analyzer/rules/loneExecutableDefinition/)                               | —                | Document        | No                |
-| [matchDocumentFilename](/graphql-analyzer/rules/matchDocumentFilename/)                                     | —                | Document        | No                |
-| [namingConvention](/graphql-analyzer/rules/namingConvention/)                                               | —                | Document        | No                |
-| [noOnePlaceFragments](/graphql-analyzer/rules/noOnePlaceFragments/)                                         | —                | Project         | No                |
-| [noRootType](/graphql-analyzer/rules/noRootType/)                                                           | —                | Schema          | No                |
-| [noScalarResultTypeOnMutation](/graphql-analyzer/rules/noScalarResultTypeOnMutation/)                       | —                | Schema          | No                |
-| [noTypenamePrefix](/graphql-analyzer/rules/noTypenamePrefix/)                                               | —                | Schema          | No                |
-| [operationNameSuffix](/graphql-analyzer/rules/operationNameSuffix/)                                         | —                | Document        | No                |
-| [relayConnectionTypes](/graphql-analyzer/rules/relayConnectionTypes/)                                       | —                | Schema          | No                |
-| [relayEdgeTypes](/graphql-analyzer/rules/relayEdgeTypes/)                                                   | —                | Schema          | No                |
-| [relayArguments](/graphql-analyzer/rules/relayArguments/)                                                   | —                | Schema          | No                |
-| [requireDeprecationDate](/graphql-analyzer/rules/requireDeprecationDate/)                                   | —                | Schema          | No                |
-| [relayPageInfo](/graphql-analyzer/rules/relayPageInfo/)                                                     | —                | Schema          | No                |
-| [requireDescription](/graphql-analyzer/rules/requireDescription/)                                           | —                | Schema          | No                |
-| [requireFieldOfTypeQueryInMutationResult](/graphql-analyzer/rules/requireFieldOfTypeQueryInMutationResult/) | —                | Schema          | No                |
-| [requireIdField](/graphql-analyzer/rules/requireIdField/)                                                   | —                | Document-Schema | No                |
-| [requireNullableFieldsWithOneof](/graphql-analyzer/rules/requireNullableFieldsWithOneof/)                   | —                | Schema          | No                |
-| [requireNullableResultInRoot](/graphql-analyzer/rules/requireNullableResultInRoot/)                         | —                | Schema          | No                |
-| [requireTypePatternWithOneof](/graphql-analyzer/rules/requireTypePatternWithOneof/)                         | —                | Schema          | No                |
-| [requireImportFragment](/graphql-analyzer/rules/requireImportFragment/)                                     | —                | Document        | No                |
+| [alphabetize](/graphql-analyzer/rules/alphabetize/)                                                         | warn             | Document + Schema | No                |
+| [descriptionStyle](/graphql-analyzer/rules/descriptionStyle/)                                               | warn             | Schema          | No                |
+| [inputName](/graphql-analyzer/rules/inputName/)                                                             | warn             | Schema          | No                |
+| [loneExecutableDefinition](/graphql-analyzer/rules/loneExecutableDefinition/)                               | warn             | Document        | No                |
+| [matchDocumentFilename](/graphql-analyzer/rules/matchDocumentFilename/)                                     | warn             | Document        | No                |
+| [namingConvention](/graphql-analyzer/rules/namingConvention/)                                               | warn             | Document + Schema | No                |
+| [noOnePlaceFragments](/graphql-analyzer/rules/noOnePlaceFragments/)                                         | warn             | Project         | No                |
+| [noRootType](/graphql-analyzer/rules/noRootType/)                                                           | error            | Schema          | No                |
+| [noScalarResultTypeOnMutation](/graphql-analyzer/rules/noScalarResultTypeOnMutation/)                       | warn             | Schema          | No                |
+| [noTypenamePrefix](/graphql-analyzer/rules/noTypenamePrefix/)                                               | warn             | Schema          | No                |
+| [operationNameSuffix](/graphql-analyzer/rules/operationNameSuffix/)                                         | warn             | Document        | No                |
+| [relayConnectionTypes](/graphql-analyzer/rules/relayConnectionTypes/)                                       | warn             | Schema          | No                |
+| [relayEdgeTypes](/graphql-analyzer/rules/relayEdgeTypes/)                                                   | warn             | Schema          | No                |
+| [relayArguments](/graphql-analyzer/rules/relayArguments/)                                                   | warn             | Schema          | No                |
+| [requireDeprecationDate](/graphql-analyzer/rules/requireDeprecationDate/)                                   | warn             | Schema          | No                |
+| [relayPageInfo](/graphql-analyzer/rules/relayPageInfo/)                                                     | warn             | Schema          | No                |
+| [requireDescription](/graphql-analyzer/rules/requireDescription/)                                           | warn             | Document + Schema | No                |
+| [requireFieldOfTypeQueryInMutationResult](/graphql-analyzer/rules/requireFieldOfTypeQueryInMutationResult/) | warn             | Schema          | No                |
+| [requireIdField](/graphql-analyzer/rules/requireIdField/)                                                   | warn             | Document-Schema | No                |
+| [requireNullableFieldsWithOneof](/graphql-analyzer/rules/requireNullableFieldsWithOneof/)                   | error            | Schema          | No                |
+| [requireNullableResultInRoot](/graphql-analyzer/rules/requireNullableResultInRoot/)                         | warn             | Schema          | No                |
+| [requireTypePatternWithOneof](/graphql-analyzer/rules/requireTypePatternWithOneof/)                         | warn             | Schema          | No                |
+| [requireImportFragment](/graphql-analyzer/rules/requireImportFragment/)                                     | warn             | Document        | No                |
 | [requireSelections](/graphql-analyzer/rules/requireSelections/)                                             | error            | Document-Schema | No                |
-| [selectionSetDepth](/graphql-analyzer/rules/selectionSetDepth/)                                             | —                | Document        | No                |
-| [strictIdInTypes](/graphql-analyzer/rules/strictIdInTypes/)                                                 | —                | Schema          | No                |
+| [selectionSetDepth](/graphql-analyzer/rules/selectionSetDepth/)                                             | warn             | Document        | No                |
+| [strictIdInTypes](/graphql-analyzer/rules/strictIdInTypes/)                                                 | warn             | Schema          | No                |
 | [uniqueNames](/graphql-analyzer/rules/uniqueNames/)                                                         | error            | Project         | No                |
-| [noUnusedVariables](/graphql-analyzer/rules/noUnusedVariables/)                                             | —                | Document        | No                |
+| [noUnusedVariables](/graphql-analyzer/rules/noUnusedVariables/)                                             | warn             | Document        | No                |
 
 ## Contexts
 

--- a/docs/src/content/docs/rules/catalog.mdx
+++ b/docs/src/content/docs/rules/catalog.mdx
@@ -5,46 +5,46 @@ description: All available lint rules.
 
 ## All rules
 
-| Rule                                                                                                        | Default Severity | Context         | In `recommended`? |
-| ----------------------------------------------------------------------------------------------------------- | ---------------- | --------------- | ----------------- |
-| [noAnonymousOperations](/graphql-analyzer/rules/noAnonymousOperations/)                                     | error            | Document        | Yes               |
-| [noDeprecated](/graphql-analyzer/rules/noDeprecated/)                                                       | warn             | Document-Schema | Yes               |
-| [noDuplicateFields](/graphql-analyzer/rules/noDuplicateFields/)                                             | warn             | Document        | Yes               |
-| [noHashtagDescription](/graphql-analyzer/rules/noHashtagDescription/)                                       | warn             | Schema          | Yes               |
-| [noUnreachableTypes](/graphql-analyzer/rules/noUnreachableTypes/)                                           | warn             | Schema          | Yes               |
-| [redundantFields](/graphql-analyzer/rules/redundantFields/)                                                 | warn             | Document        | Yes               |
-| [requireDeprecationReason](/graphql-analyzer/rules/requireDeprecationReason/)                               | warn             | Schema          | Yes               |
-| [uniqueEnumValueNames](/graphql-analyzer/rules/uniqueEnumValueNames/)                                       | warn             | Schema          | Yes               |
-| [noUnusedFragments](/graphql-analyzer/rules/noUnusedFragments/)                                             | warn             | Project         | Yes               |
-| [noUnusedFields](/graphql-analyzer/rules/noUnusedFields/)                                                   | warn             | Project         | Yes               |
+| Rule                                                                                                        | Default Severity | Context           | In `recommended`? |
+| ----------------------------------------------------------------------------------------------------------- | ---------------- | ----------------- | ----------------- |
+| [noAnonymousOperations](/graphql-analyzer/rules/noAnonymousOperations/)                                     | error            | Document          | Yes               |
+| [noDeprecated](/graphql-analyzer/rules/noDeprecated/)                                                       | warn             | Document-Schema   | Yes               |
+| [noDuplicateFields](/graphql-analyzer/rules/noDuplicateFields/)                                             | warn             | Document          | Yes               |
+| [noHashtagDescription](/graphql-analyzer/rules/noHashtagDescription/)                                       | warn             | Schema            | Yes               |
+| [noUnreachableTypes](/graphql-analyzer/rules/noUnreachableTypes/)                                           | warn             | Schema            | Yes               |
+| [redundantFields](/graphql-analyzer/rules/redundantFields/)                                                 | warn             | Document          | Yes               |
+| [requireDeprecationReason](/graphql-analyzer/rules/requireDeprecationReason/)                               | warn             | Schema            | Yes               |
+| [uniqueEnumValueNames](/graphql-analyzer/rules/uniqueEnumValueNames/)                                       | warn             | Schema            | Yes               |
+| [noUnusedFragments](/graphql-analyzer/rules/noUnusedFragments/)                                             | warn             | Project           | Yes               |
+| [noUnusedFields](/graphql-analyzer/rules/noUnusedFields/)                                                   | warn             | Project           | Yes               |
 | [alphabetize](/graphql-analyzer/rules/alphabetize/)                                                         | warn             | Document + Schema | No                |
-| [descriptionStyle](/graphql-analyzer/rules/descriptionStyle/)                                               | warn             | Schema          | No                |
-| [inputName](/graphql-analyzer/rules/inputName/)                                                             | warn             | Schema          | No                |
-| [loneExecutableDefinition](/graphql-analyzer/rules/loneExecutableDefinition/)                               | warn             | Document        | No                |
-| [matchDocumentFilename](/graphql-analyzer/rules/matchDocumentFilename/)                                     | warn             | Document        | No                |
+| [descriptionStyle](/graphql-analyzer/rules/descriptionStyle/)                                               | warn             | Schema            | No                |
+| [inputName](/graphql-analyzer/rules/inputName/)                                                             | warn             | Schema            | No                |
+| [loneExecutableDefinition](/graphql-analyzer/rules/loneExecutableDefinition/)                               | warn             | Document          | No                |
+| [matchDocumentFilename](/graphql-analyzer/rules/matchDocumentFilename/)                                     | warn             | Document          | No                |
 | [namingConvention](/graphql-analyzer/rules/namingConvention/)                                               | warn             | Document + Schema | No                |
-| [noOnePlaceFragments](/graphql-analyzer/rules/noOnePlaceFragments/)                                         | warn             | Project         | No                |
-| [noRootType](/graphql-analyzer/rules/noRootType/)                                                           | error            | Schema          | No                |
-| [noScalarResultTypeOnMutation](/graphql-analyzer/rules/noScalarResultTypeOnMutation/)                       | warn             | Schema          | No                |
-| [noTypenamePrefix](/graphql-analyzer/rules/noTypenamePrefix/)                                               | warn             | Schema          | No                |
-| [operationNameSuffix](/graphql-analyzer/rules/operationNameSuffix/)                                         | warn             | Document        | No                |
-| [relayConnectionTypes](/graphql-analyzer/rules/relayConnectionTypes/)                                       | warn             | Schema          | No                |
-| [relayEdgeTypes](/graphql-analyzer/rules/relayEdgeTypes/)                                                   | warn             | Schema          | No                |
-| [relayArguments](/graphql-analyzer/rules/relayArguments/)                                                   | warn             | Schema          | No                |
-| [requireDeprecationDate](/graphql-analyzer/rules/requireDeprecationDate/)                                   | warn             | Schema          | No                |
-| [relayPageInfo](/graphql-analyzer/rules/relayPageInfo/)                                                     | warn             | Schema          | No                |
+| [noOnePlaceFragments](/graphql-analyzer/rules/noOnePlaceFragments/)                                         | warn             | Project           | No                |
+| [noRootType](/graphql-analyzer/rules/noRootType/)                                                           | error            | Schema            | No                |
+| [noScalarResultTypeOnMutation](/graphql-analyzer/rules/noScalarResultTypeOnMutation/)                       | warn             | Schema            | No                |
+| [noTypenamePrefix](/graphql-analyzer/rules/noTypenamePrefix/)                                               | warn             | Schema            | No                |
+| [operationNameSuffix](/graphql-analyzer/rules/operationNameSuffix/)                                         | warn             | Document          | No                |
+| [relayConnectionTypes](/graphql-analyzer/rules/relayConnectionTypes/)                                       | warn             | Schema            | No                |
+| [relayEdgeTypes](/graphql-analyzer/rules/relayEdgeTypes/)                                                   | warn             | Schema            | No                |
+| [relayArguments](/graphql-analyzer/rules/relayArguments/)                                                   | warn             | Schema            | No                |
+| [requireDeprecationDate](/graphql-analyzer/rules/requireDeprecationDate/)                                   | warn             | Schema            | No                |
+| [relayPageInfo](/graphql-analyzer/rules/relayPageInfo/)                                                     | warn             | Schema            | No                |
 | [requireDescription](/graphql-analyzer/rules/requireDescription/)                                           | warn             | Document + Schema | No                |
-| [requireFieldOfTypeQueryInMutationResult](/graphql-analyzer/rules/requireFieldOfTypeQueryInMutationResult/) | warn             | Schema          | No                |
-| [requireIdField](/graphql-analyzer/rules/requireIdField/)                                                   | warn             | Document-Schema | No                |
-| [requireNullableFieldsWithOneof](/graphql-analyzer/rules/requireNullableFieldsWithOneof/)                   | error            | Schema          | No                |
-| [requireNullableResultInRoot](/graphql-analyzer/rules/requireNullableResultInRoot/)                         | warn             | Schema          | No                |
-| [requireTypePatternWithOneof](/graphql-analyzer/rules/requireTypePatternWithOneof/)                         | warn             | Schema          | No                |
-| [requireImportFragment](/graphql-analyzer/rules/requireImportFragment/)                                     | warn             | Document        | No                |
-| [requireSelections](/graphql-analyzer/rules/requireSelections/)                                             | error            | Document-Schema | No                |
-| [selectionSetDepth](/graphql-analyzer/rules/selectionSetDepth/)                                             | warn             | Document        | No                |
-| [strictIdInTypes](/graphql-analyzer/rules/strictIdInTypes/)                                                 | warn             | Schema          | No                |
-| [uniqueNames](/graphql-analyzer/rules/uniqueNames/)                                                         | error            | Project         | No                |
-| [noUnusedVariables](/graphql-analyzer/rules/noUnusedVariables/)                                             | warn             | Document        | No                |
+| [requireFieldOfTypeQueryInMutationResult](/graphql-analyzer/rules/requireFieldOfTypeQueryInMutationResult/) | warn             | Schema            | No                |
+| [requireIdField](/graphql-analyzer/rules/requireIdField/)                                                   | warn             | Document-Schema   | No                |
+| [requireNullableFieldsWithOneof](/graphql-analyzer/rules/requireNullableFieldsWithOneof/)                   | error            | Schema            | No                |
+| [requireNullableResultInRoot](/graphql-analyzer/rules/requireNullableResultInRoot/)                         | warn             | Schema            | No                |
+| [requireTypePatternWithOneof](/graphql-analyzer/rules/requireTypePatternWithOneof/)                         | warn             | Schema            | No                |
+| [requireImportFragment](/graphql-analyzer/rules/requireImportFragment/)                                     | warn             | Document          | No                |
+| [requireSelections](/graphql-analyzer/rules/requireSelections/)                                             | error            | Document-Schema   | No                |
+| [selectionSetDepth](/graphql-analyzer/rules/selectionSetDepth/)                                             | warn             | Document          | No                |
+| [strictIdInTypes](/graphql-analyzer/rules/strictIdInTypes/)                                                 | warn             | Schema            | No                |
+| [uniqueNames](/graphql-analyzer/rules/uniqueNames/)                                                         | error            | Project           | No                |
+| [noUnusedVariables](/graphql-analyzer/rules/noUnusedVariables/)                                             | warn             | Document          | No                |
 
 ## Contexts
 

--- a/docs/src/content/docs/rules/namingConvention.mdx
+++ b/docs/src/content/docs/rules/namingConvention.mdx
@@ -6,10 +6,10 @@ description: Enforce naming conventions for operations, fragments, and variables
 
 | Property         | Value              |
 | ---------------- | ------------------ |
-| Config name      | `namingConvention`  |
-| Default severity | `—`                 |
-| Context          | Document + Schema   |
-| In recommended   | No                  |
+| Config name      | `namingConvention` |
+| Default severity | `—`                |
+| Context          | Document + Schema  |
+| In recommended   | No                 |
 
 ## What it checks
 
@@ -43,27 +43,27 @@ Each option key is a GraphQL AST kind name (or a comma-separated list of kinds).
 
 **Document-side keys:**
 
-| Key                   | What it covers                  |
-| --------------------- | ------------------------------- |
+| Key                   | What it covers                      |
+| --------------------- | ----------------------------------- |
 | `OperationDefinition` | Query, mutation, subscription names |
-| `FragmentDefinition`  | Fragment names                  |
-| `VariableDefinition`  | Variable names inside operations |
+| `FragmentDefinition`  | Fragment names                      |
+| `VariableDefinition`  | Variable names inside operations    |
 
 **Schema-side keys:**
 
-| Key                        | What it covers                       |
-| -------------------------- | ------------------------------------ |
-| `types`                    | Umbrella default for all type kinds  |
-| `ObjectTypeDefinition`     | Object type names                    |
-| `InterfaceTypeDefinition`  | Interface type names                 |
-| `EnumTypeDefinition`       | Enum type names                      |
-| `UnionTypeDefinition`      | Union type names                     |
-| `ScalarTypeDefinition`     | Scalar type names                    |
-| `InputObjectTypeDefinition`| Input object type names              |
-| `FieldDefinition`          | Field names on types                 |
-| `InputValueDefinition`     | Input field and argument names       |
-| `EnumValueDefinition`      | Enum value names                     |
-| `DirectiveDefinition`      | Directive names                      |
+| Key                         | What it covers                      |
+| --------------------------- | ----------------------------------- |
+| `types`                     | Umbrella default for all type kinds |
+| `ObjectTypeDefinition`      | Object type names                   |
+| `InterfaceTypeDefinition`   | Interface type names                |
+| `EnumTypeDefinition`        | Enum type names                     |
+| `UnionTypeDefinition`       | Union type names                    |
+| `ScalarTypeDefinition`      | Scalar type names                   |
+| `InputObjectTypeDefinition` | Input object type names             |
+| `FieldDefinition`           | Field names on types                |
+| `InputValueDefinition`      | Input field and argument names      |
+| `EnumValueDefinition`       | Enum value names                    |
+| `DirectiveDefinition`       | Directive names                     |
 
 **Detailed object form** (use instead of a bare string):
 

--- a/docs/src/content/docs/rules/namingConvention.mdx
+++ b/docs/src/content/docs/rules/namingConvention.mdx
@@ -6,10 +6,10 @@ description: Enforce naming conventions for operations, fragments, and variables
 
 | Property         | Value              |
 | ---------------- | ------------------ |
-| Config name      | `namingConvention` |
-| Default severity | `—`                |
-| Context          | Document           |
-| In recommended   | No                 |
+| Config name      | `namingConvention`  |
+| Default severity | `—`                 |
+| Context          | Document + Schema   |
+| In recommended   | No                  |
 
 ## What it checks
 
@@ -35,6 +35,49 @@ query GetUser {
 }
 ```
 
+## Options
+
+Each option key is a GraphQL AST kind name (or a comma-separated list of kinds). The value is either a case-style string or a detailed object.
+
+**Accepted case styles:** `camelCase`, `PascalCase`, `snake_case`, `UPPER_CASE`
+
+**Document-side keys:**
+
+| Key                   | What it covers                  |
+| --------------------- | ------------------------------- |
+| `OperationDefinition` | Query, mutation, subscription names |
+| `FragmentDefinition`  | Fragment names                  |
+| `VariableDefinition`  | Variable names inside operations |
+
+**Schema-side keys:**
+
+| Key                        | What it covers                       |
+| -------------------------- | ------------------------------------ |
+| `types`                    | Umbrella default for all type kinds  |
+| `ObjectTypeDefinition`     | Object type names                    |
+| `InterfaceTypeDefinition`  | Interface type names                 |
+| `EnumTypeDefinition`       | Enum type names                      |
+| `UnionTypeDefinition`      | Union type names                     |
+| `ScalarTypeDefinition`     | Scalar type names                    |
+| `InputObjectTypeDefinition`| Input object type names              |
+| `FieldDefinition`          | Field names on types                 |
+| `InputValueDefinition`     | Input field and argument names       |
+| `EnumValueDefinition`      | Enum value names                     |
+| `DirectiveDefinition`      | Directive names                      |
+
+**Detailed object form** (use instead of a bare string):
+
+```yaml
+OperationDefinition:
+  style: PascalCase
+  forbiddenPrefixes: ["get", "fetch"]
+  forbiddenSuffixes: ["Query", "Mutation"]
+  requiredPrefixes: []
+  requiredSuffixes: []
+  allowLeadingUnderscore: false
+  allowTrailingUnderscore: false
+```
+
 ## Configuration
 
 ```yaml
@@ -42,5 +85,12 @@ extensions:
   graphql-analyzer:
     lint:
       rules:
-        namingConvention: warn
+        namingConvention:
+          - warn
+          - OperationDefinition: PascalCase
+            FragmentDefinition: PascalCase
+            VariableDefinition: camelCase
+            types: PascalCase
+            FieldDefinition: camelCase
+            EnumValueDefinition: UPPER_CASE
 ```

--- a/docs/src/content/docs/rules/requireDescription.mdx
+++ b/docs/src/content/docs/rules/requireDescription.mdx
@@ -6,10 +6,10 @@ description: Require descriptions on type definitions.
 
 | Property         | Value                |
 | ---------------- | -------------------- |
-| Config name      | `requireDescription` |
-| Default severity | `—`                  |
-| Context          | Schema               |
-| In recommended   | No                   |
+| Config name      | `requireDescription`  |
+| Default severity | `—`                   |
+| Context          | Document + Schema     |
+| In recommended   | No                    |
 
 ## What it checks
 
@@ -32,6 +32,20 @@ type User {
 }
 ```
 
+## Options
+
+Each option is a boolean that opts a specific AST kind into the description requirement. All options default to `true` when no options object is provided.
+
+| Option                  | Type   | Default | Description                                                                                          |
+| ----------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `types`                 | `bool` | `true`  | Require descriptions on type definitions: `ObjectTypeDefinition`, `InterfaceTypeDefinition`, `EnumTypeDefinition`, `ScalarTypeDefinition`, `InputObjectTypeDefinition`, `UnionTypeDefinition`. |
+| `rootField`             | `bool` | `true`  | Require descriptions on fields defined directly on root types (`Query`, `Mutation`, `Subscription`). |
+| `FieldDefinition`       | `bool` | `true`  | Require descriptions on all field definitions.                                                       |
+| `InputValueDefinition`  | `bool` | `true`  | Require descriptions on input fields and arguments.                                                  |
+| `EnumValueDefinition`   | `bool` | `true`  | Require descriptions on enum values.                                                                 |
+| `DirectiveDefinition`   | `bool` | `true`  | Require descriptions on directive definitions.                                                       |
+| `OperationDefinition`   | `bool` | `true`  | Require descriptions (via `#` comment) on operation definitions.                                     |
+
 ## Configuration
 
 ```yaml
@@ -40,4 +54,12 @@ extensions:
     lint:
       rules:
         requireDescription: warn
+
+# Enable only specific kinds
+        requireDescription:
+          - warn
+          - types: true
+            FieldDefinition: true
+            EnumValueDefinition: false
+            OperationDefinition: false
 ```

--- a/docs/src/content/docs/rules/requireDescription.mdx
+++ b/docs/src/content/docs/rules/requireDescription.mdx
@@ -6,10 +6,10 @@ description: Require descriptions on type definitions.
 
 | Property         | Value                |
 | ---------------- | -------------------- |
-| Config name      | `requireDescription`  |
-| Default severity | `—`                   |
-| Context          | Document + Schema     |
-| In recommended   | No                    |
+| Config name      | `requireDescription` |
+| Default severity | `—`                  |
+| Context          | Document + Schema    |
+| In recommended   | No                   |
 
 ## What it checks
 
@@ -36,15 +36,15 @@ type User {
 
 Each option is a boolean that opts a specific AST kind into the description requirement. All options default to `true` when no options object is provided.
 
-| Option                  | Type   | Default | Description                                                                                          |
-| ----------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
-| `types`                 | `bool` | `true`  | Require descriptions on type definitions: `ObjectTypeDefinition`, `InterfaceTypeDefinition`, `EnumTypeDefinition`, `ScalarTypeDefinition`, `InputObjectTypeDefinition`, `UnionTypeDefinition`. |
-| `rootField`             | `bool` | `true`  | Require descriptions on fields defined directly on root types (`Query`, `Mutation`, `Subscription`). |
-| `FieldDefinition`       | `bool` | `true`  | Require descriptions on all field definitions.                                                       |
-| `InputValueDefinition`  | `bool` | `true`  | Require descriptions on input fields and arguments.                                                  |
-| `EnumValueDefinition`   | `bool` | `true`  | Require descriptions on enum values.                                                                 |
-| `DirectiveDefinition`   | `bool` | `true`  | Require descriptions on directive definitions.                                                       |
-| `OperationDefinition`   | `bool` | `true`  | Require descriptions (via `#` comment) on operation definitions.                                     |
+| Option                 | Type   | Default | Description                                                                                                                                                                                    |
+| ---------------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `types`                | `bool` | `true`  | Require descriptions on type definitions: `ObjectTypeDefinition`, `InterfaceTypeDefinition`, `EnumTypeDefinition`, `ScalarTypeDefinition`, `InputObjectTypeDefinition`, `UnionTypeDefinition`. |
+| `rootField`            | `bool` | `true`  | Require descriptions on fields defined directly on root types (`Query`, `Mutation`, `Subscription`).                                                                                           |
+| `FieldDefinition`      | `bool` | `true`  | Require descriptions on all field definitions.                                                                                                                                                 |
+| `InputValueDefinition` | `bool` | `true`  | Require descriptions on input fields and arguments.                                                                                                                                            |
+| `EnumValueDefinition`  | `bool` | `true`  | Require descriptions on enum values.                                                                                                                                                           |
+| `DirectiveDefinition`  | `bool` | `true`  | Require descriptions on directive definitions.                                                                                                                                                 |
+| `OperationDefinition`  | `bool` | `true`  | Require descriptions (via `#` comment) on operation definitions.                                                                                                                               |
 
 ## Configuration
 

--- a/docs/src/content/docs/rules/requireIdField.mdx
+++ b/docs/src/content/docs/rules/requireIdField.mdx
@@ -7,7 +7,7 @@ description: Require id fields for cache normalization.
 | Property         | Value            |
 | ---------------- | ---------------- |
 | Config name      | `requireIdField` |
-| Default severity | —                |
+| Default severity | `warn`           |
 | Context          | Document-Schema  |
 | In recommended   | No               |
 

--- a/docs/src/content/docs/rules/selectionSetDepth.mdx
+++ b/docs/src/content/docs/rules/selectionSetDepth.mdx
@@ -43,6 +43,13 @@ query Shallow {
 }
 ```
 
+## Options
+
+| Option     | Type       | Default | Description                                                                                                                     |
+| ---------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `maxDepth` | `number`   | —       | Maximum allowed nesting depth. Required when the rule is enabled.                                                               |
+| `ignore`   | `string[]` | `[]`    | Field names that are skipped when counting depth. Useful for Relay connection wrappers like `edges` and `node` that add structural nesting without adding semantic depth. |
+
 ## Configuration
 
 ```yaml
@@ -51,4 +58,10 @@ extensions:
     lint:
       rules:
         selectionSetDepth: [warn, { maxDepth: 3 }]
+
+# Ignore Relay connection fields so edges/node don't count toward depth
+        selectionSetDepth:
+          - warn
+          - maxDepth: 4
+            ignore: ["edges", "node"]
 ```

--- a/docs/src/content/docs/rules/selectionSetDepth.mdx
+++ b/docs/src/content/docs/rules/selectionSetDepth.mdx
@@ -45,9 +45,9 @@ query Shallow {
 
 ## Options
 
-| Option     | Type       | Default | Description                                                                                                                     |
-| ---------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `maxDepth` | `number`   | —       | Maximum allowed nesting depth. Required when the rule is enabled.                                                               |
+| Option     | Type       | Default | Description                                                                                                                                                               |
+| ---------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxDepth` | `number`   | —       | Maximum allowed nesting depth. Required when the rule is enabled.                                                                                                         |
 | `ignore`   | `string[]` | `[]`    | Field names that are skipped when counting depth. Useful for Relay connection wrappers like `edges` and `node` that add structural nesting without adding semantic depth. |
 
 ## Configuration

--- a/docs/src/content/docs/rules/strictIdInTypes.mdx
+++ b/docs/src/content/docs/rules/strictIdInTypes.mdx
@@ -36,13 +36,13 @@ type User {
 
 ## Options
 
-| Option                    | Type       | Default    | Description                                                                                          |
-| ------------------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------- |
-| `acceptedIdNames`         | `string[]` | `["id"]`   | Field names that satisfy the unique identifier requirement.                                          |
-| `acceptedIdTypes`         | `string[]` | `["ID"]`   | GraphQL types (non-null) that are accepted as the identifier field's type.                           |
-| `exceptions`              | `object`   | `{}`       | Types or type-name suffixes to exclude from this rule.                                               |
-| `exceptions.types`        | `string[]` | `[]`       | Exact type names to skip (e.g. `["Error", "PageInfo"]`).                                             |
-| `exceptions.suffixes`     | `string[]` | `[]`       | Type-name suffixes to skip — any type whose name ends with one of these is excluded (e.g. `["Payload", "Connection"]`). |
+| Option                | Type       | Default  | Description                                                                                                             |
+| --------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `acceptedIdNames`     | `string[]` | `["id"]` | Field names that satisfy the unique identifier requirement.                                                             |
+| `acceptedIdTypes`     | `string[]` | `["ID"]` | GraphQL types (non-null) that are accepted as the identifier field's type.                                              |
+| `exceptions`          | `object`   | `{}`     | Types or type-name suffixes to exclude from this rule.                                                                  |
+| `exceptions.types`    | `string[]` | `[]`     | Exact type names to skip (e.g. `["Error", "PageInfo"]`).                                                                |
+| `exceptions.suffixes` | `string[]` | `[]`     | Type-name suffixes to skip — any type whose name ends with one of these is excluded (e.g. `["Payload", "Connection"]`). |
 
 ## Configuration
 

--- a/docs/src/content/docs/rules/strictIdInTypes.mdx
+++ b/docs/src/content/docs/rules/strictIdInTypes.mdx
@@ -34,6 +34,16 @@ type User {
 }
 ```
 
+## Options
+
+| Option                    | Type       | Default    | Description                                                                                          |
+| ------------------------- | ---------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| `acceptedIdNames`         | `string[]` | `["id"]`   | Field names that satisfy the unique identifier requirement.                                          |
+| `acceptedIdTypes`         | `string[]` | `["ID"]`   | GraphQL types (non-null) that are accepted as the identifier field's type.                           |
+| `exceptions`              | `object`   | `{}`       | Types or type-name suffixes to exclude from this rule.                                               |
+| `exceptions.types`        | `string[]` | `[]`       | Exact type names to skip (e.g. `["Error", "PageInfo"]`).                                             |
+| `exceptions.suffixes`     | `string[]` | `[]`       | Type-name suffixes to skip — any type whose name ends with one of these is excluded (e.g. `["Payload", "Connection"]`). |
+
 ## Configuration
 
 ```yaml
@@ -42,4 +52,13 @@ extensions:
     lint:
       rules:
         strictIdInTypes: warn
+
+# Accept _id as well as id, allow UUID type, and skip payload types
+        strictIdInTypes:
+          - warn
+          - acceptedIdNames: ["id", "_id"]
+            acceptedIdTypes: ["ID", "UUID"]
+            exceptions:
+              types: ["Error"]
+              suffixes: ["Payload", "Connection"]
 ```


### PR DESCRIPTION
## Summary

Audit-driven pass to bring the docs site up to date with current behavior. Each section was diffed against the actual implementation (CLI `--help` output, config schema, lint rule sources, LSP handlers, MCP tools) and corrected where the docs had drifted or were missing recent additions.

## Changes

**Install paths**
- Removed references to nonexistent `install-vscode.sh`/`install-vscode.ps1` scripts (`getting-started/installation`, `getting-started/quick-start`)
- VS Code Marketplace and Open VSX called out as the primary install paths in `editors/vscode` and `getting-started/installation`
- Fixed `cargo install graphql-lsp` (not on crates.io) to use `--git` form

**CLI**
- `cli/overview` now lists all 13 commands (was 9). Global options table corrected (`-c`/`-p` short flags; `--format` removed since it's per-command). Exit code 6 added.
- `cli/validate`, `cli/lint`, `cli/check`: added `--max-warnings`, `sarif` format, `-f`/`-w` short flags, exit code 6 to relevant tables
- `cli/output-formats`: GitHub format example now includes `endLine`/`endColumn`; JSON example matches actual `check` output schema
- `cli/ci-cd`: removed nonexistent `--rule` flag example; replaced with `extensions.cli.lint.rules` config approach. Added `--max-warnings 0` strictness pattern.

**Linting + rules**
- Sidebar: added 11 missing rule pages (`matchDocumentFilename`, `noRootType`, the 4 `relay*` rules, `requireDeprecationDate`, `requireImportFragment`, the 3 `requireNullable*`/`requireType*` rules)
- `linting/overview`: same 11 rules added to the additional-rules table
- `rules/catalog`: corrected default severity for ~25 rules (was `—`, now reflects actual `default_severity()` from each rule's source). Context column corrected for `alphabetize`, `namingConvention`, `requireDescription` (dual-context).
- `linting/eslint-plugin`: added 3 missing presets (`flat/schema-all`, `flat/schema-relay`, `flat/operations-all`)
- Per-rule pages: documented missing options for `alphabetize`, `namingConvention`, `requireDescription`, `strictIdInTypes`, `selectionSetDepth`. Fixed `requireIdField` default severity.

**IDE features**
- `goto-definition`: removed bogus enum-value row; added `OperationName` and `DirectiveArgumentName` rows (both implemented)
- `find-references`: added `FieldName` and `DirectiveName` rows (both implemented); qualified that type-references are schema-only
- `hover`: removed unimplemented argument-types claim; corrected deprecation example formatting; added note about directive/fragment-spread/type-name hover
- `embedded-graphql`: documented all 6 default modules (was 1); added `.mjs`/`.cjs`; documented magic-comment extraction
- `diagnostics`: removed stale Apollo-compiler attribution

**Configuration**
- `config-file`: added `package.json` discovery, `include`/`exclude` per-project fields, env-var interpolation (`${VAR}`/`${VAR:default}`), reformatted broken single-line code blocks
- `schema-sources` + `advanced/remote-schemas`: documented structured introspection config (`url`/`headers`/`timeout`/`retry`); removed false "schema is cached automatically" claim
- `documents`: corrected `tagIdentifiers` default (`["gql"]` → `["gql", "graphql"]`) and `modules` default (1 → 6 entries); added `magicComment`; added `.js`/`.jsx` to multi-pattern example
- `multi-project`: documented `include`/`exclude` and the `client` extension field
- `advanced/troubleshooting`: completed config-file priority list (added TOML, `package.json` fallback)

**MCP**
- `ai-integration/mcp`: expanded from 5 documented tools to 15 (added `goto_definition`, `find_references`, `hover`, `document_symbols`, `workspace_symbols`, `get_completions`, `get_file_diagnostics`, `get_schema_types`, `get_type_info`, `get_schema_sdl`, `get_operations`, `get_query_complexity`, `introspect_endpoint`)

**Performance / OTel**
- `advanced/performance-tuning`: corrected OTLP gRPC port (`4317`) vs Jaeger UI port (`16686`) confusion; replaced raw env-var setup with the `graphql-analyzer.debug.otelEnabled`/`otelEndpoint` settings approach; replaced direct `graphql-lsp` invocation with VS Code settings equivalent

**Editor docs**
- `editors/vscode`: added 3 missing commands (`testOtelConnection`, `startTrace`, `stopTrace`); corrected activation explanation (config-file detection, not file-open); fixed troubleshooting output channel name
- `editors/neovim`: expanded `filetypes` (was missing plain `typescript`/`javascript` and `vue`/`svelte`/`astro`); added Nvim 0.11+ note about `vim.lsp.config` and the lspconfig `graphql` server pointing to a different tool
- `editors/other`: added `workspace/executeCommand` capability; flagged Zed config caveat

## Deferred (worth follow-ups)

These showed up in the audit but were intentionally not addressed here to keep the PR scoped to currency corrections rather than expansion:

- New full pages for undocumented CLI commands (`mcp`, `lsp`, `complexity`, `coverage`, `fragments`, `stats`, `deprecations`, `list-rules`, `explain`) — currently only listed in the overview table
- New full pages for IDE features lacking docs (completion, signature help, rename, code actions, code lenses, inlay hints, semantic tokens, selection range, folding ranges, document/workspace symbols)
- Root `README.md:15` uses the wrong publisher (`trevor-scheer.graphql-analyzer` vs the correct `graphql-analyzer.graphql-analyzer`); `editors/vscode/README.md` has stale `extensions.lint` config namespace and `snake_case` rule name examples — these are README cleanups outside the docs site

## Manual Testing Plan

- `cd docs && npx astro build` (passes — 70 pages built)
- Spot-check a few key navigation paths: Rules sidebar shows all 38 rules; CLI overview shows all 13 commands; MCP page lists 15 tools
- Skim `getting-started/installation` and `editors/vscode` to confirm marketplace links land on the correct extension page