### PR TITLE
Regression test: `graphql validate` exit code on errors (#1040)

### DIFF
--- a/.changeset/validate-exit-code.md
+++ b/.changeset/validate-exit-code.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-cli: patch
+---
+
+Add regression coverage so `graphql validate` keeps exiting non-zero when validation errors are reported, fixing the gap that let CI integrations silently pass on errors ([#1054](https://github.com/trevor-scheer/graphql-analyzer/pull/1054))

--- a/crates/cli/tests/fixtures/missing-fragment/.graphqlrc.yaml
+++ b/crates/cli/tests/fixtures/missing-fragment/.graphqlrc.yaml
@@ -1,0 +1,2 @@
+schema: ./schema.graphql
+documents: ./operations.graphql

--- a/crates/cli/tests/fixtures/missing-fragment/operations.graphql
+++ b/crates/cli/tests/fixtures/missing-fragment/operations.graphql
@@ -1,0 +1,3 @@
+query Greet {
+  ...MissingFragment
+}

--- a/crates/cli/tests/fixtures/missing-fragment/schema.graphql
+++ b/crates/cli/tests/fixtures/missing-fragment/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}

--- a/crates/cli/tests/fixtures/valid/.graphqlrc.yaml
+++ b/crates/cli/tests/fixtures/valid/.graphqlrc.yaml
@@ -1,0 +1,2 @@
+schema: ./schema.graphql
+documents: ./operations.graphql

--- a/crates/cli/tests/fixtures/valid/operations.graphql
+++ b/crates/cli/tests/fixtures/valid/operations.graphql
@@ -1,0 +1,3 @@
+query Greet {
+  hello
+}

--- a/crates/cli/tests/fixtures/valid/schema.graphql
+++ b/crates/cli/tests/fixtures/valid/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}

--- a/crates/cli/tests/validate_exit_code.rs
+++ b/crates/cli/tests/validate_exit_code.rs
@@ -1,0 +1,89 @@
+//! Regression tests for `graphql validate` process exit codes.
+//!
+//! Originally reported in issue #1040: `graphql validate` printed
+//! "Found N error(s)" but exited with status 0, breaking CI tooling that
+//! relies on exit codes. These tests guard against that regression by
+//! invoking the built `graphql` binary as a subprocess and asserting the
+//! exit status.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_graphql");
+
+fn fixture_dir(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_validate(fixture: &str, global_args: &[&str], cmd_args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(BIN);
+    cmd.arg("--no-color")
+        .args(global_args)
+        .arg("validate")
+        .args(cmd_args)
+        .current_dir(fixture_dir(fixture));
+    cmd.output()
+        .unwrap_or_else(|e| panic!("failed to run {BIN}: {e}"))
+}
+
+fn assert_exit_code(output: &std::process::Output, expected: i32) {
+    let actual = output.status.code();
+    assert_eq!(
+        actual,
+        Some(expected),
+        "expected exit code {expected}, got {actual:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn validate_exits_nonzero_on_validation_errors_human_format() {
+    let output = run_validate("missing-fragment", &[], &[]);
+    // ExitCode::ValidationError = 1
+    assert_exit_code(&output, 1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Found 1 error(s)"),
+        "expected human-format summary in stdout, got:\n{stdout}",
+    );
+}
+
+#[test]
+fn validate_exits_nonzero_on_validation_errors_json_format() {
+    let output = run_validate("missing-fragment", &[], &["--format", "json"]);
+    assert_exit_code(&output, 1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("validate --format json must emit valid JSON");
+    assert_eq!(parsed["success"], serde_json::Value::Bool(false));
+    assert_eq!(parsed["stats"]["total_errors"], serde_json::json!(1));
+}
+
+#[test]
+fn validate_exits_nonzero_on_validation_errors_github_format() {
+    let output = run_validate("missing-fragment", &[], &["--format", "github"]);
+    assert_exit_code(&output, 1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("::error "),
+        "expected GitHub Actions error annotation in stdout, got:\n{stdout}",
+    );
+}
+
+#[test]
+fn validate_exits_nonzero_on_validation_errors_when_quiet() {
+    // --quiet suppresses the "Found N error(s)" summary; exit code must
+    // still reflect that errors were found.
+    let output = run_validate("missing-fragment", &["--quiet"], &[]);
+    assert_exit_code(&output, 1);
+}
+
+#[test]
+fn validate_exits_zero_when_no_errors() {
+    let output = run_validate("valid", &[], &[]);
+    assert_exit_code(&output, 0);
+}


### PR DESCRIPTION
## Summary

Adds an integration-test guard so `graphql validate` keeps exiting non-zero when validation errors are reported. Issue #1040 described the symptom: the command printed `✗ Found N error(s)` but exited 0, so CI tooling that gates on exit codes couldn't tell success apart from failure.

The exit-code logic itself is already correct in the current `crates/cli/src/commands/validate.rs`:

```rust
if total_errors > 0 {
    ExitCode::ValidationError.exit();
}
```

— but nothing pinned that down. The new test would have caught the regression originally reported and will catch any future removal of that block. It was verified to fail (4/5 cases) when that `if` block is commented out, then to pass once restored.

## Changes

- Add `crates/cli/tests/validate_exit_code.rs`: a subprocess-driven integration test that spawns the built `graphql` binary against a fixture project containing an unresolvable fragment and asserts exit status 1 across the `human`, `json`, and `github` formats, and under `--quiet`. Also asserts exit status 0 against a clean fixture.
- Add `crates/cli/tests/fixtures/missing-fragment/` and `crates/cli/tests/fixtures/valid/` to back the test cases.

## Consulted SME Agents

- N/A

## Manual Testing Plan

- `cargo nextest run -p graphql-cli --test validate_exit_code`
- From a fixture-style directory, run `graphql validate` against an unresolvable fragment and confirm `echo $?` prints `1` (and `0` on a valid setup).

## Related Issues

Fixes #1040

## Notes

Scoped to `validate` per the issue. While exploring, I confirmed `graphql lint` and `graphql check` already use the same `if total_errors > 0 { ExitCode::ValidationError.exit(); }` pattern, so they don't appear to share the bug — but they likewise lack subprocess-level exit-code coverage. Worth adding parallel tests for them in a follow-up.