### PR TITLE
Add missing `graphql-analyzer-eslint-plugin` bump to upstream-test-port changeset

### DIFF
--- a/.changeset/resty-field-names.md
+++ b/.changeset/resty-field-names.md
@@ -2,6 +2,7 @@
 graphql-analyzer-cli: minor
 graphql-analyzer-lsp: minor
 graphql-analyzer-vscode: minor
+graphql-analyzer-eslint-plugin: minor
 ---
 
 Add `resty-field-names` lint rule to detect REST anti-patterns ([#930](https://github.com/trevor-scheer/graphql-analyzer/pull/930))

--- a/.changeset/upstream-test-port.md
+++ b/.changeset/upstream-test-port.md
@@ -1,6 +1,7 @@
 ---
 graphql-analyzer-cli: patch
 graphql-analyzer-lsp: patch
+graphql-analyzer-eslint-plugin: patch
 ---
 
 Port `@graphql-eslint`'s unit tests verbatim into Rust unit tests under `crates/linter/src/rules/upstream/`, expanding lint-rule parity coverage from the existing single-fixture-per-rule integration test to upstream's full per-rule edge-case set. Surfaced and fixed multiple rule parity bugs along the way.


### PR DESCRIPTION
## Summary

Two changesets in the pending release were missing `graphql-analyzer-eslint-plugin` entries. The eslint plugin auto-exposes every linter rule via `binding.getRules()` ([packages/eslint-plugin/src/rules.ts:340](https://github.com/trevor-scheer/graphql-analyzer/blob/main/packages/eslint-plugin/src/rules.ts#L340)), so both the parity bug fixes and the new `resty-field-names` rule reach plugin users — but without these entries the plugin would skip a release that contains substantial user-visible changes for it.

## Changes

- `.changeset/upstream-test-port.md`: add `graphql-analyzer-eslint-plugin: patch` (parity fixes from #1033 — locale-aware `alphabetize`, `description-style` `messageId`, `no-deprecated` default reason, the `require-selections` semantics change, etc.).
- `.changeset/resty-field-names.md`: add `graphql-analyzer-eslint-plugin: minor` (new rule auto-propagates via `binding.getRules()`).

## Consulted SME Agents

- N/A — changeset metadata fix.

## Manual Testing Plan

- N/A. Knope will pick up the new entries on the next `prepare-release` run; the open release PR should refresh to include a `@graphql-analyzer/eslint-plugin` minor bump and a CHANGELOG entry covering both items.

## Notes

- Heads-up unrelated to this PR: `resty-field-names.md` lists `graphql-analyzer-vscode: minor`, but `knope.toml` doesn't define a `graphql-analyzer-vscode` package (the comment on `[packages.graphql-analyzer-lsp]` says the `vscode` name is retired). Knope likely silently ignores it. Worth a separate cleanup pass.

## Related Issues

- Follows up on #1033 and #930.