### PR TITLE
Fix `graphql-cli` references that should invoke the `graphql` binary

### DIFF
--- a/.github/workflows/dogfood-testbed.yml
+++ b/.github/workflows/dogfood-testbed.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Run testbed CI (lint + typecheck + build + test)
         working-directory: testbed
         run: |
-          pnpm graphql-cli check .
+          graphql check .
           pnpm lint
           pnpm --filter @analyzer-testbed/web prisma generate
           pnpm tsc --noEmit --project tsconfig.json 2>/dev/null || \
@@ -126,7 +126,7 @@ jobs:
         run: |
           fail_if_passes() {
             local project="$1"
-            if pnpm graphql-cli check --project "$project" .; then
+            if graphql check --project "$project" .; then
               echo "ERROR: $project exited 0 — expected errors but found none"
               return 1
             fi

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -186,7 +186,7 @@ irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/script
 **Homebrew:**
 
 ```sh
-brew install trevor-scheer/tap/graphql-cli
+brew install trevor-scheer/graphql-analyzer/graphql-analyzer
 ```
 
 **From source:**


### PR DESCRIPTION
## Summary

The CLI binary distributed via cargo-dist tarballs is named `graphql` (per `[[bin]] name = "graphql"` in `crates/cli/Cargo.toml`). A few spots invoked it as `pnpm graphql-cli` or `brew install .../graphql-cli` as if there were an npm shim or a homebrew formula by that name. There is neither.

This is a pure docs/CI sweep that fixes those incorrect invocations. No behavior changes.

### Why option 2 (docs sweep) over option 1 (npm shim)

The issue suggested two fixes: publish a `@graphql-analyzer/cli` npm wrapper that downloads and re-invokes the platform-specific binary on first use (similar to `swc-cli`/`esbuild`), or update docs to reference the `graphql` binary directly. I went with the docs sweep because:

- The binary genuinely is named `graphql` already.
- An npm wrapper is a much larger undertaking (platform detection, lazy download, integrity checks, version pinning to the matching CLI release, lockfile concerns) and is its own deliverable.
- Only two CI lines and one homebrew install hint were actually wrong; nothing else in the repo treats `graphql-cli` as an installable npm package.

If we later want a `@graphql-analyzer/cli` npm shim for the testbed/ESLint plugin user flow, it's an additive change that doesn't need this fix to land first.

## Changes

- `.github/workflows/dogfood-testbed.yml`: replace `pnpm graphql-cli check ...` with `graphql check ...` (the binary is already on `PATH` after the install step that extracts it to `~/.local/bin/graphql`).
- `RELEASES.md`: fix the homebrew install hint to use the actual tap+formula path `trevor-scheer/graphql-analyzer/graphql-analyzer` (matches the formula filename `Formula/graphql-analyzer.rb` and the form used in `README.md`, `crates/cli/README.md`, `docs/.../installation.mdx`, and `docs/.../cli/overview.mdx`).

### What was deliberately NOT changed (and why)

All remaining `graphql-cli` references in the repo are correct usage and were left alone:

- `crates/cli/Cargo.toml` `name = "graphql-cli"` and `Cargo.lock` entry: actual Rust crate name.
- `--package graphql-cli` in cargo invocations (`xtask`, `release.yml`, `mcp-dev.sh`, `tasks.json`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `RELEASES.md`, `crates/cli/README.md`, `docs/.../installation.mdx`): correct Cargo crate name.
- `graphql-cli-<target>.tar.xz` / `.zip` artifact filenames (in `release.yml`, `knope.toml` `assets`, install scripts, homebrew updater script, install docs): correct cargo-dist asset names derived from the crate name.
- `graphql-cli-installer.sh` / `.ps1`: cargo-dist installer filenames.
- `crates/cli/src/main.rs` tracer service name: internal OpenTelemetry identifier.
- `.claude/agents/graphql-cli.md`: SME agent file about the unrelated `graphql-cli` framework on npm.
- Architecture diagrams in `crates/CLAUDE.md` / `DEVELOPMENT.md` / `crates/cli/README.md`: refer to the crate as a top-level entrypoint.

## Consulted SME Agents

- N/A (mechanical docs/CI fix)

## Manual Testing Plan

- N/A (no behavior changes)
- The dogfood-testbed workflow change will be exercised by the next release; the binary install step on line 112 already extracts to `~/.local/bin/graphql` and adds it to `$GITHUB_PATH`, so subsequent steps with `working-directory: testbed` will resolve `graphql` from PATH.

## Related Issues

Closes #1038.


---

> **Merge note:** This PR conflicts with #1053 on `dogfood-testbed.yml` lines 115/126. #1053 is the superset on those lines (handles `--project web` and trailing `.`). Recommend merging #1053 first; this PR will then need to drop the workflow hunks (the brew-tap fix in `RELEASES.md` is unique to this PR and should stay).
