### PR TITLE
Document migration from `graphql.config.js` to static config

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -247,7 +247,7 @@ The library searches for these files in order of preference:
 
 This library only supports YAML, JSON, and TOML configuration formats. JavaScript and TypeScript config files (`graphql.config.js`, `graphql.config.ts`) are **not supported**.
 
-If you're migrating from a JS/TS config, convert your configuration to YAML, JSON, or TOML. Most configurations can be directly translated since the schema is the same:
+If your JS/TS config is a static object (or evaluates to one), most configurations translate directly:
 
 ```javascript
 // graphql.config.js (NOT SUPPORTED)
@@ -269,7 +269,31 @@ schema = "schema.graphql"
 documents = "src/**/*.graphql"
 ```
 
-For dynamic configuration needs (rare), consider using environment variables or generating the config as a build step.
+#### One-liner migration
+
+For static configs, dump to JSON in one command — `.graphqlrc.json` is supported directly:
+
+```sh
+# JS (CommonJS or ESM, Node 20+)
+node -e "import('./graphql.config.js').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
+
+# TypeScript
+npx -y tsx -e "import('./graphql.config.ts').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
+```
+
+`await import()` covers both CommonJS and ESM in modern Node; `c.default ?? c` normalizes `export default` and `module.exports = ...`.
+
+#### What won't carry over
+
+`graphql.config.js` is loaded by [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig), which evaluates JavaScript at load time. The following are **not supported** in static configs:
+
+- Functions, getters, or async values anywhere in the config tree
+- `require()` / `import()` of other modules evaluated at load time
+- Conditional logic that branches on `process.env` or other runtime state (beyond the simple `${VAR}` interpolation supported by this library)
+- Custom JavaScript loaders, transforms, or plugins registered through the config
+- Dynamically computed values — schema URLs, file paths, header values, document globs — produced by running JS
+
+For dynamic needs, use environment variable interpolation (`${VAR}` and `${VAR:default}`) or generate the config file as a build step before invoking the tool.
 
 ## Examples
 

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -274,24 +274,22 @@ documents = "src/**/*.graphql"
 For static configs, dump to JSON in one command — `.graphqlrc.json` is supported directly:
 
 ```sh
-# JS (CommonJS or ESM, Node 20+)
 node -e "import('./graphql.config.js').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
-
-# TypeScript
-npx -y tsx -e "import('./graphql.config.ts').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
 ```
 
