### PR TITLE
Align `dogfood-testbed` with current testbed structure

### DIFF
--- a/.github/workflows/dogfood-testbed.yml
+++ b/.github/workflows/dogfood-testbed.yml
@@ -112,7 +112,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           graphql --version
 
-      - name: Run testbed CI (lint + typecheck + build + test)
+      - name: Run testbed CI (lint + typecheck)
         working-directory: testbed
         run: |
           # The released binary is installed on PATH as `graphql` (see prior
@@ -125,9 +125,16 @@ jobs:
           # --project web`.
           graphql check --project web
           pnpm lint
-          pnpm --filter @analyzer-testbed/web prisma generate
-          pnpm tsc --noEmit --project tsconfig.json 2>/dev/null || \
-            pnpm -r exec tsc --noEmit
+          # Mirror the testbed's own CI script names rather than guessing.
+          # `apps/web` exposes Prisma codegen as `db:generate` (not `prisma`)
+          # and its tsc invocation as `tsc` (not `typecheck`). Examples expose
+          # `typecheck`. Relay needs its compiler to run first so generated
+          # artifacts exist before tsc sees them. The testbed has no root
+          # `tsconfig.json`; per-package typechecks are the source of truth.
+          pnpm --filter @analyzer-testbed/web db:generate
+          pnpm --filter @analyzer-testbed/web tsc
+          pnpm --filter @analyzer-testbed/example-relay relay
+          pnpm -r --if-present run typecheck
 
       - name: Run expect-failure fixtures
         working-directory: testbed


### PR DESCRIPTION
## Summary

After release `v0.2.4` the `dogfood-testbed` workflow surfaced three independent breakages in the `Run testbed CI` step (#1056). `graphql check --project web` succeeded; the steps after it had drifted from the testbed's actual shape.

## Changes

- Replace `pnpm --filter @analyzer-testbed/web prisma generate` with `db:generate` — the testbed exposes Prisma codegen under that script name, not `prisma`.
- Drop the `pnpm tsc --noEmit --project tsconfig.json || pnpm -r exec tsc --noEmit` fallback. The testbed has no root `tsconfig.json`, and `pnpm -r exec tsc` bypassed package-specific prerequisites (Prisma codegen, relay-compiler) and ran tsc against packages with no `typecheck` script.
- Mirror the testbed's own CI: run `apps/web` `tsc` after `db:generate`, run `relay-compiler` for `examples/relay-app` before typechecking, then `pnpm -r --if-present run typecheck` for everything that exposes one.

The `examples/mocks` package was missing `@types/node`, so `btoa` failed to type-resolve. That is fixed in [trevor-scheer/analyzer-testbed#11](https://github.com/trevor-scheer/analyzer-testbed/pull/11), which also adds a `typecheck` script so the package is exercised by the new `pnpm -r --if-present run typecheck` invocation here.

## Consulted SME Agents

- N/A (CI/workflow drift)

## Manual Testing Plan

End-to-end verification only happens on the next real release (this workflow is `workflow_run`-triggered against the `Release` workflow). The full step sequence was reproduced locally against a fresh `analyzer-testbed` clone with the released `graphql-cli` and the testbed PR's `mocks` fix applied — every command exits 0.

## Related Issues

Fixes #1056. Depends on [trevor-scheer/analyzer-testbed#11](https://github.com/trevor-scheer/analyzer-testbed/pull/11) being merged before the next release for the typecheck step to pass against `examples/mocks`.