### PR TITLE
Stop dogfood-regression issue spam, warn on misnamespaced lint config

### DIFF
--- a/.changeset/dogfood-rolling-issue.md
+++ b/.changeset/dogfood-rolling-issue.md
@@ -1,0 +1,5 @@
+---
+graphql-analyzer-cli: patch
+---
+
+Surface a `misnamespaced-extension` warning when an analyzer-specific config key (`lint`, `client`, `extractConfig`, `resolvedSchema`) appears at the top of `extensions:` rather than under `extensions.graphql-analyzer.*`. Previously the loader silently ignored these blocks, masking the misconfiguration entirely. Also flags the legacy camelCase `graphqlAnalyzer:` namespace key. The CLI prints these warnings up-front from `graphql check`, `graphql lint`, and other commands; the LSP surfaces them as config-file diagnostics.

--- a/.github/workflows/dogfood-testbed.yml
+++ b/.github/workflows/dogfood-testbed.yml
@@ -1,7 +1,8 @@
 # dogfood-testbed.yml
 # Triggered after a successful release of graphql-analyzer. Clones
 # analyzer-testbed, bumps all @graphql-analyzer/* deps to the just-released
-# versions, runs the full testbed CI matrix, and opens an issue on failure.
+# versions, runs the full testbed CI matrix, and on failure opens or updates
+# a single rolling issue (one comment per release, deduped by exact title).
 #
 # Trigger: workflow_run watching "Release" — fires only on success, so we
 # don't spam the testbed with every draft or failed attempt.
@@ -151,27 +152,55 @@ jobs:
           fail_if_passes fixture-deprecated-field-usage
           fail_if_passes fixture-selection-type-mismatch
 
-      - name: Open issue on failure
+      - name: Open or update rolling failure issue
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: trevor-scheer/graphql-analyzer
+          TITLE: "Dogfood regression: testbed CI failed after release"
+          RELEASE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          DOGFOOD_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CORE_VERSION: ${{ steps.versions.outputs.core_version }}
+          ESLINT_VERSION: ${{ steps.versions.outputs.eslint_version }}
+          CLI_VERSION: ${{ steps.versions.outputs.cli_version }}
         run: |
-          gh issue create \
-            --repo trevor-scheer/graphql-analyzer \
-            --title "Dogfood regression: testbed CI failed after release" \
-            --label "bug,regression" \
-            --body "$(cat <<'BODY'
+          # Single rolling issue: find an open one with this exact title and
+          # append a comment with the latest run details. Only fall through to
+          # `gh issue create` when none exists.
+          BODY="$(cat <<BODY
           The **analyzer-testbed** CI failed after a release of graphql-analyzer.
 
-          **Triggered by release run:** ${{ github.event.workflow_run.html_url }}
+          **Triggered by release run:** ${RELEASE_RUN_URL}
 
           **Versions under test:**
