### PR TITLE
Document and test SFC host support in ESLint plugin

### DIFF
--- a/.changeset/eslint-plugin-sfc-docs.md
+++ b/.changeset/eslint-plugin-sfc-docs.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-eslint-plugin: patch
+---
+
+Document `.vue`, `.svelte`, and `.astro` host support in the ESLint plugin and add end-to-end tests proving embedded-GraphQL extraction (and autofix range remapping) works for all three SFC formats ([#1036](https://github.com/trevor-scheer/graphql-analyzer/issues/1036))

--- a/.changeset/eslint-plugin-sfc-docs.md
+++ b/.changeset/eslint-plugin-sfc-docs.md
@@ -1,5 +1,5 @@
 ---
-graphql-analyzer-eslint-plugin: patch
+graphql-analyzer-eslint-plugin: minor
 ---
 
 Document `.vue`, `.svelte`, and `.astro` host support in the ESLint plugin and add end-to-end tests proving embedded-GraphQL extraction (and autofix range remapping) works for all three SFC formats ([#1036](https://github.com/trevor-scheer/graphql-analyzer/issues/1036))

--- a/docs/src/content/docs/linting/eslint-plugin.mdx
+++ b/docs/src/content/docs/linting/eslint-plugin.mdx
@@ -38,7 +38,7 @@ import graphql from "@graphql-analyzer/eslint-plugin";
 
 export default [
   // 1. Lint `.graphql` files directly. This block also handles the virtual
-  //    `.graphql` blocks the processor extracts from JS/TS hosts (block
+  //    `.graphql` blocks the processor extracts from JS/TS/SFC hosts (block
   //    paths look like `path/to/component.tsx/0_document.graphql`).
   {
     files: ["**/*.graphql"],
@@ -54,11 +54,12 @@ export default [
       "@graphql-analyzer/no-hashtag-description": "warn",
     },
   },
-  // 2. Wire the named processor onto JS/TS-family hosts. Embedded
-  //    `gql`-tagged templates get extracted into virtual blocks that flow
-  //    back through the `.graphql` block above.
+  // 2. Wire the named processor onto every host extension that may carry
+  //    embedded GraphQL. Vue, Svelte, and Astro files are supported by the
+  //    native extractor — list their extensions here alongside JS/TS so the
+  //    processor sees them.
   {
-    files: ["**/*.{js,jsx,mjs,cjs}"],
+    files: ["**/*.{js,jsx,mjs,cjs,ts,tsx,vue,svelte,astro}"],
     plugins: {
       "@graphql-analyzer": graphql,
     },
@@ -67,37 +68,76 @@ export default [
 ];
 ```
 
-The native addon detects embedded GraphQL in JavaScript, TypeScript, Vue,
-Svelte, and Astro files. Diagnostics are reported at their original
-source position so `gql` tagged templates don't need a separate file.
+The native addon detects embedded GraphQL in JavaScript, TypeScript, Vue
+single-file components, Svelte components, and Astro components.
+Diagnostics are reported at their original source position so `gql` tagged
+templates don't need a separate file.
 
-### TypeScript / Vue / Svelte / Astro hosts
+### Embedded extraction matrix
 
-ESLint's default parser (espree) can't parse TypeScript, JSX, Vue SFCs,
-Svelte components, or Astro components, so a fatal parse error on the host
-file would otherwise drop our embedded diagnostics. Add a parser for
-those hosts in a separate config block:
+| Extension                     | What gets scanned                                    | Host parser you'll likely want                                             |
+| ----------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| `.js`, `.jsx`, `.mjs`, `.cjs` | The whole file                                       | None (espree, ESLint's default, handles it)                                |
+| `.ts`, `.tsx`                 | The whole file                                       | [`@typescript-eslint/parser`](https://typescript-eslint.io/)               |
+| `.vue`                        | All `<script>` and `<script setup>` blocks           | [`vue-eslint-parser`](https://github.com/vuejs/vue-eslint-parser)          |
+| `.svelte`                     | All `<script>` blocks (including `context="module"`) | [`svelte-eslint-parser`](https://github.com/sveltejs/svelte-eslint-parser) |
+| `.astro`                      | The frontmatter (between `---` fences)               | [`astro-eslint-parser`](https://github.com/ota-meshi/astro-eslint-parser)  |
+
+The `lang` attribute on `<script>` tags is honored — `lang="ts"` is parsed
+as TypeScript, anything else as JavaScript. Astro frontmatter is always
+TypeScript per Astro's own conventions.
+
+### Host parsers for non-JS files
+
+ESLint's default parser (espree) only understands JavaScript. Without a host
+parser configured, ESLint reports a fatal "Parsing error" on the host file
+itself, which sits alongside the GraphQL diagnostics from the processor.
+The embedded GraphQL is still linted — but you'll usually want a real host
+parser so the rest of your ESLint config (TypeScript rules, framework rules,
+etc.) can run too. Add one in a separate config block per host:
 
 ```js
+import graphql from "@graphql-analyzer/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
+import vueParser from "vue-eslint-parser";
+import svelteParser from "svelte-eslint-parser";
+import astroParser from "astro-eslint-parser";
 
 export default [
-  /* ...graphql + processor blocks above... */
+  // GraphQL block + processor block (see "Usage" above).
+  /* ... */
+
+  // Host parsers — match each extension to the parser that understands it.
+  // The processor still does the embedded extraction; these blocks just give
+  // ESLint a working host AST so the rest of your config has something to
+  // run against.
   {
     files: ["**/*.{ts,tsx}"],
     languageOptions: { parser: tsParser },
   },
   {
-    files: ["**/*.{ts,tsx}"],
-    plugins: { "@graphql-analyzer": graphql },
-    processor: "@graphql-analyzer/graphql",
+    files: ["**/*.vue"],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: { parser: tsParser },
+    },
+  },
+  {
+    files: ["**/*.svelte"],
+    languageOptions: {
+      parser: svelteParser,
+      parserOptions: { parser: tsParser },
+    },
+  },
+  {
+    files: ["**/*.astro"],
+    languageOptions: { parser: astroParser },
   },
 ];
 ```
 
-Same shape for `.vue`, `.svelte`, and `.astro` — pair the host's parser
-with the processor block. We intentionally don't bundle these parsers; pick
-the one that already matches the rest of your project's ESLint config.
+We intentionally don't bundle these parsers — pick the ones that already
+match the rest of your project's ESLint config.
 
 ## Configuration
 

--- a/packages/eslint-plugin/test/integration.test.mjs
+++ b/packages/eslint-plugin/test/integration.test.mjs
@@ -210,6 +210,141 @@ test("fires no-anonymous-operations on embedded GraphQL in .js", async () => {
   assert.ok(diags[0].line >= 3, `expected embedded position remap; got line ${diags[0].line}`);
 });
 
+// SFC formats (`.vue`, `.svelte`, `.astro`) flow through the same processor
+// path. The host parse via espree will fail (espree can't parse SFC syntax)
+// and surface a fatal "Parsing error" diagnostic, but that's separate from
+// the GraphQL extraction we care about here — filtering to
+// `@graphql-analyzer/*` rule ids isolates the embedded-GraphQL contract.
+// Users in real projects pair these blocks with the matching SFC parser
+// (`vue-eslint-parser`, `svelte-eslint-parser`, `astro-eslint-parser`); we
+// don't take a devDep on those here just to assert the extraction works.
+//
+// These tests sit BEFORE the multi-project test below because the addon's
+// `init()` is global and the multi-project test points it at a tmpdir
+// that's torn down after the test — leaving the in-memory analyzer state
+// pointing at a path that no longer exists. Running our SFC checks first
+// keeps us on the eslint-migration `.graphqlrc.yaml` (which has the rules
+// we depend on enabled) for the duration of this assertion.
+function sfcLinter() {
+  return new ESLint({
+    overrideConfigFile: true,
+    cwd: fixtureRoot,
+    overrideConfig: [
+      {
+        files: ["**/*.graphql"],
+        languageOptions: { parser: plugin.parser },
+        plugins: { "@graphql-analyzer": plugin },
+        rules: {
+          "@graphql-analyzer/no-anonymous-operations": "error",
+        },
+      },
+      {
+        files: ["**/*.{vue,svelte,astro}"],
+        plugins: { "@graphql-analyzer": plugin },
+        processor: "@graphql-analyzer/graphql",
+      },
+    ],
+  });
+}
+
+test("fires no-anonymous-operations on embedded GraphQL in .vue", async () => {
+  const results = await sfcLinter().lintFiles(["src/component.vue"]);
+  const diags = results[0].messages.filter(
+    (m) => m.ruleId === "@graphql-analyzer/no-anonymous-operations",
+  );
+  assert.ok(
+    diags.length >= 1,
+    `expected ≥1 no-anonymous-operations diagnostic in component.vue; got ${diags.length}\n` +
+      `messages: ${JSON.stringify(results[0].messages, null, 2)}`,
+  );
+  // The anonymous `query` token sits on line 5 of the host; remap should
+  // place the diagnostic at or after that line.
+  assert.ok(diags[0].line >= 4, `expected line remap into <script>; got line ${diags[0].line}`);
+});
+
+test("fires no-anonymous-operations on embedded GraphQL in .svelte", async () => {
+  const results = await sfcLinter().lintFiles(["src/component.svelte"]);
+  const diags = results[0].messages.filter(
+    (m) => m.ruleId === "@graphql-analyzer/no-anonymous-operations",
+  );
+  assert.ok(
+    diags.length >= 1,
+    `expected ≥1 no-anonymous-operations diagnostic in component.svelte; got ${diags.length}\n` +
+      `messages: ${JSON.stringify(results[0].messages, null, 2)}`,
+  );
+  assert.ok(diags[0].line >= 4, `expected line remap into <script>; got line ${diags[0].line}`);
+});
+
+test("fires no-anonymous-operations on embedded GraphQL in .astro", async () => {
+  const results = await sfcLinter().lintFiles(["src/page.astro"]);
+  const diags = results[0].messages.filter(
+    (m) => m.ruleId === "@graphql-analyzer/no-anonymous-operations",
+  );
+  assert.ok(
+    diags.length >= 1,
+    `expected ≥1 no-anonymous-operations diagnostic in page.astro; got ${diags.length}\n` +
+      `messages: ${JSON.stringify(results[0].messages, null, 2)}`,
+  );
+  // Anonymous `query` in the frontmatter sits on line 5 of the host.
+  assert.ok(diags[0].line >= 4, `expected line remap into frontmatter; got line ${diags[0].line}`);
+});
+
+// SFC autofix: prove fix-range remapping works through the SFC byte offset.
+// Uses `alphabetize` (one of the rules with full autofix support) inside a
+// Svelte `<script>` block — applying `--fix` should reorder the fields
+// inside the gql template without disturbing the surrounding markup.
+test("autofix remaps fix range correctly in .svelte host", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "sfc-fix-"));
+  try {
+    writeFileSync(path.join(root, ".graphqlrc.yaml"), 'schema: "schema.graphql"\n');
+    writeFileSync(
+      path.join(root, "schema.graphql"),
+      "type Query { user(id: ID!): User }\ntype User { id: ID! name: String email: String }\n",
+    );
+    const before =
+      `<script lang="ts">\n` +
+      `  import { gql } from "graphql-tag";\n` +
+      `  const Q = gql\`query GetUser { user(id: "1") { name id } }\`;\n` +
+      `</script>\n` +
+      `<p>hi</p>\n`;
+    writeFileSync(path.join(root, "Test.svelte"), before);
+
+    const eslint = new ESLint({
+      overrideConfigFile: true,
+      cwd: root,
+      fix: true,
+      overrideConfig: [
+        {
+          files: ["**/*.graphql"],
+          languageOptions: { parser: plugin.parser },
+          plugins: { "@graphql-analyzer": plugin },
+          rules: {
+            "@graphql-analyzer/alphabetize": ["error", { selections: ["OperationDefinition"] }],
+          },
+        },
+        {
+          files: ["**/*.svelte"],
+          plugins: { "@graphql-analyzer": plugin },
+          processor: "@graphql-analyzer/graphql",
+        },
+      ],
+    });
+    const [result] = await eslint.lintFiles(["Test.svelte"]);
+    // ESLint only sets `output` when at least one fix was applied.
+    assert.ok(result.output, "expected SFC autofix to produce output");
+    assert.match(
+      result.output,
+      /id name/,
+      `alphabetize should reorder the gql body fields in-place; got:\n${result.output}`,
+    );
+    // Markup outside the <script> block must be left untouched.
+    assert.match(result.output, /<p>hi<\/p>/);
+    assert.match(result.output, /<\/script>/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 // Multi-project `.graphqlrc.yaml`: two projects in the same workspace,
 // each with its own schema and `lint.rules` block. The plugin must route
 // each file to the matching project so the per-project lint config takes
@@ -291,10 +426,10 @@ test("multi-project .graphqlrc routes files to matching project", async () => {
   }
 });
 
-// `.tsx`/`.ts`/`.vue`/`.svelte` extraction goes through the same processor
-// path verified by the `.js` test above, but ESLint can't lint the host
-// source without a parser that understands the host's syntax (espree can't
-// parse JSX/TS). Users must wire e.g. `@typescript-eslint/parser` in a
-// matching config block; that's a host-side concern documented in
+// `.tsx`/`.ts` extraction goes through the same processor path verified by
+// the `.js` test above, but ESLint can't lint the host source without a
+// parser that understands the host's syntax (espree can't parse JSX/TS).
+// Users must wire e.g. `@typescript-eslint/parser` in a matching config
+// block; that's a host-side concern documented in
 // `docs/.../eslint-plugin.mdx`. We don't add a devDep on
 // `@typescript-eslint/parser` here just to assert that.

--- a/test-workspace/eslint-migration/README.md
+++ b/test-workspace/eslint-migration/README.md
@@ -46,3 +46,6 @@ documents intentional gaps.
 | `schema.graphql`           | Sample schema with intentional lint issues |
 | `src/operations.graphql`   | Sample operations with lint issues         |
 | `src/component.tsx`        | Embedded GraphQL in TypeScript             |
+| `src/component.vue`        | Embedded GraphQL in a Vue SFC `<script>`   |
+| `src/component.svelte`     | Embedded GraphQL in a Svelte `<script>`    |
+| `src/page.astro`           | Embedded GraphQL in Astro frontmatter      |

--- a/test-workspace/eslint-migration/src/component.svelte
+++ b/test-workspace/eslint-migration/src/component.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { gql } from "graphql-tag";
+
+  const GET_USER = gql`
+    query {
+      user(id: "1") {
+        name
+      }
+    }
+  `;
+</script>
+
+<p>{GET_USER}</p>

--- a/test-workspace/eslint-migration/src/component.vue
+++ b/test-workspace/eslint-migration/src/component.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { gql } from "graphql-tag";
+
+const GET_USER = gql`
+  query {
+    user(id: "1") {
+      name
+    }
+  }
+`;
+</script>
+
+<template>
+  <div>{{ GET_USER }}</div>
+</template>

--- a/test-workspace/eslint-migration/src/page.astro
+++ b/test-workspace/eslint-migration/src/page.astro
@@ -1,0 +1,17 @@
+---
+import { gql } from "graphql-tag";
+
+const GET_USER = gql`
+  query {
+    user(id: "1") {
+      name
+    }
+  }
+`;
+---
+
+<html>
+  <body>
+    <pre>{GET_USER}</pre>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

[#1036](https://github.com/trevor-scheer/graphql-analyzer/issues/1036) reports that the ESLint plugin's processor doesn't extract embedded GraphQL from `.svelte` / `.vue` / `.astro` host files. Investigation found that the underlying support is **already complete** — `crates/extract` parses Vue and Svelte SFC `<script>` blocks and Astro frontmatter, the napi binding maps each extension to the right `Language`, and the processor's `LANG_BY_EXT` already wires `.vue` / `.svelte` / `.astro` to those identifiers. The friction is purely surface-level: the docs only mention SFC support in passing, and the example config in `Usage` only lists JS/TS extensions in the processor's `files` glob, so a user copy-pasting it doesn't get SFC coverage.

This PR closes the gap with documentation and tests rather than code changes to the extraction path.

## Changes

- Add SFC fixtures (`component.vue`, `component.svelte`, `page.astro`) to the `eslint-migration` test workspace, each carrying an anonymous `gql`-tagged query so rule tests have a real on-disk file to lint
- Add four new ESLint integration tests covering end-to-end extraction through the processor for each SFC format, plus an autofix test that exercises the SFC byte-offset path via `alphabetize` inside a Svelte `<script>` block
- Restructure `docs/src/content/docs/linting/eslint-plugin.mdx`:
  - Bake `vue,svelte,astro` into the `Usage` example's processor `files` glob
  - Add an "Embedded extraction matrix" table mapping each extension to what gets scanned and which host parser pairs with it
  - Replace the brief TS/Vue/Svelte/Astro paragraph with a complete copy-pasteable host-parser config covering all four
- Add a patch changeset for `@graphql-analyzer/eslint-plugin`

## Consulted SME Agents

- N/A — surface-level fix; investigation confirmed `crates/extract`, `crates/napi`, and the existing processor all already speak SFC.

## Manual Testing Plan

- `npm run build:debug --workspace=@graphql-analyzer/core && npm run build --workspace=@graphql-analyzer/eslint-plugin`
- `cd packages/eslint-plugin && npm run test:unit` — confirm the four new SFC tests pass
- Open `test-workspace/eslint-migration/src/component.{vue,svelte}` and `page.astro` and confirm the `gql` template body extraction looks right against the docs claim
- Try the docs config in a real Vue / Svelte / Astro project to confirm the host-parser advice works end-to-end

## Scope notes

- Test pollution: the existing `multi-project .graphqlrc routes files to matching project` test fails before and after this change. The native addon's `init()` is global and the multi-project test points it at a tmpdir that's torn down after the test, leaving the in-memory analyzer state pointing at a path that no longer exists. New SFC tests deliberately sit before that test in `integration.test.mjs` so they run against the still-valid `eslint-migration` config. The underlying global-state bug is out of scope here — worth a separate issue if not already tracked.
- ESLint host parsing for SFC: with no host parser configured, ESLint emits a fatal `Parsing error` on the host file alongside our GraphQL diagnostics. The new docs section calls this out and shows how to wire `vue-eslint-parser` / `svelte-eslint-parser` / `astro-eslint-parser`. We intentionally don't take a devDep on these parsers in `packages/eslint-plugin`.

## Related Issues

Closes #1036.