### PR TITLE
Add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,43 @@ jobs:
       - name: Check workspace
         run: cargo check --workspace --all-features --verbose
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        run: rustup show
+
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "ci-coverage"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@e537394e10461340f56469a03c3e73f1705074a9 # nextest
+        with:
+          tool: nextest
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov nextest --workspace --all-features --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   dogfood:
     name: Dogfood GraphQL Check
     needs: [build]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true
+
+ignore:
+  - "benches/**"
+  - "xtask/**"
+  - "crates/test-utils/**"
+  - "crates/lsp-wasm/**"
+  - "**/tests/**"


### PR DESCRIPTION
## Summary

Wires up Codecov for the Rust workspace using `cargo-llvm-cov` + `cargo-nextest`. Coverage reporting is intentionally non-blocking — status checks are `informational` and the job is excluded from the `ci-success` aggregator, so coverage drops surface in PR comments but never fail merges.

## Changes

- New `coverage` job in `.github/workflows/ci.yml` (Ubuntu only) that runs `cargo llvm-cov nextest --workspace --all-features --lcov` and uploads to Codecov via `codecov/codecov-action@v5`. `fail_ci_if_error: false` so flaky uploads don't break CI.
- New `codecov.yml` with `informational: true` on both `project` and `patch` statuses, plus an `ignore` list for `benches/`, `xtask/`, `crates/test-utils/`, `crates/lsp-wasm/`, and `**/tests/**`.
- All actions SHA-pinned to match the existing workflow style.

## Consulted SME Agents

- N/A — CI infrastructure change

## Manual Testing Plan

- After merge, open a follow-up PR and confirm the Codecov bot comments with a coverage diff
- Verify the `Coverage` job appears in the CI run and uploads `lcov.info` successfully
- Confirm the `Coverage` check does not appear as a required status (it is excluded from `ci-success`)

## Related Issues

N/A