-          - \`@graphql-analyzer/core\`: ${{ steps.versions.outputs.core_version }}
-          - \`@graphql-analyzer/eslint-plugin\`: ${{ steps.versions.outputs.eslint_version }}
-          - \`graphql-cli\`: ${{ steps.versions.outputs.cli_version }}
+          - \`@graphql-analyzer/core\`: ${CORE_VERSION}
+          - \`@graphql-analyzer/eslint-plugin\`: ${ESLINT_VERSION}
+          - \`graphql-cli\`: ${CLI_VERSION}
 
-          **Dogfood CI run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Dogfood CI run:** ${DOGFOOD_RUN_URL}
 
           Please investigate before the next release. The testbed CI log (linked above) has the full failure output.
           BODY
           )"
+
+          # `--search` matches title text; filter to exact-title open issues so
+          # near-misses (e.g. user-edited titles) don't suppress new reports.
+          EXISTING="$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --label regression \
+            --search "in:title \"$TITLE\"" \
+            --json number,title \
+            --jq "[.[] | select(.title == \"$TITLE\")] | first | .number // empty")"
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+          else
+            echo "No existing rolling issue found; creating one"
+            gh issue create \
+              --repo "$REPO" \
+              --title "$TITLE" \
+              --label "bug,regression" \
+              --body "$BODY"
+          fi

--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -1,7 +1,10 @@
 use crate::ExitCode;
 use anyhow::{Context, Result};
 use colored::Colorize;
-use graphql_config::{find_config, load_config, GraphQLConfig, ProjectConfig, CONFIG_FILES};
+use graphql_config::{
+    extension_namespace_warnings, find_config, load_config, GraphQLConfig, ProjectConfig,
+    CONFIG_FILES,
+};
 use std::path::PathBuf;
 
 /// Common context for all CLI commands that require config and project selection
@@ -57,6 +60,15 @@ documents: \"src/**/*.graphql\"",
         };
 
         let config = load_config(&config_path).context("Failed to load config")?;
+
+        // Surface silent-config-drop warnings (e.g. `extensions.lint:` placed
+        // outside the `graphql-analyzer:` namespace, which the loader ignores
+        // without complaint). The full file/lint validators run later in the
+        // pipeline; we deliberately only print the namespacing warning here so
+        // we don't double-report errors that downstream code will also surface.
+        for warning in extension_namespace_warnings(&config) {
+            eprintln!("{} {}", "warning:".yellow().bold(), warning.message());
+        }
 
         // Validate project requirement for multi-project configs.
         // Special case: Allow omitting --project if there's a "default" project,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -13,5 +13,6 @@ pub use env::{interpolate_env_vars, EnvInterpolationError};
 pub use error::{ConfigError, Result};
 pub use loader::{find_config, load_config, load_config_from_str, CONFIG_FILES};
 pub use validation::{
-    validate, ConfigValidationError, FileType, LintValidationContext, Location, Severity,
+    extension_namespace_warnings, validate, ConfigValidationError, FileType, LintValidationContext,
+    Location, Severity,
 };

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -1353,7 +1353,7 @@ projects:
         assert_eq!(loc.line, 4);
     }
 
-    fn project_with_extensions(ext: serde_json::Value) -> ProjectConfig {
+    fn project_with_extensions(ext: &serde_json::Value) -> ProjectConfig {
         let map: StdHashMap<String, serde_json::Value> = ext
             .as_object()
             .expect("extensions must be an object")
@@ -1369,7 +1369,7 @@ projects:
         )
     }
 
-    fn single_project_config(ext: serde_json::Value) -> GraphQLConfig {
+    fn single_project_config(ext: &serde_json::Value) -> GraphQLConfig {
         let mut projects = std::collections::HashMap::new();
         projects.insert("myapp".to_string(), project_with_extensions(ext));
         GraphQLConfig::Multi { projects }
@@ -1377,7 +1377,7 @@ projects:
 
     #[test]
     fn test_misnamespaced_lint_at_extensions_root() {
-        let config = single_project_config(serde_json::json!({
+        let config = single_project_config(&serde_json::json!({
             "lint": { "rules": { "no-deprecated": "error" } }
         }));
 
@@ -1395,7 +1395,7 @@ projects:
 
     #[test]
     fn test_misnamespaced_camelcase_namespace_key() {
-        let config = single_project_config(serde_json::json!({
+        let config = single_project_config(&serde_json::json!({
             "graphqlAnalyzer": { "lint": "recommended" }
         }));
 
@@ -1412,7 +1412,7 @@ projects:
 
     #[test]
     fn test_correctly_namespaced_extension_is_silent() {
-        let config = single_project_config(serde_json::json!({
+        let config = single_project_config(&serde_json::json!({
             "graphql-analyzer": { "lint": "recommended" }
         }));
 
@@ -1424,7 +1424,7 @@ projects:
     fn test_unrelated_extensions_are_not_flagged() {
         // Other tools (codegen, endpoints) live at the root of `extensions:`
         // — we must not warn on those, only on analyzer-specific keys.
-        let config = single_project_config(serde_json::json!({
+        let config = single_project_config(&serde_json::json!({
             "endpoints": { "default": "https://example.com/graphql" },
             "codegen": { "generates": {} }
         }));

--- a/crates/config/src/validation.rs
+++ b/crates/config/src/validation.rs
@@ -106,6 +106,18 @@ pub enum ConfigValidationError {
     },
     /// The resolved schema file was not found on disk.
     ResolvedSchemaNotFound { project: String, path: String },
+    /// An analyzer-specific extension key (`lint`, `client`, `extractConfig`,
+    /// `resolvedSchema`) appeared at the top of `extensions:` instead of
+    /// nested under the `graphql-analyzer:` namespace, so the analyzer
+    /// silently ignores it. Also fires for the legacy camelCase
+    /// `graphqlAnalyzer:` namespace key.
+    MisnamespacedExtension {
+        project: String,
+        /// The actual key the user wrote (e.g. `lint`, `graphqlAnalyzer`).
+        key: String,
+        /// The corrected nesting the user should write instead.
+        suggestion: String,
+    },
 }
 
 impl ConfigValidationError {
@@ -120,6 +132,7 @@ impl ConfigValidationError {
             Self::UnknownLintRule { .. } => "unknown-lint-rule",
             Self::UnknownPreset { .. } => "unknown-preset",
             Self::ResolvedSchemaNotFound { .. } => "resolved-schema-not-found",
+            Self::MisnamespacedExtension { .. } => "misnamespaced-extension",
         }
     }
 
@@ -129,7 +142,8 @@ impl ConfigValidationError {
         match self {
             Self::UnmatchedPattern { .. }
             | Self::NoFilesFound { .. }
-            | Self::ResolvedSchemaNotFound { .. } => Severity::Warning,
+            | Self::ResolvedSchemaNotFound { .. }
+            | Self::MisnamespacedExtension { .. } => Severity::Warning,
             Self::OverlappingPattern { .. }
             | Self::ContentMismatch { .. }
             | Self::UnknownLintRule { .. }
@@ -207,6 +221,14 @@ impl ConfigValidationError {
             Self::ResolvedSchemaNotFound { path, .. } => {
                 format!("Resolved schema file not found: '{path}'")
             }
+            Self::MisnamespacedExtension {
+                key, suggestion, ..
+            } => {
+                format!(
+                    "`extensions.{key}` is ignored — graphql-analyzer reads its config from \
+                    the `graphql-analyzer` namespace. Move it under `extensions.{suggestion}`."
+                )
+            }
         }
     }
 
@@ -237,6 +259,9 @@ impl ConfigValidationError {
             Self::ResolvedSchemaNotFound { path, .. } => {
                 find_pattern_location(config_content, path, 0)
             }
+            Self::MisnamespacedExtension { key, .. } => {
+                find_pattern_location(config_content, &format!("{key}:"), 0)
+            }
         }
     }
 }
@@ -258,8 +283,54 @@ pub fn validate(
     errors.extend(validate_file_uniqueness(config, workspace_path));
     errors.extend(validate_unmatched_patterns(config, workspace_path));
     errors.extend(validate_resolved_schema(config, workspace_path));
+    errors.extend(validate_extension_namespace(config));
     if let Some(ctx) = lint_context {
         errors.extend(validate_lint_config(config, ctx));
+    }
+    errors
+}
+
+/// Catch the common mistake of putting analyzer-specific config (`lint`,
+/// `client`, `extractConfig`, `resolvedSchema`) at the top of `extensions:`
+/// instead of nested under `graphql-analyzer:`. graphql-config namespaces
+/// extensions per tool, so an unscoped `lint:` block is silently ignored.
+/// Also flags the legacy camelCase `graphqlAnalyzer:` key.
+///
+/// Public so the CLI can surface these warnings up-front without triggering
+/// the full filesystem-traversing validator.
+#[must_use]
+pub fn extension_namespace_warnings(config: &GraphQLConfig) -> Vec<ConfigValidationError> {
+    validate_extension_namespace(config)
+}
+
+fn validate_extension_namespace(config: &GraphQLConfig) -> Vec<ConfigValidationError> {
+    // Keys that are uniquely meaningful to this tool. If a user writes them at
+    // the top level of `extensions:` they almost certainly meant to nest them
+    // under `graphql-analyzer:`. Generic graphql-config keys (e.g. `endpoints`,
+    // `codegen`) are intentionally not in this list.
+    const ANALYZER_KEYS: &[&str] = &["lint", "client", "extractConfig", "resolvedSchema"];
+
+    let mut errors = Vec::new();
+    for (project_name, project_config) in config.projects() {
+        let Some(ext) = &project_config.extensions else {
+            continue;
+        };
+
+        for key in ext.keys() {
+            if key == "graphqlAnalyzer" {
+                errors.push(ConfigValidationError::MisnamespacedExtension {
+                    project: project_name.to_string(),
+                    key: key.clone(),
+                    suggestion: "graphql-analyzer".to_string(),
+                });
+            } else if ANALYZER_KEYS.contains(&key.as_str()) {
+                errors.push(ConfigValidationError::MisnamespacedExtension {
+                    project: project_name.to_string(),
+                    key: key.clone(),
+                    suggestion: format!("graphql-analyzer.{key}"),
+                });
+            }
+        }
     }
     errors
 }
@@ -1280,5 +1351,85 @@ projects:
         assert!(loc.is_some());
         let loc = loc.unwrap();
         assert_eq!(loc.line, 4);
+    }
+
+    fn project_with_extensions(ext: serde_json::Value) -> ProjectConfig {
+        let map: StdHashMap<String, serde_json::Value> = ext
+            .as_object()
+            .expect("extensions must be an object")
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        ProjectConfig::new(
+            SchemaConfig::Path("schema.graphql".to_string()),
+            None,
+            None,
+            None,
+            Some(map),
+        )
+    }
+
+    fn single_project_config(ext: serde_json::Value) -> GraphQLConfig {
+        let mut projects = std::collections::HashMap::new();
+        projects.insert("myapp".to_string(), project_with_extensions(ext));
+        GraphQLConfig::Multi { projects }
+    }
+
+    #[test]
+    fn test_misnamespaced_lint_at_extensions_root() {
+        let config = single_project_config(serde_json::json!({
+            "lint": { "rules": { "no-deprecated": "error" } }
+        }));
+
+        let errors = validate_extension_namespace(&config);
+        assert_eq!(errors.len(), 1);
+        let err = &errors[0];
+        assert_eq!(err.code(), "misnamespaced-extension");
+        assert_eq!(err.severity(), Severity::Warning);
+        assert!(
+            err.message().contains("graphql-analyzer.lint"),
+            "expected suggestion to point at `graphql-analyzer.lint`, got: {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn test_misnamespaced_camelcase_namespace_key() {
+        let config = single_project_config(serde_json::json!({
+            "graphqlAnalyzer": { "lint": "recommended" }
+        }));
+
+        let errors = validate_extension_namespace(&config);
+        assert_eq!(errors.len(), 1);
+        let err = &errors[0];
+        assert_eq!(err.code(), "misnamespaced-extension");
+        assert!(
+            err.message().contains("graphql-analyzer"),
+            "expected suggestion to recommend `graphql-analyzer`, got: {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn test_correctly_namespaced_extension_is_silent() {
+        let config = single_project_config(serde_json::json!({
+            "graphql-analyzer": { "lint": "recommended" }
+        }));
+
+        let errors = validate_extension_namespace(&config);
+        assert!(errors.is_empty(), "expected no warnings, got: {errors:?}");
+    }
+
+    #[test]
+    fn test_unrelated_extensions_are_not_flagged() {
+        // Other tools (codegen, endpoints) live at the root of `extensions:`
+        // — we must not warn on those, only on analyzer-specific keys.
+        let config = single_project_config(serde_json::json!({
+            "endpoints": { "default": "https://example.com/graphql" },
+            "codegen": { "generates": {} }
+        }));
+
+        let errors = validate_extension_namespace(&config);
+        assert!(errors.is_empty(), "expected no warnings, got: {errors:?}");
     }
 }

--- a/crates/linter/CLAUDE.md
+++ b/crates/linter/CLAUDE.md
@@ -14,18 +14,26 @@ Rules live in `src/rules/`. Each rule is a separate module.
 
 ## Configuration
 
-Lint config uses `extensions.lint` in `.graphqlrc.yaml` with camelCase rule names:
+Lint config lives under the `graphql-analyzer` extension namespace in
+`.graphqlrc.yaml`, and uses camelCase rule names:
 
 ```yaml
 extensions:
