### PR TITLE
Point CLI installer URL at `scripts/install.sh`

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -415,7 +415,7 @@ jobs:
       - name: Install CLI
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+            https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
       - name: Validate GraphQL
         run: graphql validate --format github
       - name: Lint GraphQL

--- a/docs/src/content/docs/cli/ci-cd.mdx
+++ b/docs/src/content/docs/cli/ci-cd.mdx
@@ -17,7 +17,7 @@ jobs:
       - name: Install GraphQL CLI
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+            https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
       - name: Check GraphQL
         run: graphql check --format github
 ```
@@ -40,7 +40,7 @@ jobs:
       - name: Install GraphQL CLI
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+            https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
       - name: Check GraphQL
         run: graphql check --format sarif > results.sarif
       - name: Upload SARIF
@@ -63,7 +63,7 @@ To run validation and linting as separate steps:
 ```yaml
 graphql:
   script:
-    - curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+    - curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
     - graphql check --format json
 ```
 
@@ -71,7 +71,7 @@ graphql:
 
 ```sh
 # Install
-curl -LsSf https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+curl -LsSf https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
 
 # Run checks
 graphql check --format json > results.json

--- a/docs/src/content/docs/cli/overview.mdx
+++ b/docs/src/content/docs/cli/overview.mdx
@@ -12,7 +12,7 @@ The `graphql` CLI validates and lints your GraphQL projects. Use it in CI/CD pip
 brew install trevor-scheer/graphql-analyzer/graphql-analyzer
 
 # Or via install script
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
 ```
 
 See [Installation](/graphql-analyzer/getting-started/installation/) for all methods.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -47,13 +47,13 @@ brew install trevor-scheer/graphql-analyzer/graphql-analyzer
 **Install script (macOS/Linux):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
 ```
 
 **Install script (Windows PowerShell):**
 
 ```powershell
-irm https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.ps1 | iex
+irm https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.ps1 | iex
 ```
 
 **Via Cargo:**


### PR DESCRIPTION
## Summary

The CLI install URL referenced in the docs — `https://github.com/trevor-scheer/graphql-analyzer/releases/latest/download/graphql-cli-installer.sh` — 404s. Two reasons:

1. This repo doesn't use cargo-dist (the release workflow builds and uploads `.tar.xz`/`.zip` archives by hand), so `graphql-cli-installer.sh` is never published as a release asset.
2. `releases/latest` resolves to whichever release was published most recently across the entire repo. The CLI uses the `graphql-analyzer-cli/vX.Y.Z` tag form, so `releases/latest` typically points at `eslint-plugin` or `core` releases anyway.

The project already ships an installer at `scripts/install.sh` that handles the multi-package tag scheme correctly (it queries the GitHub API for the most recent CLI-tagged release). The root `README.md` and `RELEASES.md` already use that URL — this PR brings the rest of the docs in line.

## Changes

- Replace `releases/latest/download/graphql-cli-installer.sh` with `raw.githubusercontent.com/.../main/scripts/install.sh` in:
  - `docs/src/content/docs/cli/ci-cd.mdx` (4 occurrences)
  - `docs/src/content/docs/cli/overview.mdx`
  - `docs/src/content/docs/getting-started/installation.mdx` (`.sh` and `.ps1`)
  - `crates/cli/README.md`

## Tradeoff considered

The issue suggested a hybrid — enable cargo-dist installer generation in `Cargo.toml` *and* update the docs. I went docs-only because cargo-dist isn't wired into the release pipeline at all (the `[package.metadata.dist] dist = true` in `crates/cli/Cargo.toml` is vestigial), and adopting cargo-dist would be a meaningful release-pipeline change that's out of scope for a docs bug. The existing `scripts/install.sh` is the project's chosen installer and already handles the per-package `releases/latest` problem correctly via the GH API.

## Consulted SME Agents

- N/A — docs-only fix.

## Manual Testing Plan

- Open the docs preview and confirm the install snippets reference `raw.githubusercontent.com/.../main/scripts/install.sh`.
- Optional: `curl -fsSL https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh` in a clean environment to confirm a CLI install lands.

## Related Issues

Fixes #1034