### PR TITLE
Reduce Renovate update frequency from weekly to monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly"
+    "schedule:monthly"
   ],
   "schedule": [
-    "before 9am on Sunday"
+    "before 9am on the first day of the month"
   ],
   "ignorePaths": [
     "test-workspace/**"


### PR DESCRIPTION
## Summary

Reduces the Renovate dependency update cadence from weekly to monthly to cut down on update noise.

## Changes

- `extends`: `schedule:weekly` → `schedule:monthly`
- `schedule`: `"before 9am on Sunday"` → `"before 9am on the first day of the month"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY6GSDJXUGhoUP1hx3eGDB)_