-  lint: recommended # Happy path - just use preset
+  graphql-analyzer:
+    lint: recommended # Happy path - just use preset
 ```
 
 Or configure individual rules:
 
 ```yaml
 extensions:
-  lint:
-    noAnonymousOperations: error
-    noDeprecated: warn
+  graphql-analyzer:
+    lint:
+      rules:
+        noAnonymousOperations: error
+        noDeprecated: warn
 ```
+
+Putting the `lint:` block at the top of `extensions:` (without the
+`graphql-analyzer:` namespace) is silently ignored by the loader — the
+config validator emits a `misnamespaced-extension` warning when this happens.


### PR DESCRIPTION
## Summary

Two related fixes to make the post-release `Dogfood testbed` workflow useful instead of noisy:

1. **Single rolling issue**: each failed dogfood run was opening a new GitHub issue. Find the existing open one with the matching title and append a comment instead.
2. **Diagnose the actual failure**: the `fixture-deprecated-field-usage` fixture was exiting 0 because the testbed's `.graphqlrc.yaml` placed its lint config at `extensions.lint:` rather than `extensions.graphql-analyzer.lint:` — and the analyzer silently ignored the misnamespaced block. Surface a `misnamespaced-extension` warning so this never happens silently again.

The actual testbed config bug is fixed in [analyzer-testbed#12](https://github.com/trevor-scheer/analyzer-testbed/pull/12).

## Changes

- `.github/workflows/dogfood-testbed.yml`: replace `gh issue create` with a search-then-comment-or-create flow against the rolling title; also documents the new behavior in the file header.
- `crates/config/src/validation.rs`: new `MisnamespacedExtension` variant + validator that fires when an analyzer-specific key (`lint`, `client`, `extractConfig`, `resolvedSchema`) appears at the top of `extensions:`, or when the legacy camelCase `graphqlAnalyzer:` namespace key is used. Severity = warning. Wired into `validate()` so the LSP renders it as a config-file diagnostic.
- `crates/config/src/lib.rs`: export `extension_namespace_warnings` as a focused public helper.
- `crates/cli/src/commands/common.rs`: every CLI command now prints these warnings to stderr at load time, before kicking off any work — kept narrow on purpose so we don't double-report errors that downstream code already surfaces.
- `.changeset/dogfood-rolling-issue.md`: CLI patch.

## Consulted SME Agents

-

## Manual Testing Plan

- Create a `.graphqlrc.yaml` with `extensions.lint:` at the wrong nesting level. Run `graphql check` and confirm a yellow `warning: \`extensions.lint\` is ignored — graphql-analyzer reads its config from the \`graphql-analyzer\` namespace. Move it under \`extensions.graphql-analyzer.lint\`.` line precedes the rest of the output.
- Repeat with `graphqlAnalyzer:` (camelCase) and confirm the same warning fires with a `graphql-analyzer` suggestion.
- Open the same file in VS Code with the LSP running and confirm a yellow squiggle appears on the misnamespaced key with the `misnamespaced-extension` code.
- After the next post-release dogfood run, confirm any failure adds a comment to the existing open `Dogfood regression: testbed CI failed after release` issue rather than opening a new one.