### PR TITLE
Fix dogfood-testbed CLI invocation: `graphql` binary, not `pnpm graphql-cli`

### DIFF
--- a/.github/workflows/dogfood-testbed.yml
+++ b/.github/workflows/dogfood-testbed.yml
@@ -115,7 +115,15 @@ jobs:
       - name: Run testbed CI (lint + typecheck + build + test)
         working-directory: testbed
         run: |
-          pnpm graphql-cli check .
+          # The released binary is installed on PATH as `graphql` (see prior
+          # step). It is not an npm-published `graphql-cli` package, so invoke
+          # it directly rather than through `pnpm`. The `check` subcommand
+          # has no positional path argument and `--project` is required when
+          # the discovered `.graphqlrc.yaml` defines multiple projects, which
+          # the testbed root config does. Run against the main app project,
+          # mirroring the testbed's own CI which runs `graphql validate
+          # --project web`.
+          graphql check --project web
           pnpm lint
           pnpm --filter @analyzer-testbed/web prisma generate
           pnpm tsc --noEmit --project tsconfig.json 2>/dev/null || \
@@ -126,7 +134,7 @@ jobs:
         run: |
           fail_if_passes() {
             local project="$1"
-            if pnpm graphql-cli check --project "$project" .; then
+            if graphql check --project "$project"; then
               echo "ERROR: $project exited 0 — expected errors but found none"
               return 1
             fi


### PR DESCRIPTION
## Summary

Issue #1048 fixed the version-resolution and download bugs that were masking everything downstream in `dogfood-testbed.yml`. Now that those steps work, the next step (`Run testbed CI`) reaches its `pnpm graphql-cli check .` invocation and fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL: Command "graphql-cli" not found` — see the failed run linked from #1050.

Three things wrong with that invocation against the just-released CLI:

1. The released tarball ships a binary named `graphql`, not `graphql-cli`. The install step in this very workflow even calls `chmod +x ~/.local/bin/graphql` and `graphql --version`, then immediately tries to run `pnpm graphql-cli` next.
2. There is no `graphql-cli` script or dep in the testbed (root `package.json`, all `apps/*`, all `examples/*`), so `pnpm` has nothing to resolve to either.
3. The `graphql check` subcommand has no positional path argument and `--project` is required when the discovered `.graphqlrc.yaml` defines multiple projects (the testbed root config defines `web`, `relay`, `svelte`, `vue`, `astro`, `remote-schema`, plus the fixtures). So even `graphql check .` would have failed with `unexpected argument '.'`, and `graphql check` alone would have failed with `Multi-project configuration requires --project flag`.

## Changes

- `Run testbed CI` step: replace `pnpm graphql-cli check .` with `graphql check --project web`. This mirrors the testbed's own CI which runs `graphql validate --project web` against the same project.
- `Run expect-failure fixtures` step: drop the bogus trailing `.` from the `graphql check --project "$project"` invocation in `fail_if_passes` (same root cause — `check` takes no positional path).
- Comment block above the invocation explaining the binary name and the `--project` requirement so the next person doesn't reintroduce either mistake.

## Consulted SME Agents

- N/A — CI workflow change, no domain agent applicable

## Manual Testing Plan

- Locally built `graphql-cli` and confirmed `graphql check .` fails with `unexpected argument '.'`, `graphql check` fails with `Multi-project configuration requires --project flag`, and `graphql check --project <name>` succeeds against the in-repo `test-workspace/`.
- Inspected the released tarball at `graphql-analyzer-cli/v0.2.4` — single binary named `graphql`.
- End-to-end verification only happens on the next release that triggers `Dogfood testbed`. The `workflow_run` trigger means this can't run on the PR itself.

## Related Issues

Fixes #1050


---

> **Merge note:** This PR conflicts with #1051 on `dogfood-testbed.yml` lines 115/126. The fix here is the superset (handles `--project web` and the trailing `.`). Recommend merging this PR first; #1051 will then need to drop those hunks.