-`await import()` covers both CommonJS and ESM in modern Node; `c.default ?? c` normalizes `export default` and `module.exports = ...`.
+The dynamic `import()` returns a promise resolving to the namespace object, which `.then(c => …)` unwraps. `c.default ?? c` picks the ESM default export when present, otherwise falls back to the CJS exports object — so the same command handles both `module.exports = …` and `export default …`.
+
+For TypeScript configs, point at `graphql.config.ts` instead. Modern Node strips type annotations natively (Node 22.6+ with `--experimental-strip-types`, or Node 23.6+ where it's on by default), so no separate runner like `tsx` is needed.
 
 #### What won't carry over
 
 `graphql.config.js` is loaded by [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig), which evaluates JavaScript at load time. The following are **not supported** in static configs:
 
-- Functions, getters, or async values anywhere in the config tree
-- `require()` / `import()` of other modules evaluated at load time
-- Conditional logic that branches on `process.env` or other runtime state (beyond the simple `${VAR}` interpolation supported by this library)
-- Custom JavaScript loaders, transforms, or plugins registered through the config
-- Dynamically computed values — schema URLs, file paths, header values, document globs — produced by running JS
+- **Function-valued fields anywhere in the tree** — common cases include HTTP `Authorization` headers built by a function for dynamic auth tokens, or `extensions.codegen.hooks.afterAllFileWrite` set to a function (only string shell commands carry over). Function values silently disappear from `JSON.stringify()`, so the one-liner produces an _incomplete_ config rather than erroring.
+- **`process.env` interpolation via JS** — e.g. `headers.Authorization` built from a template literal embedding `process.env.TOKEN`. Use the static `${TOKEN}` interpolation supported by this library instead.
+- **Conditional branches on runtime state** — e.g. switching `documents` globs or `projects` based on `process.env.CI` or `NODE_ENV`.
+- **Spread-imported config fragments** — e.g. spreading the result of `require("./shared-globs")` into the `documents` array.
+- **Custom loaders, transforms, or plugins registered in JS** — e.g. graphql-config v5's top-level `loaders: [new UrlLoader()]`, or codegen plugins referenced via `require()`.
 
 For dynamic needs, use environment variable interpolation (`${VAR}` and `${VAR:default}`) or generate the config file as a build step before invoking the tool.
 

--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -152,22 +152,15 @@ documents: "src/**/*.graphql"
 
 ### One-liner conversion
 
-If your JS/TS config is a static object (or evaluates to one), you can dump it to JSON with a single command. `.graphqlrc.json` is supported directly — no further conversion required.
+If your config is a static object (or evaluates to one), dump it to JSON with a single command. `.graphqlrc.json` is supported directly — no further conversion required.
 
-<Tabs>
-  <TabItem label="JS (CommonJS or ESM)">
-    ```sh
-    node -e "import('./graphql.config.js').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
-    ```
-  </TabItem>
-  <TabItem label="TypeScript">
-    ```sh
-    npx -y tsx -e "import('./graphql.config.ts').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
-    ```
-  </TabItem>
-</Tabs>
+```sh
+node -e "import('./graphql.config.js').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
+```
 
-`await import()` works for both CommonJS and ESM modules in Node 20+. The `c.default ?? c` handles `export default` (ESM) and `module.exports = ...` (CJS) uniformly.
+The dynamic `import()` returns a promise resolving to the namespace object, which `.then(c => …)` unwraps. `c.default ?? c` picks the ESM default export when present, otherwise falls back to the CJS exports object — so the same command handles both `module.exports = …` and `export default …`.
+
+For TypeScript configs, point at `graphql.config.ts` instead. Modern Node strips type annotations natively (Node 22.6+ with `--experimental-strip-types`, or Node 23.6+ where it's on by default), so no separate runner like `tsx` is needed.
 
 If you'd prefer YAML, pipe the JSON through any YAML converter — for example, with `js-yaml` installed:
 
@@ -181,13 +174,13 @@ node -e "console.log(require('js-yaml').dump(require('./.graphqlrc.json')))" > .
 
 :::caution[Unsupported in static configs]
 
-- **Functions, getters, or async values** anywhere in the config tree
-- **`require()` / `import()` of other modules** evaluated at load time
-- **Conditional logic** that branches on `process.env`, the working directory, or other runtime state (beyond the simple `${VAR}` interpolation described below)
-- **Custom JavaScript loaders, transforms, or plugins** registered through the config
-- **Dynamically computed values** — schema URLs, file paths, header values, document globs, etc. — produced by running JS
+- **Function-valued fields anywhere in the tree** — common cases include HTTP `Authorization` headers built by a function for dynamic auth tokens, or `extensions.codegen.hooks.afterAllFileWrite` set to a function (only string shell commands carry over). Function values silently disappear from `JSON.stringify()`, so the one-liner produces an _incomplete_ config rather than erroring — easy to miss.
+- **`process.env` interpolation via JS** — e.g. `headers.Authorization` built from a template literal embedding `process.env.TOKEN`. Use the static `${TOKEN}` interpolation [described below](#environment-variable-interpolation) instead — it's resolved when the YAML/JSON is loaded, not baked into the file.
+- **Conditional branches on runtime state** — e.g. switching `documents` globs or `projects` based on `process.env.CI` or `NODE_ENV`.
+- **Spread-imported config fragments** — e.g. spreading the result of `require("./shared-globs")` into the `documents` array.
+- **Custom loaders, transforms, or plugins registered in JS** — e.g. graphql-config v5's top-level `loaders: [new UrlLoader()]`, or codegen plugins referenced via `require()`.
 
-If your existing config uses any of these, the one-liner above will either fail or produce an incomplete config. You will need to address each dynamic value before migrating.
+If your existing config uses any of these, you'll need to address them before migrating.
 
 :::
 

--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -132,7 +132,9 @@ See [Multi-Project Workspaces](/graphql-analyzer/configuration/multi-project/) f
 
 ## Migrating from JavaScript config
 
-If you have a `graphql.config.js`, convert it to YAML or TOML:
+If you have a `graphql.config.js` or `graphql.config.ts`, convert it to YAML, JSON, or TOML.
+
+For configs that are already plain objects, the translation is mechanical:
 
 ```javascript
 // graphql.config.js (NOT SUPPORTED)
@@ -144,15 +146,68 @@ module.exports = {
 
 <Tabs>
   <TabItem label="YAML">
-    ```yaml # .graphqlrc.yml (equivalent) schema: schema.graphql documents: src/**/*.graphql ```
+    ```yaml
+    # .graphqlrc.yml (equivalent)
+    schema: schema.graphql
+    documents: src/**/*.graphql
+    ```
   </TabItem>
   <TabItem label="TOML">
-    ```toml # .graphqlrc.toml (equivalent) schema = "schema.graphql" documents = "src/**/*.graphql"
+    ```toml
+    # .graphqlrc.toml (equivalent)
+    schema = "schema.graphql"
+    documents = "src/**/*.graphql"
     ```
   </TabItem>
 </Tabs>
 
-For dynamic configuration needs, generate the YAML/JSON/TOML config as a build step.
+### One-liner conversion
+
+If your JS/TS config is a static object (or evaluates to one), you can dump it to JSON with a single command. `.graphqlrc.json` is supported directly — no further conversion required.
+
+<Tabs>
+  <TabItem label="JS (CommonJS or ESM)">
+    ```sh
+    node -e "import('./graphql.config.js').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
+    ```
+  </TabItem>
+  <TabItem label="TypeScript">
+    ```sh
+    npx -y tsx -e "import('./graphql.config.ts').then(c => console.log(JSON.stringify(c.default ?? c, null, 2)))" > .graphqlrc.json
+    ```
+  </TabItem>
+</Tabs>
+
+`await import()` works for both CommonJS and ESM modules in Node 20+. The `c.default ?? c` handles `export default` (ESM) and `module.exports = ...` (CJS) uniformly.
+
+If you'd prefer YAML, pipe the JSON through any YAML converter — for example, with `js-yaml` installed:
+
+```sh
+node -e "console.log(require('js-yaml').dump(require('./.graphqlrc.json')))" > .graphqlrc.yml && rm .graphqlrc.json
+```
+
+### What won't carry over
+
+`graphql.config.js` is loaded by [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig), which evaluates the JavaScript at load time. That means JS configs can express things a static YAML/JSON/TOML file cannot. GraphQL Analyzer **does not support** any of the following:
+
+:::caution[Unsupported in static configs]
+
+- **Functions, getters, or async values** anywhere in the config tree
+- **`require()` / `import()` of other modules** evaluated at load time
+- **Conditional logic** that branches on `process.env`, the working directory, or other runtime state (beyond the simple `${VAR}` interpolation described below)
+- **Custom JavaScript loaders, transforms, or plugins** registered through the config
+- **Dynamically computed values** — schema URLs, file paths, header values, document globs, etc. — produced by running JS
+
+If your existing config uses any of these, the one-liner above will either fail or produce an incomplete config. You will need to address each dynamic value before migrating.
+
+:::
+
+### Workarounds for dynamic needs
+
+Most real-world dynamic configs fall into one of two buckets, and both have static equivalents:
+
+- **Secrets, tokens, and per-environment URLs** → use [environment variable interpolation](#environment-variable-interpolation). `${API_TOKEN}` and `${TENANT_ID:default-tenant}` cover the common cases without any JavaScript.
+- **Anything else dynamic** (computed schemas, conditional projects, generated globs) → generate the config file as a build step. Have your existing JavaScript write a `.graphqlrc.yml` or `.graphqlrc.json` to disk before invoking GraphQL Analyzer; treat the generated file as a build artifact.
 
 ## Environment variable interpolation
 

--- a/docs/src/content/docs/configuration/config-file.mdx
+++ b/docs/src/content/docs/configuration/config-file.mdx
@@ -144,22 +144,11 @@ module.exports = {
 };
 ```
 
-<Tabs>
-  <TabItem label="YAML">
-    ```yaml
-    # .graphqlrc.yml (equivalent)
-    schema: schema.graphql
-    documents: src/**/*.graphql
-    ```
-  </TabItem>
-  <TabItem label="TOML">
-    ```toml
-    # .graphqlrc.toml (equivalent)
-    schema = "schema.graphql"
-    documents = "src/**/*.graphql"
-    ```
-  </TabItem>
-</Tabs>
+```yaml
+# .graphqlrc.yml (equivalent)
+schema: "schema.graphql"
+documents: "src/**/*.graphql"
+```
 
 ### One-liner conversion
 


### PR DESCRIPTION
## Summary

Expand the existing brief \"Migrating from JavaScript config\" section in the configuration docs (and mirror in the `graphql-config` crate README) with an actionable one-liner for users moving off of `graphql.config.js` / `graphql.config.ts`, and explicit guidance about which JS-only features won't survive the migration.

The motivation: we don't load JS/TS configs (no cosmiconfig), but the prior docs only said \"convert to YAML\" without explaining how, or what to watch out for when the source config relies on runtime evaluation.

## Changes

- Add a tabbed \"One-liner conversion\" subsection with a `node -e` / `npx tsx -e` command that dumps a static JS/TS config to `.graphqlrc.json` using `await import()` (works for both CJS and ESM in Node 20+) and `c.default ?? c` to normalize the export shape. Includes an optional follow-up to convert JSON → YAML via `js-yaml`.
- Add a `:::caution` callout titled \"Unsupported in static configs\" enumerating the cosmiconfig-evaluated features that won't carry over: functions/getters/async values, load-time `require`/`import`, conditional logic on `process.env`, custom JS loaders/transforms/plugins, and dynamically computed schema URLs/paths/headers/globs.
- Add a \"Workarounds for dynamic needs\" subsection pointing users at the existing `${VAR}` interpolation for the common secrets/env case, and at generating the config as a build step for everything else.
- Mirror the same content (one-liner + unsupported list + workaround pointer) into `crates/config/README.md` so the crate's standalone documentation stays in sync.

## Consulted SME Agents

- N/A — docs-only change, no architectural decisions.

## Manual Testing Plan

- Run `npm run build` in `docs/` and confirm the page builds without MDX errors and the caution callout renders (`starlight-aside--caution` class present in the generated HTML).
- Verify the one-liner against a CommonJS `graphql.config.js` and against an ESM `graphql.config.js` (`"type": "module"` + `export default`); both should emit a clean JSON object on stdout.

## Related Issues

- N/A