### PR TITLE
Add regression coverage for `no-unreachable-types` interface dispatch

### DIFF
--- a/crates/linter/src/rules/no_unreachable_types.rs
+++ b/crates/linter/src/rules/no_unreachable_types.rs
@@ -448,4 +448,62 @@ mod tests {
             .collect();
         assert_eq!(orphan_warnings.len(), 1);
     }
+
+    // Regression test for #1037: object types that implement a reachable
+    // interface must themselves be considered reachable. Clients reach them
+    // via inline fragments and the resolver's `__resolveType` dispatches.
+    // Mirrors the exact repro from the issue.
+    #[test]
+    fn test_interface_implementors_are_reachable_regression_1037() {
+        let db = RootDatabase::default();
+        let rule = NoUnreachableTypesRuleImpl;
+        let schema = "
+            interface Move { id: ID! }
+            type PhysicalMove implements Move { id: ID!, makesContact: Boolean! }
+            type SpecialMove implements Move { id: ID!, effectChance: Int }
+            type StatusMove implements Move { id: ID!, inflicts: String }
+            type Pokemon { moves: [Move!]! }
+            type Query { pokemon: Pokemon }
+        ";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        for n in ["PhysicalMove", "SpecialMove", "StatusMove"] {
+            let hits: Vec<_> = all
+                .iter()
+                .filter(|d| d.message.contains(&format!("`{n}`")))
+                .collect();
+            assert!(
+                hits.is_empty(),
+                "expected `{n}` to be reachable via interface dispatch, got: {hits:?}"
+            );
+        }
+    }
+
+    // Companion regression test for #1037: union members are reachable via
+    // the same dispatch mechanism (inline fragments on the union type).
+    #[test]
+    fn test_union_members_are_reachable_regression_1037() {
+        let db = RootDatabase::default();
+        let rule = NoUnreachableTypesRuleImpl;
+        let schema = "
+            type Cat { meows: Boolean! }
+            type Dog { barks: Boolean! }
+            union Pet = Cat | Dog
+            type Query { pet: Pet }
+        ";
+        let project_files = create_schema_project(&db, schema);
+        let diagnostics = rule.check(&db, project_files, None);
+        let all: Vec<_> = diagnostics.values().flatten().collect();
+        for n in ["Cat", "Dog"] {
+            let hits: Vec<_> = all
+                .iter()
+                .filter(|d| d.message.contains(&format!("`{n}`")))
+                .collect();
+            assert!(
+                hits.is_empty(),
+                "expected union member `{n}` to be reachable, got: {hits:?}"
+            );
+        }
+    }
 }

--- a/test-workspace/lint-examples/schema/noUnreachableTypes.graphql
+++ b/test-workspace/lint-examples/schema/noUnreachableTypes.graphql
@@ -33,3 +33,75 @@ enum Priority {
   MEDIUM
   HIGH
 }
+
+# --- Negative examples (regression coverage for #1037) ---
+# Object types reached only through interface dispatch or union membership
+# must NOT be flagged as unreachable. Clients select them via inline
+# fragments (`... on PhysicalMove { makesContact }`) and the resolver's
+# `__resolveType` hook dispatches to the concrete type.
+
+"""
+A move a Pokemon can use. Reached as an interface return type.
+"""
+interface Move {
+  id: ID!
+}
+
+"""
+Reached only via interface dispatch from `Move`. Should not be flagged.
+"""
+type PhysicalMove implements Move {
+  id: ID!
+  makesContact: Boolean!
+}
+
+"""
+Reached only via interface dispatch from `Move`. Should not be flagged.
+"""
+type SpecialMove implements Move {
+  id: ID!
+  effectChance: Int
+}
+
+"""
+Reached only via interface dispatch from `Move`. Should not be flagged.
+"""
+type StatusMove implements Move {
+  id: ID!
+  inflicts: String
+}
+
+# Extend the root `Query` type so `Pokemon`, `Move`, and `Pet` are reachable
+# from a root operation. Type system extensions cannot carry descriptions;
+# the rationale lives in this comment.
+extend type Query {
+  pokemon: Pokemon
+}
+
+"""
+A Pokemon's move list returns the `Move` interface.
+"""
+type Pokemon {
+  id: ID!
+  moves: [Move!]!
+  pet: Pet
+}
+
+"""
+Reached only via union membership in `Pet`. Should not be flagged.
+"""
+type Cat {
+  meows: Boolean!
+}
+
+"""
+Reached only via union membership in `Pet`. Should not be flagged.
+"""
+type Dog {
+  barks: Boolean!
+}
+
+"""
+A union of pet kinds — clients pick a concrete variant via inline fragments.
+"""
+union Pet = Cat | Dog


### PR DESCRIPTION
## Summary

Pins regression coverage for [#1037](https://github.com/trevor-scheer/graphql-analyzer/issues/1037) (\`no-unreachable-types\` flagging interface implementors and union members as unreachable).

The underlying fix already landed in [#1033](https://github.com/trevor-scheer/graphql-analyzer/pull/1033) — it added the reverse-implementors pass and union-membership traversal that mirror graphql-js \`schema.getImplementations(type)\`. That PR bundled the fix with the full upstream-test port; the issue's exact wording (\`Move\` interface, \`PhysicalMove\` / \`SpecialMove\` / \`StatusMove\` implementors) wasn't pinned as a dedicated test, so this adds it.

## Changes

- Two new unit tests in \`crates/linter/src/rules/no_unreachable_types.rs\`:
  - \`test_interface_implementors_are_reachable_regression_1037\` — verbatim repro from the issue.
  - \`test_union_members_are_reachable_regression_1037\` — companion case (same dispatch mechanism, union variant).
- Extends \`test-workspace/lint-examples/schema/noUnreachableTypes.graphql\` with positive examples: \`Move\` interface + concrete implementors and a \`Pet\` union with \`Cat\` / \`Dog\` members. The existing unreachable demos (\`OrphanedEntity\`, \`Auditable\`, \`Priority\`) stay so the file documents both flagged and non-flagged shapes side-by-side.

## Consulted SME Agents

- N/A — the fix already shipped; this PR is regression coverage and demo refresh.

## Manual Testing Plan

- N/A — covered by the new \`cargo nextest\` cases.

## Related Issues

Closes #1037