### PR TITLE
Make VS Code extension publish steps idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,6 +357,10 @@ jobs:
       - name: List VSIX files
         run: find vsix-artifacts -name "*.vsix" -type f
 
+      # `--skip-duplicate` makes this idempotent on rerun: already-published
+      # (version, target) combos log a skip message and exit 0, so a partial
+      # failure where some platforms uploaded successfully can be recovered
+      # by re-running the job.
       - name: Publish to VS Code Marketplace
         working-directory: editors/vscode
         env:
@@ -364,7 +368,7 @@ jobs:
         run: |
           for vsix in ../../vsix-artifacts/*.vsix; do
             echo "Publishing $vsix"
-            pnpm exec vsce publish --packagePath "$vsix"
+            pnpm exec vsce publish --packagePath "$vsix" --skip-duplicate
           done
 
   # Publish VS Code extension to Open VSX Registry
@@ -387,13 +391,15 @@ jobs:
           path: vsix-artifacts
           merge-multiple: true
 
+      # See note on publish-vscode — `--skip-duplicate` provides the same
+      # idempotency guard for Open VSX so partial-failure reruns are safe.
       - name: Publish to Open VSX Registry
         env:
           OVSX_PAT: ${{ secrets.OPENVSX_PUBLISH_PAT }}
         run: |
           for vsix in vsix-artifacts/*.vsix; do
             echo "Publishing $vsix"
-            pnpm dlx ovsx publish "$vsix" --pat "$OVSX_PAT"
+            pnpm dlx ovsx publish "$vsix" --pat "$OVSX_PAT" --skip-duplicate
           done
 
   # Publish @graphql-analyzer/* packages to npm.


### PR DESCRIPTION
## Summary

In the most recent release, one of the platform-specific VS Code extensions failed to publish to the marketplace. Re-running the job didn't help: the publishes that *had* succeeded the first time around now hit "version already exists" and aborted the bash loop before reaching the failed target.

Both `vsce` and `ovsx` ship a `--skip-duplicate` flag that turns "this (version, target) is already published" from a fatal error into a logged skip. Adding it to both publish steps makes them idempotent on rerun — already-published targets are skipped, and only the genuinely-missing ones are uploaded.

## Changes

- `vsce publish ... --skip-duplicate` in the `publish-vscode` job
- `ovsx publish ... --skip-duplicate` in the `publish-openvsx` job
- Comments on each step explaining the rerun semantics

## Consulted SME Agents

- N/A — change is confined to `.github/workflows/release.yml`

## Manual Testing Plan

Hard to exercise without triggering a real publish. The flag's behavior is documented and implemented per-target in both tools:
- `vsce` matches duplicates on `version === manifest.version && targetPlatform === options.target` ([`vscode-vsce/src/publish.ts`](https://github.com/microsoft/vscode-vsce/blob/main/src/publish.ts))
- `ovsx` matches the registry's `is already published.` error ([`openvsx/cli/src/publish.ts`](https://github.com/eclipse/openvsx/blob/master/cli/src/publish.ts))

The next release will be the real-world test. If a platform fails again, re-running the job should now recover instead of aborting.

## Related Issues

N/A