### PR TITLE
Fix `dogfood-testbed` workflow tag format and broken fallbacks

### DIFF
--- a/.github/workflows/dogfood-testbed.yml
+++ b/.github/workflows/dogfood-testbed.yml
@@ -31,34 +31,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Extract the version for each package from the tags created by knope.
-          # knope tags releases as "<package-name>-v<version>", e.g.
-          # "graphql-analyzer-lsp-v1.2.3".
-          #
-          # We query the GitHub releases API and look for the most recent
-          # release for each package that was published in the triggering run.
-          # Fallback: use "latest" tag, which npm resolves correctly for stable
-          # releases.
-          #
-          # At implementation time: if knope's tag format differs, adjust the
-          # grep pattern below to match.
+          # knope tags releases as "<package-name>/v<version>", e.g.
+          # "graphql-analyzer-lsp/v1.2.3".
           CLI_VERSION="$(gh release list \
             --repo trevor-scheer/graphql-analyzer \
-            --limit 10 \
+            --limit 30 \
             --json tagName,publishedAt \
-            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-cli-v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-cli-v")' \
-            2>/dev/null || echo "latest")"
+            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-cli/v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-cli/v")')"
           CORE_VERSION="$(gh release list \
             --repo trevor-scheer/graphql-analyzer \
-            --limit 10 \
+            --limit 30 \
             --json tagName,publishedAt \
-            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-core-v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-core-v")' \
-            2>/dev/null || echo "latest")"
+            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-core/v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-core/v")')"
           ESLINT_VERSION="$(gh release list \
             --repo trevor-scheer/graphql-analyzer \
-            --limit 10 \
+            --limit 30 \
             --json tagName,publishedAt \
-            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-eslint-plugin-v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-eslint-plugin-v")' \
-            2>/dev/null || echo "latest")"
+            --jq '[.[] | select(.tagName | startswith("graphql-analyzer-eslint-plugin/v"))] | sort_by(.publishedAt) | last | .tagName | ltrimstr("graphql-analyzer-eslint-plugin/v")')"
+          if [ -z "$CLI_VERSION" ] || [ -z "$CORE_VERSION" ] || [ -z "$ESLINT_VERSION" ]; then
+            echo "Failed to resolve one or more package versions from recent releases"
+            echo "CLI=$CLI_VERSION CORE=$CORE_VERSION ESLINT=$ESLINT_VERSION"
+            exit 1
+          fi
           echo "cli_version=$CLI_VERSION" >> "$GITHUB_OUTPUT"
           echo "core_version=$CORE_VERSION" >> "$GITHUB_OUTPUT"
           echo "eslint_version=$ESLINT_VERSION" >> "$GITHUB_OUTPUT"
