### PR TITLE
Docs: GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Use `--format json` or `--format github` for CI integration.
 
 For full CLI documentation, see the **[CLI README](crates/cli/README.md)**.
 
+### GitHub Action
+
+For GitHub-native CI with inline PR annotations, SARIF, and an optional summary comment:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: trevor-scheer/graphql-analyzer-action@v1
+```
+
+See the **[GitHub Action docs](https://graphql-analyzer.dev/cli/github-action)** and the **[action repo](https://github.com/trevor-scheer/graphql-analyzer-action)**.
+
 ## Configuration
 
 ```yaml

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
             { label: "completions", slug: "cli/completions" },
             { label: "Output Formats", slug: "cli/output-formats" },
             { label: "CI/CD Integration", slug: "cli/ci-cd" },
+            { label: "GitHub Action", slug: "cli/github-action" },
           ],
         },
         {

--- a/docs/src/content/docs/cli/ci-cd.mdx
+++ b/docs/src/content/docs/cli/ci-cd.mdx
@@ -5,6 +5,25 @@ description: Using GraphQL Analyzer in continuous integration pipelines.
 
 ## GitHub Actions
 
+The shortest path is the [GitHub Action](./github-action):
+
+```yaml
+name: GraphQL
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trevor-scheer/graphql-analyzer-action@v1
+```
+
+It installs the released CLI, runs `graphql check`, emits inline PR annotations, and supports SARIF + an optional summary comment. See the [GitHub Action page](./github-action) for the full reference.
+
+### Without the action
+
+If you'd rather call the CLI directly — for example, on self-hosted runners or to share install logic across many steps — the binary install pattern still works:
+
 ```yaml
 name: GraphQL Validation
 on: [pull_request]
@@ -22,31 +41,17 @@ jobs:
         run: graphql check --format github
 ```
 
-Using `--format github` turns errors into pull request annotations.
+`--format github` turns errors into pull request annotations.
 
 ### GitHub Code Scanning (SARIF)
 
-For richer integration with GitHub's Security tab, use SARIF output:
-
 ```yaml
-name: GraphQL Validation
-on: [pull_request]
-
-jobs:
-  graphql:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install GraphQL CLI
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://raw.githubusercontent.com/trevor-scheer/graphql-analyzer/main/scripts/install.sh | sh
-      - name: Check GraphQL
-        run: graphql check --format sarif > results.sarif
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+- name: Check GraphQL (SARIF)
+  run: graphql check --format sarif > results.sarif
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
 ```
 
 To run validation and linting as separate steps:

--- a/docs/src/content/docs/cli/github-action.mdx
+++ b/docs/src/content/docs/cli/github-action.mdx
@@ -86,26 +86,26 @@ steps:
 
 ## Inputs
 
-| Name                | Default                  | Description                                                       |
-| ------------------- | ------------------------ | ----------------------------------------------------------------- |
-| `command`           | `check`                  | One of `check`, `validate`, `lint`.                               |
-| `config`            | (auto-discover)          | Path to `.graphqlrc.yaml`.                                        |
-| `project`           | (none)                   | Multi-project name.                                               |
-| `version`           | `latest`                 | CLI version: `latest` or `X.Y.Z`.                                 |
-| `max-warnings`      | (none)                   | Threshold for `--max-warnings`. Set `0` to fail on any warning.   |
-| `annotate`          | `true`                   | Emit inline PR annotations.                                       |
-| `sarif`             | `false`                  | Produce a SARIF file at `sarif-file`.                             |
-| `sarif-file`        | `graphql-results.sarif`  | SARIF output path.                                                |
-| `comment`           | `false`                  | Post (or update) a PR summary comment.                            |
-| `working-directory` | `.`                      | Directory to run the CLI in.                                      |
+| Name                | Default                 | Description                                                     |
+| ------------------- | ----------------------- | --------------------------------------------------------------- |
+| `command`           | `check`                 | One of `check`, `validate`, `lint`.                             |
+| `config`            | (auto-discover)         | Path to `.graphqlrc.yaml`.                                      |
+| `project`           | (none)                  | Multi-project name.                                             |
+| `version`           | `latest`                | CLI version: `latest` or `X.Y.Z`.                               |
+| `max-warnings`      | (none)                  | Threshold for `--max-warnings`. Set `0` to fail on any warning. |
+| `annotate`          | `true`                  | Emit inline PR annotations.                                     |
+| `sarif`             | `false`                 | Produce a SARIF file at `sarif-file`.                           |
+| `sarif-file`        | `graphql-results.sarif` | SARIF output path.                                              |
+| `comment`           | `false`                 | Post (or update) a PR summary comment.                          |
+| `working-directory` | `.`                     | Directory to run the CLI in.                                    |
 
 ## Outputs
 
-| Name         | Description                                  |
-| ------------ | -------------------------------------------- |
-| `errors`     | Number of error-severity diagnostics.        |
-| `warnings`   | Number of warning-severity diagnostics.      |
-| `sarif-file` | Path to the SARIF file when `sarif: true`.   |
+| Name         | Description                                |
+| ------------ | ------------------------------------------ |
+| `errors`     | Number of error-severity diagnostics.      |
+| `warnings`   | Number of warning-severity diagnostics.    |
+| `sarif-file` | Path to the SARIF file when `sarif: true`. |
 
 ## Pinning the CLI version
 

--- a/docs/src/content/docs/cli/github-action.mdx
+++ b/docs/src/content/docs/cli/github-action.mdx
@@ -1,0 +1,140 @@
+---
+title: GitHub Action
+description: Run the GraphQL Analyzer CLI in CI with inline PR annotations, SARIF, and an optional summary comment.
+---
+
+[`trevor-scheer/graphql-analyzer-action`](https://github.com/trevor-scheer/graphql-analyzer-action) wraps the CLI for GitHub Actions: inline PR annotations, optional SARIF for the Security tab, and an optional PR summary comment.
+
+## Quickstart
+
+```yaml
+name: GraphQL
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trevor-scheer/graphql-analyzer-action@v1
+```
+
+That's it — the action installs the latest released CLI, runs `graphql check`, and emits inline annotations on the PR diff for every diagnostic.
+
+## With SARIF (Security tab)
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trevor-scheer/graphql-analyzer-action@v1
+        id: graphql
+        with:
+          sarif: true
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always() && steps.graphql.outputs.sarif-file != ''
+        with:
+          sarif_file: ${{ steps.graphql.outputs.sarif-file }}
+```
+
+The action produces the SARIF file; `upload-sarif` posts it to GitHub code scanning so findings appear in **Security → Code scanning alerts**.
+
+## With a PR summary comment
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trevor-scheer/graphql-analyzer-action@v1
+        with:
+          comment: true
+```
+
+The comment is keyed by an HTML marker and **updated** on subsequent runs rather than duplicated.
+
+## Multi-project
+
+```yaml
+- uses: trevor-scheer/graphql-analyzer-action@v1
+  with:
+    project: web
+```
+
+Use a matrix to fan out across projects:
+
+```yaml
+strategy:
+  matrix:
+    project: [web, api, mobile]
+steps:
+  - uses: actions/checkout@v4
+  - uses: trevor-scheer/graphql-analyzer-action@v1
+    with:
+      project: ${{ matrix.project }}
+```
+
+## Inputs
+
+| Name                | Default                  | Description                                                       |
+| ------------------- | ------------------------ | ----------------------------------------------------------------- |
+| `command`           | `check`                  | One of `check`, `validate`, `lint`.                               |
+| `config`            | (auto-discover)          | Path to `.graphqlrc.yaml`.                                        |
+| `project`           | (none)                   | Multi-project name.                                               |
+| `version`           | `latest`                 | CLI version: `latest` or `X.Y.Z`.                                 |
+| `max-warnings`      | (none)                   | Threshold for `--max-warnings`. Set `0` to fail on any warning.   |
+| `annotate`          | `true`                   | Emit inline PR annotations.                                       |
+| `sarif`             | `false`                  | Produce a SARIF file at `sarif-file`.                             |
+| `sarif-file`        | `graphql-results.sarif`  | SARIF output path.                                                |
+| `comment`           | `false`                  | Post (or update) a PR summary comment.                            |
+| `working-directory` | `.`                      | Directory to run the CLI in.                                      |
+
+## Outputs
+
+| Name         | Description                                  |
+| ------------ | -------------------------------------------- |
+| `errors`     | Number of error-severity diagnostics.        |
+| `warnings`   | Number of warning-severity diagnostics.      |
+| `sarif-file` | Path to the SARIF file when `sarif: true`.   |
+
+## Pinning the CLI version
+
+The action installs the **latest** released CLI by default. Pin a specific version with:
+
+```yaml
+- uses: trevor-scheer/graphql-analyzer-action@v1
+  with:
+    version: 0.3.0
+```
+
+Pinning the action major (`@v1`) does **not** pin the CLI version — `version:` is the lever for that.
+
+## Failing on warnings
+
+The CLI exits non-zero on errors by default. To fail when warnings are present, set `max-warnings: 0`:
+
+```yaml
+- uses: trevor-scheer/graphql-analyzer-action@v1
+  with:
+    max-warnings: 0
+```
+
+## Dogfooded in `analyzer-testbed`
+
+The action is the example CI integration used by [`trevor-scheer/analyzer-testbed`](https://github.com/trevor-scheer/analyzer-testbed/blob/main/.github/workflows/ci.yml) — see the `Lint & Format` job for a complete worked example with SARIF upload.
+
+## See also
+
+- [CI/CD Integration](./ci-cd) — running the CLI directly in CI without the action.
+- [Output Formats](./output-formats) — `--format=github`, `--format=sarif`, `--format=json` reference.
+- [Action repository](https://github.com/trevor-scheer/graphql-analyzer-action) — source, releases, and issue tracker.


### PR DESCRIPTION
## Summary

Adds documentation for [`trevor-scheer/graphql-analyzer-action`](https://github.com/trevor-scheer/graphql-analyzer-action), now shipping at `v1.0.0` and dogfooded by [`analyzer-testbed`](https://github.com/trevor-scheer/analyzer-testbed/blob/main/.github/workflows/ci.yml).

- New page `docs/src/content/docs/cli/github-action.mdx` with quickstart, four worked examples (basic, SARIF, PR comment, multi-project), full input/output reference, version pinning, and a pointer to the testbed.
- Updates `docs/src/content/docs/cli/ci-cd.mdx` to lead with the action; demotes the manual `run: graphql check` snippet to a "Without the action" subsection.
- Adds `cli/github-action` to the sidebar.
- Adds a brief "GitHub Action" section to root `README.md` linking to the docs page and action repo.
- No changeset: docs-only, no CLI/LSP/MCP/VSCode behavior change.

## Closes

- Closes #420 (the parent feature request)
- Supersedes / closes #427 (the exploration PR)

## Test plan

- [x] `npm run build` from `docs/` succeeds (73 pages built clean)
- [x] All four code examples on the new page were verified against the action's actual behavior in the testbed CI