### PR TITLE
Emit one suggestion per missing `idName` in `require-selections`

### DIFF
--- a/.changeset/require-selections-multi-suggestion.md
+++ b/.changeset/require-selections-multi-suggestion.md
@@ -1,0 +1,7 @@
+---
+graphql-analyzer-cli: patch
+graphql-analyzer-lsp: patch
+graphql-analyzer-eslint-plugin: patch
+---
+
+`require-selections`: emit one quick-fix suggestion per missing `idName` instead of a single autofix that stacks every candidate. Picking which `idName` to add is a semantic choice; the IDE menu now offers one entry per candidate, matching `@graphql-eslint`. The single-candidate case still autofixes ([#1079](https://github.com/trevor-scheer/graphql-analyzer/pull/1079))

--- a/crates/linter/src/rules/require_selections.rs
+++ b/crates/linter/src/rules/require_selections.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{CodeFix, LintDiagnostic, LintSeverity, TextEdit};
+use crate::diagnostics::{CodeFix, CodeSuggestion, LintDiagnostic, LintSeverity, TextEdit};
 use crate::schema_utils::extract_root_type_names;
 use crate::traits::{DocumentSchemaLintRule, LintRule};
 use apollo_parser::cst::{self, CstNode};
@@ -564,27 +564,35 @@ fn check_selection_set(
             );
         }
     } else {
-        // OR mode: one grouped diagnostic listing all candidates.
-        let fix_label = if missing_fields.len() == 1 {
-            format!("Add `{}` selection", missing_fields[0])
+        // OR mode: one grouped diagnostic listing all candidates. Mirror
+        // graphql-eslint's `require-selections` by surfacing one
+        // `CodeSuggestion` per missing `idName` — the choice of which
+        // candidate to add is semantic and must stay with the user. The
+        // single-suggestion case still gets the same shape (one entry).
+        let suggestions: Vec<CodeSuggestion> = missing_fields
+            .iter()
+            .map(|f| {
+                let edit_text = format!("{f}\n{indent}");
+                CodeSuggestion {
+                    desc: format!("Add `{f}` selection"),
+                    fix: CodeFix::new(String::new(), vec![TextEdit::insert(insert_pos, edit_text)]),
+                }
+            })
+            .collect();
+
+        // Keep an autofix only when there's a single candidate — applying
+        // it is unambiguous. With multiple candidates, autofix would have
+        // to pick one (or stack all of them, which over-fetches), so we
+        // leave the choice to the user via the suggestion menu.
+        let single_fix = if missing_fields.len() == 1 {
+            let f = missing_fields[0];
+            Some(CodeFix::new(
+                format!("Add `{f}` selection"),
+                vec![TextEdit::insert(insert_pos, format!("{f}\n{indent}"))],
+            ))
         } else {
-            // TODO(parity): graphql-eslint emits one suggestion per `idName`
-            // in a multi-suggestion code action. We only have a single-fix API
-            // today, so we concatenate the missing fields into one fix.
-            let joined = missing_fields
-                .iter()
-                .map(|f| format!("`{f}`"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("Add {joined} selections")
+            None
         };
-        let mut fix_text = String::new();
-        for f in &missing_fields {
-            fix_text.push_str(f);
-            fix_text.push('\n');
-            fix_text.push_str(&indent);
-        }
-        let fix = CodeFix::new(fix_label, vec![TextEdit::insert(insert_pos, fix_text)]);
 
         let plural_suffix = if missing_fields.len() > 1 { "s" } else { "" };
         let joined_field_refs = english_join_words(
@@ -598,17 +606,19 @@ fn check_selection_set(
         // opening `{` with a start-only `loc` (no end position). Emit a
         // degenerate range (start == end); the eslint adapter strips
         // `endLine`/`endColumn` for rules listed in `START_ONLY_RULES`.
-        diagnostics.push(
-            LintDiagnostic::error(
-                doc.span(selection_set_start, selection_set_start),
-                format!(
-                    "Field{plural_suffix} {joined_field_refs} must be selected when it's available on a type.\nInclude it in your selection set{addition}."
-                ),
-                "requireSelections",
-            )
-            .with_message_id("require-selections")
-            .with_fix(fix),
-        );
+        let mut diag = LintDiagnostic::error(
+            doc.span(selection_set_start, selection_set_start),
+            format!(
+                "Field{plural_suffix} {joined_field_refs} must be selected when it's available on a type.\nInclude it in your selection set{addition}."
+            ),
+            "requireSelections",
+        )
+        .with_message_id("require-selections")
+        .with_suggestions(suggestions);
+        if let Some(fix) = single_fix {
+            diag = diag.with_fix(fix);
+        }
+        diagnostics.push(diag);
     }
 }
 

--- a/crates/linter/src/rules/require_selections.rs
+++ b/crates/linter/src/rules/require_selections.rs
@@ -1648,6 +1648,60 @@ query GetUser {
     }
 
     #[test]
+    fn test_or_mode_emits_one_suggestion_per_id_name() {
+        // Mirror graphql-eslint's `require-selections`: when multiple `idName`
+        // candidates are configured and none are selected, the diagnostic
+        // surfaces one `suggest` entry per candidate so the user can pick
+        // which field to add. (Picking which `idName` to add is a semantic
+        // choice — concatenating all of them into one fix is wrong.)
+        let db = RootDatabase::default();
+        let rule = RequireSelectionsRuleImpl;
+
+        let source = "
+query GetUser {
+    user(id: \"1\") {
+        email
+    }
+}
+";
+        let options = serde_json::json!({ "fieldName": ["id", "name"] });
+
+        let (file_id, content, metadata, project_files) =
+            create_test_project(&db, TEST_SCHEMA, source);
+
+        let diagnostics = rule.check(
+            &db,
+            file_id,
+            content,
+            metadata,
+            project_files,
+            Some(&options),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        let descs: Vec<&str> = diagnostics[0]
+            .suggestions
+            .iter()
+            .map(|s| s.desc.as_str())
+            .collect();
+        assert_eq!(descs, vec!["Add `id` selection", "Add `name` selection"]);
+
+        // Each suggestion's fix should insert exactly one field at the
+        // selection-set insertion point — not the concatenated list.
+        for sug in &diagnostics[0].suggestions {
+            assert_eq!(sug.fix.edits.len(), 1);
+            let inserted = &sug.fix.edits[0].new_text;
+            // No suggestion should mention the *other* candidate.
+            let added_one = (inserted.contains("id") && !inserted.contains("name"))
+                || (inserted.contains("name") && !inserted.contains("id"));
+            assert!(
+                added_one,
+                "suggestion fix should insert exactly one candidate; got: {inserted:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_inline_fragment_provides_field() {
         let db = RootDatabase::default();
         let rule = RequireSelectionsRuleImpl;

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,22 +234,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.8.0.tgz",
-      "integrity": "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.9.0.tgz",
+      "integrity": "sha512-CzE+4PefDSJWj26zU7G1bKchlGRRHMBFreG4tAlGuzyI8hAPiYGobaJvZBgZBf6L63iphX7VH+ityL8VgEQz9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1"
+        "@azure/msal-common": "16.5.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.1.tgz",
-      "integrity": "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -257,15 +257,14 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
-      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -287,9 +286,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -458,9 +457,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1304,6 +1303,86 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@graphql-analyzer/core-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-analyzer/core-darwin-arm64/-/core-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-saXrosyhzeB29ZPxVd2ftuNzXJVdf1JmH8BB/IADFzwl2xXN0sKlCt1VbSsYRxUIDPpH48dw7m3M0oMwHuW8lA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-analyzer/core-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-analyzer/core-darwin-x64/-/core-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-r53lsS1dqQP/U+nwDizn/Jw4DzTxlLPTHKYOqJh3PhML75WyNU2WI6FZitMTx/G71GTgy05p4s997vAGVZXPWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-analyzer/core-linux-arm64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-analyzer/core-linux-arm64-gnu/-/core-linux-arm64-gnu-0.1.2.tgz",
+      "integrity": "sha512-pcQ/BhtQYfRbSkQRhcPvT7VnwaHhr1mDr/lFLBXk66c9Qg8i9GFc1lJw74OPRfVVR12hb3m7gEz+Uh4nrHpKsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-analyzer/core-linux-x64-gnu": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-analyzer/core-linux-x64-gnu/-/core-linux-x64-gnu-0.1.2.tgz",
+      "integrity": "sha512-RUC+nVFbkLHVB3t62/gSnbnlHYis95dBTa6hQ8XZI78HZTDoF3BOsZs8tMAHUOc3BYUIGeu+inXAYVya7+53dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@graphql-analyzer/core-win32-x64-msvc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-analyzer/core-win32-x64-msvc/-/core-win32-x64-msvc-0.1.2.tgz",
+      "integrity": "sha512-8xcoDF5sh57oqji1zy0yeWNSq3qgUYywYu6IFGvWMAvBoQG0FXPqSaEahlZCpMwZBIgWRvPFGNS6SHkaF0shsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@graphql-analyzer/eslint-plugin": {
       "resolved": "packages/eslint-plugin",
       "link": true
@@ -1434,9 +1513,9 @@
       }
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "12.0.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-12.0.14.tgz",
-      "integrity": "sha512-/xCDM8zlCk1Lccww9asOIpxna9IFpIlol4yGsBD9Y2+3/Zu5k4/HzDC8LKJtw5MxdG+uJN1l9nRepr4GeBC4kA==",
+      "version": "12.0.15",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-12.0.15.tgz",
+      "integrity": "sha512-5931VfQ3Ze6rQLPmdw3UlR16g+z1iMyGlxvTMMHCT+P+mDd4v7bsDuE8L17/s46K5HAz3h0hX3MSc4jZbSy86A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4025,9 +4104,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.116.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
-      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4288,9 +4367,9 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-g6L7hed1Y2OGwAzZ+vXoGSvtJUdWUtTqtsn/16+UjYbu3+6pol0cggdWj26SFxI41R+jLfnT2+JGtoXRBdH+RQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-skD0ig8IzPwSY1L8VmNgfaxkfT8ImBwKeIypfZyJA+zHzWvroRKbRbT2GryOSREl22ZqLOuDfcq+7BdA0rjF2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4300,19 +4379,19 @@
         "node": ">=16.20.0"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260427.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260427.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260501.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260501.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-8zxaaEgIpHSadCoCAvUsp0C6WDH0dUXix7Mm7IBjh+EhSxI2clhXwPZTqgtDqbowXHeE82BG5mBbQx+CXDwGOQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-OIYsqKouI2U7W5Q6VgUz7+t9FpIXNFk30xSUG7gGlN1bdDniWfW7t5n6mzEtiHUVTxRgJQBjXGAlhVa6A9h+pg==",
       "cpu": [
         "arm64"
       ],
@@ -4327,9 +4406,9 @@
       }
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-6MjekGfajPtny/bBoBYJ+8dTOlgw6nhSSgJ3Us4R/4L8R90ll803Krz+iz907r1SnYeK5eWubDMV/p1ryLNXkQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-hQ5UsEyOz3ErQE3sKKHMCfJJGQenD0DSCi2ob+ywElXirG2NyFNA8cmx1g+MIm1lpQeEQslWZhe9EGwo9DJAbg==",
       "cpu": [
         "x64"
       ],
@@ -4344,9 +4423,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-3bhv/NxU9FHIN3MSmoplIAkIHF62mlF9l5XooAFawwj8yscvPZih/m5fkYIiP5qGri3828XwGyT1Cksaft6FWQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-agkTW/t85XSJKWGcXdUV9ZmSi3Akh3POK+HhWehigEJR3W/jebiO9njifETfoUF6cpoYkFn+CZvfAJ00IWGZfA==",
       "cpu": [
         "arm"
       ],
@@ -4361,9 +4440,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-a1yG/vrLaN3dORvaMuNqXz5jcTaTEPBfhmq77vzqRn8As7EdqxtizPosfxB9K1s7PEB8NeGQKqHEQroPUCsPFg==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-fbaFKE1UvtsQ6i1eJjBiNbglR9ywXrW/CH1sqYPEtr0WgTUpixbE6inQOXjB0jlEA9RzQq+QMzDyaCDmU82Dkw==",
       "cpu": [
         "arm64"
       ],
@@ -4378,9 +4457,9 @@
       }
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-lqaA9oF9ZSw1jn87+Ncxo0Sf0d65eVXMjAD0z44ne7QKFRgWd+QpvK4AXAG4lxnFR+XdndWlVm6O1/tdvcG7xQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-Sd8D+S88P7K0IH1U+a8pK20ZD+GM54t48/GLw9ebSklfCdt0iKdHgprjKIcl54C3SocGCcvEBPr1thwtTO9Vtg==",
       "cpu": [
         "x64"
       ],
@@ -4395,9 +4474,9 @@
       }
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-ZGXRDC0WPVK/Ky2fZRhy2EcNmdHg22biVYWcWgOUK5tCbJd/KJs3VXk758gn0UbFHEQAR5d7dsvDucCCjZkWpA==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-07sJNDnU7KHfo/trv/cBXpgFBELDYJAsTx5kNvBckSQUxbX+p/b9oQ3eFbtK3zDP4EEKdeiD9EelIy22atBnzA==",
       "cpu": [
         "arm64"
       ],
@@ -4412,9 +4491,9 @@
       }
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260427.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260427.1.tgz",
-      "integrity": "sha512-Ut4Hncq1IuSeNIfcPs1s719j8H3ZA+ogsJ53W3s/Wy1UF5BIhu5Hkspdc7TzGgJgYqGJKo/+pr4vsRnbBPdWgQ==",
+      "version": "7.0.0-dev.20260501.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260501.1.tgz",
+      "integrity": "sha512-8rzd/eQZyBuR+IRiPnIQrCwSuXIGBFiL8LsUMFqQt2WAUlQ0gGWBlLJHUVU4YNlju9QROjNHUGpJ52XGZbFv0Q==",
       "cpu": [
         "x64"
       ],
@@ -5099,9 +5178,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5882,9 +5961,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.348",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
+      "integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -8334,9 +8413,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -8368,9 +8447,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9099,9 +9178,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -10299,9 +10378,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10654,16 +10733,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -11742,21 +11811,6 @@
         "@graphql-analyzer/core-linux-x64-gnu": "0.1.2",
         "@graphql-analyzer/core-win32-x64-msvc": "0.1.2"
       }
-    },
-    "packages/core/node_modules/@graphql-analyzer/core-darwin-arm64": {
-      "optional": true
-    },
-    "packages/core/node_modules/@graphql-analyzer/core-darwin-x64": {
-      "optional": true
-    },
-    "packages/core/node_modules/@graphql-analyzer/core-linux-arm64-gnu": {
-      "optional": true
-    },
-    "packages/core/node_modules/@graphql-analyzer/core-linux-x64-gnu": {
-      "optional": true
-    },
-    "packages/core/node_modules/@graphql-analyzer/core-win32-x64-msvc": {
-      "optional": true
     },
     "packages/eslint-plugin": {
       "name": "@graphql-analyzer/eslint-plugin",


### PR DESCRIPTION
## Summary

Closes the last `TODO(parity)` site against `@graphql-eslint`'s `require-selections`. When multiple `idName` candidates are configured (e.g. `fieldName: ["id", "_id"]`) and none are selected, the rule now surfaces one `CodeSuggestion` per candidate so the user picks which field to add — instead of a single autofix that concatenated every candidate (over-fetching).

## Changes

- `crates/linter/src/rules/require_selections.rs`: in OR mode, build one `CodeSuggestion` per missing `idName` (`Add ` + backtick + idName + backtick + ` selection`). Each suggestion's `fix` inserts only that one candidate.
- Single-candidate case keeps the existing autofix so CLI `--fix` is unchanged.
- Multi-candidate case drops the autofix — picking which `idName` to add is a semantic choice and stacking all of them was wrong.
- Drops the `TODO(parity)` comment that flagged this site.
- Adds a unit test pinning the per-candidate suggestion shape.

## Consulted SME Agents

N/A — narrow parity nit, source pointer was named directly in the issue.

## Manual Testing Plan

- In an editor with the `@graphql-analyzer/eslint-plugin` wired up, configure `require-selections` with `fieldName: ['id', '_id']`, write a query that selects neither, and confirm two distinct ``Add ` selection`` quick-fixes appear in the suggestion menu (one per candidate).
- Run `graphql fix` on the same project and confirm no autofix is applied for the multi-candidate case.
- With the default single-candidate config (`fieldName: 'id'`), confirm `graphql fix` still inserts `id` automatically.

## Related Issues

Closes #1077.