@@ -107,21 +101,12 @@ jobs:
           CLI_VERSION: ${{ steps.versions.outputs.cli_version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Download the linux-x86_64 CLI binary from the release.
-          # At implementation time: verify the asset naming matches the
-          # release artifacts actually produced by the release workflow.
           ASSET="graphql-cli-x86_64-unknown-linux-gnu.tar.xz"
-          gh release download "graphql-analyzer-cli-v${CLI_VERSION}" \
+          gh release download "graphql-analyzer-cli/v${CLI_VERSION}" \
             --repo trevor-scheer/graphql-analyzer \
             --pattern "$ASSET" \
-            --dir /tmp/graphql-cli-release 2>/dev/null || {
-            echo "Warning: could not download versioned release, falling back to latest"
-            gh release download \
-              --repo trevor-scheer/graphql-analyzer \
-              --pattern "$ASSET" \
-              --dir /tmp/graphql-cli-release \
-              --latest
-          }
+            --dir /tmp/graphql-cli-release
+          mkdir -p ~/.local/bin
           tar -xJf "/tmp/graphql-cli-release/$ASSET" -C ~/.local/bin/
           chmod +x ~/.local/bin/graphql
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -155,10 +140,6 @@ jobs:
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRIGGERING_RUN: ${{ github.event.workflow_run.html_url }}
-          CLI_VERSION: ${{ steps.versions.outputs.cli_version }}
-          CORE_VERSION: ${{ steps.versions.outputs.core_version }}
-          ESLINT_VERSION: ${{ steps.versions.outputs.eslint_version }}
         run: |
           gh issue create \
             --repo trevor-scheer/graphql-analyzer \
@@ -167,12 +148,12 @@ jobs:
             --body "$(cat <<'BODY'
           The **analyzer-testbed** CI failed after a release of graphql-analyzer.
 
-          **Triggered by release run:** $TRIGGERING_RUN
+          **Triggered by release run:** ${{ github.event.workflow_run.html_url }}
 
           **Versions under test:**
-          - \`@graphql-analyzer/core\`: $CORE_VERSION
-          - \`@graphql-analyzer/eslint-plugin\`: $ESLINT_VERSION
-          - \`graphql-cli\`: $CLI_VERSION
+          - \`@graphql-analyzer/core\`: ${{ steps.versions.outputs.core_version }}
+          - \`@graphql-analyzer/eslint-plugin\`: ${{ steps.versions.outputs.eslint_version }}
+          - \`graphql-cli\`: ${{ steps.versions.outputs.cli_version }}
 
           **Dogfood CI run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
## Summary

The dogfood workflow has been silently failing on every release run. Issue [#1046](https://github.com/trevor-scheer/graphql-analyzer/issues/1046) is the most recent autogenerated report, and the issue body itself shows the symptoms (template variables like `$CORE_VERSION` rendered literally instead of expanding).

Three independent bugs in `.github/workflows/dogfood-testbed.yml`:

1. **Tag format mismatch.** The version-resolution jq filter and the download command both looked up `graphql-analyzer-cli-v*`, but knope produces `graphql-analyzer-cli/v*` (slash, not hyphen). The filter never matched anything, `last | .tagName | ltrimstr(...)` errored on `null`, and the `|| echo "latest"` fallback fired — so `CLI_VERSION` ended up as the literal string `latest`. The download step then ran `gh release download "graphql-analyzer-cli-vlatest"`, which 404s.
2. **Invalid `gh release download --latest` flag.** The download fallback used `--latest`, which isn't a flag on that subcommand (it exists on `gh release view`). The fallback path crashed with `unknown flag: --latest` the moment it ran. Removing `--latest` alone wouldn't help either — `gh release download` with no tag uses GitHub's "Latest" release, which on this repo is whichever package was tagged most recently and may not contain the CLI asset.
3. **Quoted-heredoc swallows bash variables.** The issue body used `<<'BODY'` (quoted delimiter), so `$TRIGGERING_RUN`, `$CORE_VERSION`, `$ESLINT_VERSION`, and `$CLI_VERSION` came through verbatim. Only the `${{ github.* }}` markers expanded, because Actions interpolation runs at the YAML layer before bash sees the script.

## Changes

- Switch the three jq filters and the download tag from `graphql-analyzer-<pkg>-v` to `graphql-analyzer-<pkg>/v`
- Bump `--limit` from 10 to 30 so a CLI release isn't pushed off the window if several packages release at once
- Drop the silent `|| echo "latest"` fallback; if resolution can't find a tag, fail loudly with the partial values printed
- Drop the broken `--latest` download fallback (with the format fix, it shouldn't be needed; if it ever is, failing loud is more useful than downloading the wrong release)
- Add `mkdir -p ~/.local/bin` before the `tar -xJf` extract for safety
- Replace `\$VAR` references in the issue body with `\${{ steps.versions.outputs.* }}` and `\${{ github.event.workflow_run.html_url }}`, which pass through the quoted heredoc correctly because they're interpolated at the Actions layer; remove the now-unused `env:` entries

## Consulted SME Agents

- N/A — CI workflow change, no domain agent applicable

## Manual Testing Plan

I verified the fixed jq filters against the live releases API and confirmed each returns the expected version (`cli: 0.2.4`, `core: 0.1.1`, `eslint-plugin: 0.1.2`), and confirmed `gh release download --latest` does not exist as a flag.

End-to-end verification will only happen on the next release that triggers `Dogfood testbed`. The workflow_run trigger means this can't run on the PR itself. If we want a faster signal, we could:

- Manually re-trigger the workflow via `gh workflow run` after merge (it requires `workflow_run` context, so this is awkward)
- Or temporarily add a `workflow_dispatch` trigger to test it without a real release

Open to either, but happy to just merge and watch the next release cycle.

## Related Issues

Fixes #1046