### PR TITLE
Add missing `actions/checkout` to `publish-openvsx` release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,6 +380,8 @@ jobs:
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Summary

- The `publish-openvsx` job in `.github/workflows/release.yml` was missing an `actions/checkout` step. Every other job that runs `setup-node` had one already.
- Until [#1028](https://github.com/trevor-scheer/graphql-analyzer/pull/1028) this latent bug was harmless — `setup-node` was configured with a hardcoded `node-version: "24"`, so it never needed a file from disk. After #1028 switched to `node-version-file: .node-version`, the missing checkout turned into a hard failure: `The specified node version file at: .../.node-version does not exist`.
- See the failing run on the latest release: https://github.com/trevor-scheer/graphql-analyzer/actions/runs/25178118862/job/73832855535

## Changes

- Add `actions/checkout` step at the top of the `publish-openvsx` job so `.node-version` is on disk when `setup-node` reads it.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- N/A — change matches the pattern used by every other job in the same workflow (`publish-vscode`, `publish-npm`, etc.). Validation will come from the next release run.

## Related Issues